### PR TITLE
[Master]Support disk_pool to None by default

### DIFF
--- a/zvmsdk/config.py
+++ b/zvmsdk/config.py
@@ -122,7 +122,8 @@ Possible values:
         section='zvm'),
     Opt('disk_pool',
         section='zvm',
-        required=True,
+        default=None,
+        required=False,
         help='''
 zVM disk pool and type for root/ephemeral disks.
 

--- a/zvmsdk/hostops.py
+++ b/zvmsdk/hostops.py
@@ -60,8 +60,12 @@ class HOSTOps(object):
             host_info['hypervisor_version'] = version
             host_info['hypervisor_hostname'] = inv_info['hypervisor_name']
             host_info['ipl_time'] = inv_info['ipl_time']
-        diskpool_name = CONF.zvm.disk_pool.split(':')[1]
-        dp_info = self.diskpool_get_info(diskpool_name)
+        disk_pool = CONF.zvm.disk_pool
+        if disk_pool is None:
+            dp_info = {'disk_total': 0, 'disk_used': 0, 'disk_available': 0}
+        else:
+            diskpool_name = disk_pool.split(':')[1]
+            dp_info = self.diskpool_get_info(diskpool_name)
         host_info.update(dp_info)
 
         return host_info

--- a/zvmsdk/tests/unit/test_api.py
+++ b/zvmsdk/tests/unit/test_api.py
@@ -110,6 +110,23 @@ class SDKAPITestCase(base.SDKTestCase):
                                   '', '', '', [], {})
 
     @mock.patch("zvmsdk.vmops.VMOps.create_vm")
+    def test_guest_create_with_no_disk_pool(self, create_vm):
+        disk_list = [{'size': '1g', 'is_boot_disk': True,
+                      'disk_pool': 'ECKD: eckdpool1'},
+                     {'size': '1g', 'format': 'ext3'}]
+        vcpus = 1
+        memory = 1024
+        user_profile = 'profile'
+        max_cpu = 10
+        max_mem = '4G'
+        base.set_conf('zvm', 'disk_pool', None)
+        self.assertRaises(exception.SDKInvalidInputFormat,
+                          self.api.guest_create, self.userid, vcpus,
+                          memory, disk_list, user_profile,
+                          max_cpu, max_mem)
+        create_vm.assert_not_called()
+
+    @mock.patch("zvmsdk.vmops.VMOps.create_vm")
     def test_guest_create_with_default_max_cpu_memory(self, create_vm):
         vcpus = 1
         memory = 1024
@@ -232,6 +249,16 @@ class SDKAPITestCase(base.SDKTestCase):
         disk_list = [{'size': '1g'}]
         self.api.guest_create_disks(self.userid, disk_list)
         cds.assert_called_once_with(self.userid, disk_list)
+
+    @mock.patch("zvmsdk.vmops.VMOps.create_disks")
+    def test_guest_add_disks_no_disk_pool(self, cds):
+        disk_list = [{'size': '1g', 'is_boot_disk': True,
+                      'disk_pool': 'ECKD: eckdpool1'},
+                     {'size': '1g', 'format': 'ext3'}]
+        base.set_conf('zvm', 'disk_pool', None)
+        self.assertRaises(exception.SDKInvalidInputFormat,
+                          self.api.guest_create_disks, self.userid, disk_list)
+        cds.ssert_not_called()
 
     @mock.patch("zvmsdk.vmops.VMOps.create_disks")
     def test_guest_add_disks_nothing_to_do(self, cds):
@@ -482,3 +509,12 @@ class SDKAPITestCase(base.SDKTestCase):
     def test_host_get_guest_list(self, guest_list):
         self.api.host_get_guest_list()
         guest_list.assert_called_once_with()
+
+    @mock.patch("zvmsdk.hostops.HOSTOps.diskpool_get_info")
+    def test_host_diskpool_get_info(self, dp_info):
+        base.set_conf('zvm', 'disk_pool', None)
+        results = self.api.host_diskpool_get_info()
+        self.assertEqual(results['disk_total'], 0)
+        self.assertEqual(results['disk_available'], 0)
+        self.assertEqual(results['disk_used'], 0)
+        dp_info.ssert_not_called()

--- a/zvmsdk/tests/unit/test_hostops.py
+++ b/zvmsdk/tests/unit/test_hostops.py
@@ -56,11 +56,19 @@ class SDKHostOpsTestCase(base.SDKTestCase):
             }
         host_info = self._hostops.get_info()
         get_host_info.assert_called_once_with()
+        base.set_conf('zvm', 'disk_pool', 'ECKD:TESTPOOL')
         diskpool = CONF.zvm.disk_pool.split(':')[1]
         diskpool_get_info.assert_called_once_with(diskpool)
         self.assertEqual(host_info['vcpus'], 10)
         self.assertEqual(host_info['hypervisor_version'], 610)
         self.assertEqual(host_info['disk_total'], 406105)
+
+        # Test disk_pool is None
+        base.set_conf('zvm', 'disk_pool', None)
+        host_info = self._hostops.get_info()
+        self.assertEqual(host_info['disk_total'], 0)
+        self.assertEqual(host_info['disk_used'], 0)
+        self.assertEqual(host_info['disk_available'], 0)
 
     @mock.patch("zvmsdk.smtclient.SMTClient.get_diskpool_info")
     def test_get_diskpool_info(self, get_diskpool_info):

--- a/zvmsdk/tests/unit/test_smtclient.py
+++ b/zvmsdk/tests/unit/test_smtclient.py
@@ -257,6 +257,14 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         self._smtclient._add_mdisk(userid, disk, vdev),
         request.assert_called_once_with(rd)
 
+    def test_add_mdisk_no_disk_pool(self):
+        vdev = '0101'
+        disk = {'size': '1g',
+                'format': 'ext3'}
+        base.set_conf('zvm', 'disk_pool', None)
+        self.assertRaises(exception.SDKGuestOperationError,
+                          self._smtclient._add_mdisk, 'fakeuser', disk, vdev)
+
     @mock.patch.object(smtclient.SMTClient, '_request')
     def test_add_mdisk_format_none(self, request):
         userid = 'fakeuser'
@@ -1864,6 +1872,15 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         self._smtclient.add_mdisks(userid, disk_list)
         add_mdisk.assert_any_call(userid, disk_list[0], '0100')
         add_mdisk.assert_any_call(userid, disk_list[1], '0101')
+
+    def test_add_mdisks_no_disk_pool(self):
+        disk_list = [{'size': '1g',
+                      'is_boot_disk': True,
+                      'disk_pool': 'ECKD:eckdpool1'},
+                     {'size': '200000',
+                      'format': 'ext3'}]
+        self.assertRaises(exception.SDKGuestOperationError,
+                          self._smtclient.add_mdisks, 'fakeuser', disk_list)
 
     @mock.patch.object(smtclient.SMTClient, '_add_mdisk')
     def test_add_mdisks_with_1dev(self, add_mdisk):


### PR DESCRIPTION
Please help review the code logic first, the ut and fvt will complete later on.
There's one point not quiet sure:
In guest_create() of api.py, if disk_list has only one disk info and disk_pool is None:
such as disk_list=[{'size':'1g', 'format':'xfs'}]  and disk_pool not configured in zvmsdk.conf
in such case, the guest_create report ERROR？or Continue( does boot_from_volume deploy vm go into this guest_create() fucntion in api.py?)


To support CIC manage a zvm host without diskpool, such as
zvm host configured FCP stroage only, we do the corresponding
change to support disk_pool to None by default.

Code changes:
- Add extra check for disk_pool=None before previous check logic
  > guest_create
  > host_diskpool_get_info
  > get_info
  > add_mdisks
  > _add_mdisk
- Not call Image_Volume_Space_Query_DM and return minimal disk values directly if disk_pool is None
- Add some comments for disk_pool is None
- Remove the disk from disk_list if disk_pool is None
- Add default value None to config option

Related issue:
https://github.ibm.com/zvc/planning/issues/2771

Signed-off-by: Xiao Feng Ren <renxiaof@linux.vnet.ibm.com>





