### PR TITLE
Flashcopy support

### DIFF
--- a/zthin-parts/zthin/bin/flashdiskimage
+++ b/zthin-parts/zthin/bin/flashdiskimage
@@ -1,0 +1,197 @@
+#!/bin/bash
+###############################################################################
+# Copyright 2017 IBM Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+###############################################################################
+# COMPONENT: flashdiskimage                                                   #
+#                                                                             #
+# Deploys a disk image to the specified z/VM guest system and disk using      #
+# FLASHCOPY.                                                                  #
+###############################################################################
+
+source /opt/zthin/lib/zthinshellutils
+
+###############################################################################
+### FUNCTIONS #################################################################
+###############################################################################
+
+function printCMDDescription {
+  : SOURCE: ${BASH_SOURCE}
+  : STACK:  ${FUNCNAME[@]}
+  # @Description:
+  #   Prints a short description of this command.
+  # @Overrides:
+  #   printCMDDescription{} in "zthinshellutils".
+  # @Code:
+  echo -n "Deploys a disk image to the specified z/VM guest system and disk "
+  echo    "using FLASHCOPY."
+} #printCMDDescription{}
+
+###############################################################################
+
+function parseArgs {
+  : SOURCE: ${BASH_SOURCE}
+  : STACK:  ${FUNCNAME[@]}
+  # @Description:
+  #   Parses and checks command-line arguments.
+  # @Code:
+  # Non-local variables in this function are intentionally non-local.
+  isOption -h --help "     Print this help message."   && printHelp='true'
+  isOption -v --verbose "  Print verbose output."      && verbose='-v'
+  isOption -x --debug "    Print debugging output."    && debug='-x'
+
+  getPositionalArg 1 srcUserid
+  getPositionalArg 2 srcVdev
+  getPositionalArg 3 tgtUserid
+  getPositionalArg 4 tgtVdev
+
+  srcUserid=$(echo ${srcUserid} | tr '[:lower:]' '[:upper:]')
+  srcVdev=$(echo ${srcVdev} | tr '[:lower:]' '[:upper:]')
+  tgtUserid=$(echo ${tgtUserid} | tr '[:lower:]' '[:upper:]')
+  tgtVdev=$(echo ${tgtVdev} | tr '[:lower:]' '[:upper:]')
+
+  if [[ $printHelp ]]; then
+    printHelp
+    exit 0
+  fi
+  local badOptions=$(getBadOptions)
+  if [[ $badOptions ]]; then
+    echo "ERROR: ${badOptions}"
+    printCMDUsage
+    exit 10
+  fi
+
+  if [[ ${#args[@]} == 4 && (! $srcUserid || ! $srcVdev || ! $tgtUserid || ! $tgtVdev) ]]; then
+    echo 'ERROR: Missing required parameter.'
+    printCMDUsage
+    exit 11
+  fi
+
+  # Remove old traces beyond the number specified in /var/opt/zthin/settings.conf. If the
+  # specified number is 0, less than 0, or not actually a number, then we skip
+  # this cleanup.
+  if [[ $keepOldTraces -gt 0 ]]; then
+    local removeTraces=$(($(ls -1 /var/log/zthin/flashdiskimage_trace_* | wc -l) -
+                          ${keepOldTraces}))
+    if [[ $removeTraces -gt 0 ]]; then
+      for trace in $(ls -1 /var/log/zthin/flashdiskimage_trace_* |
+                     head -${removeTraces}); do
+        rm -f $trace
+      done
+    fi
+  fi
+
+  timestamp=$(date -u --rfc-3339=ns | sed 's/ /-/;s/\.\(...\).*/.\1/')
+  logFile=/var/log/zthin/flashdiskimage_trace_${timestamp}.txt
+  if [[ $debug ]]; then
+    exec 2> >(tee -a $logFile)
+    set -x
+  else
+    exec 2> $logFile
+    set -x
+  fi
+  inform "flashdiskimage ${args} start time: ${timestamp}"
+
+  echo "SOURCE USER ID: \"$srcUserid\""
+  echo "SOURCE VDEV:    \"$srcVdev\""
+  echo "TARGET USER ID: \"$tgtUserid\""
+  echo "TARGET VDEV:    \"$tgtVdev\""
+  echo ""
+} #parseArgs{}
+
+###############################################################################
+### SET TRAP FOR CLEANUP ON EXIT ##############################################
+###############################################################################
+
+function cleanup {
+  : SOURCE: ${BASH_SOURCE}
+  : STACK:  ${FUNCNAME[@]}
+  # @Description:
+  #   Clean up lock files, disk links, and (if we passed the sanity check but
+  #   failed after creating one or more z/VM user IDs, those newly-created
+  #   user IDs).
+  # @Code:
+  # Nothing to do for help or version options.
+  if [[ $printHelp ]]; then
+    return
+  fi
+
+  if [[ $successful ]]; then
+    inform "Image deployment successful."
+    # Only keep traces of failed disk-image creation attempt unless overriden
+    # by a configuration property.
+    if [[ -e $logFile ]]; then
+      if [[ $saveAllLogs ]]; then
+        inform "A detailed trace can be found at: ${logFile}"
+      else
+        rm -f $logFile
+      fi
+    fi
+  else
+    if [[ ! $printHelp ]]; then
+      echo -e '\nIMAGE DEPLOYMENT FAILED.'
+      [[ $logFile ]] && inform "A detailed trace can be found at: ${logFile}"
+    fi
+  fi
+
+  # Make sure we've released our connection to the source and target disks.
+  disconnectDiskCP $srcUserid $srcVdev
+  disconnectDiskCP $tgtUserid $tgtVdev
+
+  timestamp=$(date -u --rfc-3339=ns | sed 's/ /-/;s/\.\(...\).*/.\1/')
+  inform "flashdiskimage end time: ${timestamp}"
+} #cleanup{}
+
+trap 'cleanup' EXIT
+
+trap "echo -e '\nExecution interrupted. Exiting...\n'; exit" SIGINT
+
+###############################################################################
+### START EXECUTION ###########################################################
+###############################################################################
+
+parseArgs
+
+inform "Starting FLASHCOPY of ${srcUserid}.${srcVdev} to ${tgtUserid}.${tgtVdev}"
+connectDiskCP $srcUserid $srcVdev "RR" srcAlias
+if [[ $? -ne 0 ]]; then
+  echo -e "Failed to link source disk"
+  exit 2 
+fi
+
+connectDiskCP $tgtUserid $tgtVdev "MR" tgtAlias
+if [[ $? -ne 0 ]]; then
+  echo -e "Failed to link target disk"
+  exit 3 
+fi
+
+# Retry FLASHCOPY on HCPCMM296E with code = AE
+retry=60
+while [[ retry -gt 0 ]]; do
+  out=$(vmcp "FLASHCOPY $srcAlias 0 END $tgtAlias 0 END")
+  cnt=$(echo $out | grep HCPCMM296E | grep "code = AE" | wc -l)
+  echo $out
+  if [[ $cnt -gt 0 ]]; then
+    retry=$((retry-1))
+    sleep 5 
+  else
+    successful='true'
+    retry=0
+  fi
+done
+
+###############################################################################
+### END OF SCRIPT #############################################################
+###############################################################################

--- a/zthin-parts/zthin/lib/zthinshellutils
+++ b/zthin-parts/zthin/lib/zthinshellutils
@@ -591,6 +591,90 @@ function connectFcp {
 
 ###############################################################################
 
+function connectDiskCP {
+  : SOURCE: ${BASH_SOURCE}
+  : STACK:  ${FUNCNAME[@]}
+  # @Description:
+  #   Links to (or attaches) the disk at the specified virtual device address
+  #   (on the system being captured/deployed) using the specified link mode (or
+  #   'RR' if a mode is not specified).
+  # @Returns:
+  #   0 if the connection was successful.
+  #   1 if there was an error with attaching a dedicated disk.
+  #   2 if there was an error with linking to a minidisk.
+  #   5 if we time out waiting for the disk connection lock.
+  # @Parameters:
+  local userID=$1            # ID of disk-owning z/VM user.
+  local vdev=$2              # Virtual device address of disk to connect to.
+  local mode=$3              # The disk linking mode.
+  local -n localAlias=$4     # Local disk alias
+
+  # @Code:
+  [[ $mode ]] || mode='rr'
+
+  # Obtain the disk connection lock.
+  local attempts=1
+  while [[ $(mkdir $diskConnectionLock; echo $?) -ne 0 ]]; do
+    if [[ $attempts -gt 120 ]]; then
+      return 5
+    fi
+    if [[ $(( $attempts % 30 )) -eq 0 ]]; then
+      warn "Waiting on lock: ${diskConnectionLock}" | sed 's/^/  /'
+    fi
+    attempts=$((attempts + 1))
+    sleep 1
+  done
+
+  # Keep a file in /tmp listing previously-used aliases, to avoid always
+  # using different aliases (which makes udev keep incrementing addresses
+  # in the /dev/dasd[letter][number] scheme). Try each of those aliases
+  # before generating new ones.
+  while read line; do
+    if [[ $(vmcp "query virtual ${line}" 2>&1 |
+            grep 'HCPQVD040E') ]]; then
+      localAlias=$line
+      break
+    fi
+  done < $diskLinkingAliases
+
+  # Since none of the already-used aliases are free, keep picking a random
+  # virtual device address until one is found that hasn't already been taken.
+  while [[ $(vmcp "query virtual ${localAlias}" 2>&1 |
+             grep 'HCPQVD040E' |
+             wc -l) -eq 0 ]]; do
+    localAlias=$(uuidgen | sed 's/\(....\).*/\1/')
+  done
+
+  # Record the alias we used, both in the list of used aliases and in the list
+  # of aliases currently in use.
+  if [[ ! $(grep "${localAlias}" $diskLinkingAliases) ]]; then
+    echo $localAlias >> $diskLinkingAliases
+  fi
+  echo "${userID} ${vdev} AS ${localAlias}" >> $currentDiskAliases
+
+  local rc=0
+  local cmdResp=$(vmcp "link $userID $vdev as $localAlias $mode" 2>&1)
+  local error=$(echo "$cmdResp" | grep '^Error:')
+
+  # We can at this point remove the disk connection lock, since we have
+  # reserved its channel ID alias by linking it and made all required
+  # alterations to the alias listing file.
+  rmdir $diskConnectionLock
+
+  # Check for link errors
+  if [[ $error ]]; then
+    local errorInfo=$(echo "$cmdResp" | grep '^HCP')
+    printError "Unable to link $userID $vdev disk. $errorInfo"
+    # Note: We will do a detach just in case we linked it in read mode.
+    vmcp "detach $localAlias"
+    local rc=2
+  fi
+
+  return $rc
+} #connectDiskCP{}
+
+###############################################################################
+
 function connectDisk {
   : SOURCE: ${BASH_SOURCE}
   : STACK:  ${FUNCNAME[@]}
@@ -616,65 +700,8 @@ function connectDisk {
                              # raw_track_access mode. Otherwise existing mode
                              # is used.
   # @Code:
-  [[ $mode ]] || mode='rr'
-
-  # Obtain the disk connection lock.
-  local attempts=1
-  while [[ $(mkdir $diskConnectionLock; echo $?) -ne 0 ]]; do
-    if [[ $attempts -gt 120 ]]; then
-      return 5
-    fi
-    if [[ $(( $attempts % 30 )) -eq 0 ]]; then
-      warn "Waiting on lock: ${diskConnectionLock}" | sed 's/^/  /'
-    fi
-    attempts=$((attempts + 1))
-    sleep 1
-  done
-
-  # Keep a file in /tmp listing previously-used aliases, to avoid always
-  # using different aliases (which makes udev keep incrementing addresses
-  # in the /dev/dasd[letter][number] scheme). Try each of those aliases
-  # before generating new ones.
-  while read line; do
-    if [[ $(vmcp "query virtual ${line}" 2>&1 |
-            grep 'HCPQVD040E') ]]; then
-      local alias=$line
-      break
-    fi
-  done < $diskLinkingAliases
-
-  # Since none of the already-used aliases are free, keep picking a random
-  # virtual device address until one is found that hasn't already been taken.
-  while [[ $(vmcp "query virtual ${alias}" 2>&1 |
-             grep 'HCPQVD040E' |
-             wc -l) -eq 0 ]]; do
-    local alias=$(uuidgen | sed 's/\(....\).*/\1/')
-  done
-
-  # Record the alias we used, both in the list of used aliases and in the list
-  # of aliases currently in use.
-  if [[ ! $(grep "${alias}" $diskLinkingAliases) ]]; then
-    echo $alias >> $diskLinkingAliases
-  fi
-  echo "${userID} ${vdev} AS ${alias}" >> $currentDiskAliases
-
-  local rc=0
-  local cmdResp=$(vmcp "link $userID $vdev as $alias $mode" 2>&1)
-  local error=$(echo "$cmdResp" | grep '^Error:')
-
-  # We can at this point remove the disk connection lock, since we have
-  # reserved its channel ID alias by linking it and made all required
-  # alterations to the alias listing file.
-  rmdir $diskConnectionLock
-
-  # Check for link errors
-  if [[ $error ]]; then
-    local errorInfo=$(echo "$cmdResp" | grep '^HCP')
-    printError "Unable to link $userID $vdev disk. $errorInfo"
-    # Note: We will do a detach just in case we linked it in read mode.
-    vmcp "detach $alias"
-    local rc=2
-  fi
+  connectDiskCP $userID $vdev $mode alias
+  rc = $?
 
   # Make sure device channel isn't black-listed..
   if [[ $rc -eq 0 ]]; then
@@ -896,6 +923,61 @@ function undedicateFcp {
 
 ###############################################################################
 
+function disconnectDiskCP {
+  : SOURCE: ${BASH_SOURCE}
+  : STACK:  ${FUNCNAME[@]}
+  # @Description:
+  #   Detaches the disk at the specified virtual device address.
+  # @Returns:
+  #   0 if the disconnection was successful.
+  #   3 if there was an error with detaching the disk.
+  #   4 if we time out waiting for the disk connection lock.
+  # @Parameters:
+  local userID=$1
+  local disk=$2
+  # @Code:
+  local alias=$(getDiskAlias $userID $disk)
+  local rc=0
+
+  # Obtain the disk connection lock.
+  local attempts=1
+  while [[ $(mkdir $diskConnectionLock; echo $?) -ne 0 ]]; do
+    if [[ $attempts -gt 360 ]]; then
+      # Waited 6 minutes (360 seconds, 3 times max of connectDisk), give up.
+      return 4
+    fi
+    if [[ $(( $attempts % 30 )) -eq 0 ]]; then
+      warn "Waiting on lock: ${diskConnectionLock}" | sed 's/^/  /'
+    fi
+    attempts=$((attempts + 1))
+    sleep 1
+  done
+
+  # Detach the disk.
+  if [[ $(vmcp 'query virtual dasd' |
+          grep -i "^DASD $alias" | wc -l) -eq 1 ]]; then
+    local error=$(vmcp detach $alias 2>&1 | grep '^Error:')
+    if [[ $error ]]; then
+      warn "Disk Detach $error"
+      local rc=3
+    fi
+  fi
+
+  # If the disk is no longer attached to the zthin virtual machine then remove it
+  # from the current disk aliases.
+  if [[ $(vmcp 'query virtual dasd' |
+          grep -i "^DASD $alias" | wc -l) -eq 0 ]]; then
+    sed -i "/${userID} ${disk} AS ${alias}/d" \
+           $currentDiskAliases
+  fi
+
+  # Release the disk connection lock and return.
+  rmdir $diskConnectionLock
+  return $rc
+} #disconnectDiskCP{}
+
+###############################################################################
+
 function disconnectDisk {
   : SOURCE: ${BASH_SOURCE}
   : STACK:  ${FUNCNAME[@]}
@@ -946,45 +1028,9 @@ function disconnectDisk {
     fi
   fi
 
-  # Obtain the disk connection lock.
-  local attempts=1
-  while [[ $(mkdir $diskConnectionLock; echo $?) -ne 0 ]]; do
-    if [[ $attempts -gt 360 ]]; then
-      # Waited 6 minutes (360 seconds, 3 times max of connectDisk), give up.
-      return 4
-    fi
-    if [[ $(( $attempts % 30 )) -eq 0 ]]; then
-      warn "Waiting on lock: ${diskConnectionLock}" | sed 's/^/  /'
-    fi
-    attempts=$((attempts + 1))
-    sleep 1
-  done
+  disconnectDiskCP $userID $disk
+  rc=$?
 
-  # Detach the disk.
-  if [[ $(vmcp 'query virtual dasd' |
-          grep -i "^DASD $alias" | wc -l) -eq 1 ]]; then
-    local error=$(vmcp detach $alias 2>&1 | grep '^Error:')
-    if [[ $error ]]; then
-      warn "Disk Detach $error"
-      local rc=3
-    fi
-  fi
-
-  # Remove the left partition link
-  if [[ -L /dev/disk/by-path/ccw-0.0.${alias}-part1 ]]; then
-    rm -f /dev/disk/by-path/ccw-0.0.${alias}-part1
-  fi
-
-  # If the disk is no longer attached to the zthin virtual machine then remove it
-  # from the current disk aliases.
-  if [[ $(vmcp 'query virtual dasd' |
-          grep -i "^DASD $alias" | wc -l) -eq 0 ]]; then
-    sed -i "/${userID} ${disk} AS ${alias}/d" \
-           $currentDiskAliases
-  fi
-
-  # Release the disk connection lock and return.
-  rmdir $diskConnectionLock
   return $rc
 } #disconnectDisk{}
 

--- a/zvmsdk/api.py
+++ b/zvmsdk/api.py
@@ -335,6 +335,49 @@ class SDKAPI(object):
             LOG.error("Failed to export image '%s'" % image_name)
             raise
 
+    def flashimage_import(self, image_name, userid, vdev, image_meta):
+        """Import flashcopy image to zvmsdk image repository
+
+        :param image_name: image name that can be uniquely identify an image
+        :param userid: owner of the disk to be used as the image
+        :parm vdev: disk to be used as the image
+        :param dict image_meta:
+               a dictionary to describe the image info, such as md5sum,
+               os_version. For example:
+               {'os_version': 'rhel6.2',
+               'md5sum': ' 46f199c336eab1e35a72fa6b5f6f11f5'}
+        """
+        try:
+            self._imageops.flashimage_import(image_name, userid, vdev, image_meta)
+        except exception.SDKBaseException:
+            LOG.error("Failed to import flash image '%s'" % image_name)
+            raise
+
+    def flashimage_query(self, imagename=None):
+        """Get the list of flash image info in image repository
+
+        :param imagename:  Used to retrieve the specified image info,
+               if not specified, all images info will be returned
+
+        :returns: A list that contains the specified or all images info
+        """
+        try:
+            return self._imageops.flashimage_query(imagename)
+        except exception.SDKBaseException:
+            LOG.error("Failed to query flash image")
+            raise
+
+    def flashimage_delete(self, image_name):
+        """Delete flash image from image repository
+
+        :param image_name: the name of the image to be deleted
+        """
+        try:
+            self._imageops.flashimage_delete(image_name)
+        except exception.SDKBaseException:
+            LOG.error("Failed to delete flash image '%s'" % image_name)
+            raise
+
     @check_guest_exist()
     def guest_deploy(self, userid, image_name, transportfiles=None,
                      remotehost=None, vdev=None, hostname=None):

--- a/zvmsdk/config.py
+++ b/zvmsdk/config.py
@@ -214,6 +214,18 @@ The length of namelist must no longer than 64.
         help='''
 The port number of remotehost sshd.
 '''),
+    Opt('temp_vdev_start',
+        section='zvm',
+        default='FF00',
+        help='''
+The starting vdev to use for temporary operations.
+'''),
+    Opt('temp_vdev_end',
+        section='zvm',
+        default='FF1F',
+        help='''
+The ending vdev to use for temporary operations.
+'''),
     # image options
     Opt('sdk_image_repository',
         section='image',

--- a/zvmsdk/constants.py
+++ b/zvmsdk/constants.py
@@ -125,6 +125,7 @@ DATABASE_VOLUME = 'sdk_volume.sqlite'
 DATABASE_NETWORK = 'sdk_network.sqlite'
 DATABASE_GUEST = 'sdk_guest.sqlite'
 DATABASE_IMAGE = 'sdk_image.sqlite'
+DATABASE_FLASHIMAGE = 'sdk_flashimage.sqlite'
 DATABASE_FCP = 'sdk_fcp.sqlite'
 
 IMAGE_TYPE = {

--- a/zvmsdk/imageops.py
+++ b/zvmsdk/imageops.py
@@ -56,3 +56,12 @@ class ImageOps(object):
     def image_export(self, image_name, dest_url, remote_host=None):
         return self._smtclient.image_export(image_name, dest_url,
                                              remote_host)
+
+    def flashimage_import(self, image_name, userid, vdev, image_meta):
+        return self._smtclient.flashimage_import(image_name, userid, vdev, image_meta)
+
+    def flashimage_query(self, image_name=None):
+        return self._smtclient.flashimage_query(image_name)
+
+    def flashimage_delete(self, image_name):
+        return self._smtclient.flashimage_delete(image_name)

--- a/zvmsdk/returncode.py
+++ b/zvmsdk/returncode.py
@@ -108,6 +108,7 @@ ModRCs = {
     'network': 20,
     'volume': 30,
     'image': 40,
+    'flashimage': 45,
     'monitor': 50,
     'file': 60,
     'sdkserver': 100,
@@ -165,6 +166,9 @@ errors = {
                11: ("Failed to live resize memory of guest: '%(userid)s', "
                    "error: define standby memory failed with "
                    "smt error: '%(err)s'."),
+               12: ("Failed to deploy image to userid: '%(userid)s', "
+                   "flashdiskimage failed with rc: %(unpack_rc)d, "
+                   "error: %(err)s"),
               },
               "Operation on Guest failed"
               ],

--- a/zvmsdk/sdkwsgi/handler.py
+++ b/zvmsdk/sdkwsgi/handler.py
@@ -103,6 +103,13 @@ ROUTE_LIST = (
     ('/images/{name}/root_disk_size', {
         'GET': image.image_get_root_disk_size,
     }),
+    ('/flashimages', {
+        'POST': image.flashimage_create,
+        'GET': image.flashimage_query
+    }),
+    ('/flashimages/{name}', {
+        'DELETE': image.flashimage_delete
+    }), 
     ('/files', {
         'PUT': file.file_import,
         'POST': file.file_export,

--- a/zvmsdk/sdkwsgi/schemas/image.py
+++ b/zvmsdk/sdkwsgi/schemas/image.py
@@ -35,6 +35,25 @@ create = {
     'additionalProperties': False
 }
 
+flash_create = {
+    'type': 'object',
+    'properties': {
+        'image': {
+            'type': 'object',
+            'properties': {
+                'image_name': parameter_types.name,
+                'userid': parameter_types.userid,
+                'vdev': parameter_types.vdev,
+                'image_meta': parameter_types.image_meta
+            },
+            'required': ['image_name', 'userid', 'vdev', 'image_meta'],
+            'additionalProperties': False
+        },
+        'additionalProperties': False
+    },
+    'required': ['image'],
+    'additionalProperties': False
+}
 
 export = {
     'type': 'object',


### PR DESCRIPTION
**Basic design**

- New services to import, query, and delete flashcopy sources stored in a new sqlite table
- Flashcopy sources consist of a userid/device address pair to identify the source of the flashcopy operation
- Modify the guest_deploy service to check if a flashcopy source exists for the image. If so, use the flash copy as the source rather than unpackdiskimage.