### PR TITLE
[master] fix exit code bug in detach scripts

### DIFF
--- a/zvmsdk/volumeops/templates/rhel7_detach_volume.j2
+++ b/zvmsdk/volumeops/templates/rhel7_detach_volume.j2
@@ -27,12 +27,16 @@ output=$(multipath -f $map_name 2>&1)
 exit_code=$?
 
 # error output not empty, means error happened
+# and the error 'in use' and 'must provode a map name'
+# of multipath -f will return same exit code 1
+# so diff them, we will ingore the error of 'must provide a map name'
 if [ "$output" ]; then
-    if [ "$(echo $output | grep -i 'in use')" ]; then
+    if [ "$(echo $output | grep -i 'must provide a map name')" ]; then
+        echo "ignore error on FCP $fcp and Lun $lun:$output"
+        exit_code=0
+    elif [ "$(echo $output | grep -i 'in use')" ]; then
         echo "FCP $fcp and Lun $lun is use:$output"
         exit_code=1
-    elif [ "$(echo $output | grep -i 'must provide a map name')" ]; then
-        echo "ignore error on FCP $fcp and Lun $lun:$output"
     else
         echo "unknown error on FCP $fcp and Lun $lun:$output"
         exit_code=2
@@ -41,9 +45,10 @@ fi
 
 echo "exit code for multipath -f: $exit_code"
 # if above code didn't succeed, exit now.
-if [[ $exit_code != 0  ]]; then
+if [[ $exit_code != 0 ]]; then
     exit $exit_code
 fi
+
 
 # flush IO for devices
 RealPath=`readlink -f /dev/disk/by-path/$SourceDevice`

--- a/zvmsdk/volumeops/templates/rhel8_detach_volume.j2
+++ b/zvmsdk/volumeops/templates/rhel8_detach_volume.j2
@@ -27,12 +27,16 @@ output=$(multipath -f $map_name 2>&1)
 exit_code=$?
 
 # error output not empty, means error happened
+# and the error 'in use' and 'must provode a map name'
+# of multipath -f will return same exit code 1
+# so diff them, we will ingore the error of 'must provide a map name'
 if [ "$output" ]; then
-    if [ "$(echo $output | grep -i 'in use')" ]; then
+    if [ "$(echo $output | grep -i 'must provide a map name')" ]; then
+        echo "ignore error on FCP $fcp and Lun $lun:$output"
+        exit_code=0
+    elif [ "$(echo $output | grep -i 'in use')" ]; then
         echo "FCP $fcp and Lun $lun is use:$output"
         exit_code=1
-    elif [ "$(echo $output | grep -i 'must provide a map name')" ]; then
-        echo "ignore error on FCP $fcp and Lun $lun:$output"
     else
         echo "unknown error on FCP $fcp and Lun $lun:$output"
         exit_code=2
@@ -41,7 +45,7 @@ fi
 
 echo "exit code for multipath -f: $exit_code"
 # if above code didn't succeed, exit now.
-if [[ $exit_code != 0  ]]; then
+if [[ $exit_code != 0 ]]; then
     exit $exit_code
 fi
 


### PR DESCRIPTION
we execute multipath -f will meet 2 error cases:
1. `multipath -f <with a none input>`, it will report error 'must provide a map name'
2. `multipath -f map_name_in_use`, it will report error 'in use'
but the exit code $? of the 2 errors are same, it is 1.
so need to diff them.

Signed-off-by: SharpRazor <bjcb@cn.ibm.com>