### PR TITLE
[master]forget adding templates into package data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,9 @@ setuptools.setup(
         'zvmsdk': [
             'vmactions/templates/grow_root_volume.j2',
             'volumeops/templates/rhel7_attach_volume.j2',
-            'volumeops/templates/rhel7_detach_volume.j2'
+            'volumeops/templates/rhel7_detach_volume.j2',
+            'volumeops/templates/rhel8_attach_volume.j2',
+            'volumeops/templates/rhel8_detach_volume.j2'
         ]
     },
     classifiers=[


### PR DESCRIPTION
fix for PR: https://github.com/openmainframeproject/feilong/pull/372
forget to add rhel8_attach_volume.j2 and rhel8_detach_volume.j2 into package data.

Signed-off-by: SharpRazor <bjcb@cn.ibm.com>