### PR TITLE
[master]fix fcp database allocation bug

### DIFF
--- a/zvmsdk/database.py
+++ b/zvmsdk/database.py
@@ -445,6 +445,15 @@ class FCPDbOperator(object):
 
         return connections
 
+    def get_allocated_fcps_from_assigner(self, assigner_id):
+        with get_fcp_conn() as conn:
+
+            result = conn.execute("SELECT * FROM fcp WHERE assigner_id=? "
+                                  "and (connections<>0 or reserved<>0) order "
+                                  "by fcp_id ASC", (assigner_id,))
+            fcp_list = result.fetchall()
+        return fcp_list
+
     def get_from_assigner(self, assigner_id):
         with get_fcp_conn() as conn:
 

--- a/zvmsdk/tests/unit/test_database.py
+++ b/zvmsdk/tests/unit/test_database.py
@@ -391,6 +391,33 @@ class FCPDbOperatorTestCase(base.SDKTestCase):
             self.db_op.delete('1111')
             self.db_op.delete('1112')
 
+    def test_get_allocated_fcps_from_assigner(self):
+        self.db_op.new('1111', 0)
+        self.db_op.new('1112', 1)
+
+        try:
+            self.db_op.assign('1111', 'user1', update_connections=False)
+            self.db_op.assign('1112', 'user1', update_connections=False)
+
+            fcp_list = self.db_op.get_allocated_fcps_from_assigner('user1')
+            self.assertEqual(0, len(fcp_list))
+
+            self.db_op.assign('1111', 'user2', update_connections=True)
+            fcp_list = self.db_op.get_allocated_fcps_from_assigner('user2')
+            self.assertEqual(1, len(fcp_list))
+
+            self.db_op.assign('1112', 'user2', update_connections=False)
+            self.db_op.reserve('1112')
+            fcp_list = self.db_op.get_allocated_fcps_from_assigner('user2')
+            self.assertEqual(2, len(fcp_list))
+
+            fcp = fcp_list[0]
+            self.assertEqual('1111', fcp[0])
+            self.assertEqual('user2', fcp[1])
+        finally:
+            self.db_op.delete('1111')
+            self.db_op.delete('1112')
+
     def test_get_from_fcp(self):
         self.db_op.new('1111', 0)
         self.db_op.new('1112', 2)

--- a/zvmsdk/tests/unit/test_volumeop.py
+++ b/zvmsdk/tests/unit/test_volumeop.py
@@ -559,7 +559,10 @@ class TestFCPVolumeManager(base.SDKTestCase):
         base.set_conf('volume', 'fcp_list', 'b83c')
         # assign FCP
         self.db_op.new('b83c', 0)
+        # set connections to 1 and assigner_id to b83c
         self.db_op.assign('b83c', 'fakeuser')
+        # set reserved to 1
+        self.db_op.reserve('b83c')
 
         try:
             connections = self.volumeops.get_volume_connector('fakeuser',
@@ -570,7 +573,7 @@ class TestFCPVolumeManager(base.SDKTestCase):
             self.assertEqual(expected, connections)
 
             fcp_list = self.db_op.get_from_fcp('b83c')
-            expected = [(u'b83c', u'fakeuser', 1, 0, 0, u'')]
+            expected = [(u'b83c', u'fakeuser', 1, 1, 0, u'')]
             self.assertEqual(expected, fcp_list)
         finally:
             self.db_op.delete('b83c')

--- a/zvmsdk/volumeop.py
+++ b/zvmsdk/volumeop.py
@@ -542,8 +542,10 @@ class FCPManager(object):
         available_list = []
         # first check whether this userid already has a FCP device
         # get the FCP devices belongs to assigner_id
-        fcp_list = self.db.get_from_assigner(assigner_id)
+        fcp_list = self.db.get_allocated_fcps_from_assigner(assigner_id)
         if not fcp_list:
+            LOG.info("There is no allocated fcps for %s, will allocate "
+                     "new ones." % assigner_id)
             if CONF.volume.get_fcp_pair_with_same_index:
                 '''
                 If use get_fcp_pair_with_same_index,
@@ -568,9 +570,11 @@ class FCPManager(object):
                 # with the get_volume_connector call.
                 self.db.assign(item, assigner_id, update_connections=False)
 
-            LOG.debug("allocated %s fcp for %s assigner" %
+            LOG.info("allocated %s fcp for %s assigner" %
                       (available_list, assigner_id))
         else:
+            LOG.info("Found allocated fcps %s for %s, will reuse them."
+                     % (fcp_list, assigner_id))
             path_count = self.db.get_path_count()
             if len(fcp_list) < path_count:
                 # TODO: handle the case when len(fcp_list) < multipath_count


### PR DESCRIPTION
the bug is that:
sometimes get_available_fcp will return the fcp_list whose
len is less the count of multipath

Signed-off-by: SharpRazor <bjcb@cn.ibm.com>