### PR TITLE
Add vlan id as param to couple_nic_to_vswitch function

### DIFF
--- a/doc/source/parameters.yaml
+++ b/doc/source/parameters.yaml
@@ -979,7 +979,7 @@ user_vlan_id:
   type: dict
 vlan_id:
   description: |
-    The VLAN ID. This can be any of the value between 1-4094.
+    The VLAN ID. This can be any of the value between -1 or 1-4094.
   in: body
   required: true
   type: integer

--- a/doc/source/restapi.rst
+++ b/doc/source/restapi.rst
@@ -1346,6 +1346,7 @@ Couple or uncouple nic with vswitch on the guest.
   - couple: couple_action
   - active: active_flag
   - vswitch: vswitch_name_body_opt
+  - vlan_id: vlan_id
 
 * Request sample:
 

--- a/zvmsdk/api.py
+++ b/zvmsdk/api.py
@@ -953,16 +953,18 @@ class SDKAPI(object):
 
     @check_guest_exist()
     def guest_nic_couple_to_vswitch(self, userid, nic_vdev,
-                                    vswitch_name, active=False):
+                                    vswitch_name, active=False, vlan_id=-1):
         """ Couple nic device to specified vswitch.
 
         :param str userid: the user's name who owns the nic
         :param str nic_vdev: nic device number, 1- to 4- hexadecimal digits
         :param str vswitch_name: the name of the vswitch
         :param bool active: whether make the change on active guest system
+        :param str vlan_id: the VLAN ID of the NIC
         """
         self._networkops.couple_nic_to_vswitch(userid, nic_vdev,
-                                               vswitch_name, active=active)
+                                               vswitch_name, active=active,
+                                               vlan_id=vlan_id)
 
     @check_guest_exist()
     def guest_nic_uncouple_from_vswitch(self, userid, nic_vdev,

--- a/zvmsdk/networkops.py
+++ b/zvmsdk/networkops.py
@@ -53,9 +53,10 @@ class NetworkOPS(object):
         return self._smtclient.get_vswitch_list()
 
     def couple_nic_to_vswitch(self, userid, nic_vdev,
-                              vswitch_name, active=False):
+                              vswitch_name, active=False, vlan_id=-1):
         self._smtclient.couple_nic_to_vswitch(userid, nic_vdev,
-                                               vswitch_name, active=active)
+                                              vswitch_name, active=active,
+                                              vlan_id=vlan_id)
 
     def uncouple_nic_from_vswitch(self, userid, nic_vdev,
                                   active=False):

--- a/zvmsdk/sdkwsgi/handlers/guest.py
+++ b/zvmsdk/sdkwsgi/handlers/guest.py
@@ -220,10 +220,13 @@ class VMHandler(object):
 
         couple = util.bool_from_string(info['couple'], strict=True)
 
+        # vlan_id is for couple operation only, uncouple ignore it
+        vlan_id = info.get('vlan_id', -1)
+
         if couple:
             info = self.client.send_request('guest_nic_couple_to_vswitch',
                                             userid, vdev, info['vswitch'],
-                                            active=active)
+                                            active=active, vlan_id=vlan_id)
         else:
             info = self.client.send_request('guest_nic_uncouple_from_vswitch',
                                             userid, vdev,

--- a/zvmsdk/sdkwsgi/schemas/guest.py
+++ b/zvmsdk/sdkwsgi/schemas/guest.py
@@ -186,6 +186,7 @@ nic_couple_uncouple = {
                 'couple': parameter_types.boolean,
                 'active': parameter_types.boolean,
                 'vswitch': parameter_types.vswitch_name,
+                'vlan_id': parameter_types.vlan_id_or_minus_1,
             },
             # FIXME: vswitch should be required when it's couple
             'required': ['couple'],

--- a/zvmsdk/sdkwsgi/validation/parameter_types.py
+++ b/zvmsdk/sdkwsgi/validation/parameter_types.py
@@ -563,3 +563,9 @@ hostname = {
          'pattern': '^[a-zA-Z0-9-._]*$'}
     ]
 }
+
+vlan_id_or_minus_1 = {
+    'type': 'integer',
+    'minimum': -1,
+    'maximum': 4094,
+}

--- a/zvmsdk/tests/unit/sdkclientcases/test_restclient.py
+++ b/zvmsdk/tests/unit/sdkclientcases/test_restclient.py
@@ -493,6 +493,27 @@ class RESTClientTestCase(unittest.TestCase):
 
     @mock.patch.object(requests, 'request')
     @mock.patch('zvmconnector.restclient.RESTClient._get_token')
+    def test_guest_nic_couple_to_vswitch_vlan_id(self, get_token, request):
+        method = 'PUT'
+        url = '/guests/%s/nic/%s' % (self.fake_userid, '123')
+        body = {'info': {'couple': True,
+                         'vswitch': 'vswitch1',
+                         'active': False,
+                         'vlan_id': 1234}}
+        body = json.dumps(body)
+        header = self.headers
+        full_uri = self.base_url + url
+        request.return_value = self.response
+        get_token.return_value = self._tmp_token()
+
+        self.client.call("guest_nic_couple_to_vswitch", self.fake_userid,
+                         '123', 'vswitch1', active=False, vlan_id=1234)
+        request.assert_called_with(method, full_uri,
+                                   data=body, headers=header,
+                                   verify=False)
+
+    @mock.patch.object(requests, 'request')
+    @mock.patch('zvmconnector.restclient.RESTClient._get_token')
     def test_guest_nic_uncouple_from_vswitch(self, get_token, request):
         method = 'PUT'
         url = '/guests/%s/nic/%s' % (self.fake_userid, '123')

--- a/zvmsdk/tests/unit/sdkwsgi/handlers/test_guest.py
+++ b/zvmsdk/tests/unit/sdkwsgi/handlers/test_guest.py
@@ -1046,7 +1046,7 @@ class HandlersGuestTest(SDKWSGITest):
         guest.guest_couple_uncouple_nic(self.req)
         mock_couple.assert_called_once_with('guest_nic_couple_to_vswitch',
                                             FAKE_USERID, "1000", "vsw1",
-                                            active=False)
+                                            active=False, vlan_id=-1)
 
     @mock.patch('zvmconnector.connector.ZVMConnector.send_request')
     @mock.patch.object(util, 'wsgi_path_item')

--- a/zvmsdk/tests/unit/test_networkops.py
+++ b/zvmsdk/tests/unit/test_networkops.py
@@ -42,10 +42,11 @@ class SDKNetworkOpsTestCase(base.SDKTestCase):
     def test_couple_nic_to_vswitch(self, couple_nic_to_vswitch):
         self.networkops.couple_nic_to_vswitch("fake_userid", "nic_vdev",
                                               "fake_VS_name",
-                                              True)
+                                              active=True, vlan_id=5)
         couple_nic_to_vswitch.assert_called_with("fake_userid",
                                                  "nic_vdev",
                                                  "fake_VS_name",
+                                                 vlan_id=5,
                                                  active=True)
 
     @mock.patch('zvmsdk.smtclient.SMTClient.uncouple_nic_from_vswitch')


### PR DESCRIPTION
add VLAN ID first into couple action
then replace old couple NIC to VSWITCH method from SMAPI call to Image_Replace_DM
Also, more important, couple NIC to VSWITCH as well by adding VLAN ID