### PR TITLE
add reachable check in guest_start

### DIFF
--- a/doc/source/errcode.csv
+++ b/doc/source/errcode.csv
@@ -18,6 +18,8 @@
 300;10;300;12;Failed to deploy image to userid: '%(userid)s', get unpackdiskimage cmd failed: %(err)s
 300;10;300;13;Failed to deploy image to userid: '%(userid)s', ignition file is required when deploying RHCOS image
 300;10;300;14;Failed to deploy image to userid: '%(userid)s', %(msg)s
+300;10;300;15;Failed to live resize cpus of guest: '%(userid)s', error: enable new defined cpus failed: '%(err)s'.
+300;10;300;16;Failed to start the guest: '%(userid)s', %(msg)s
 **Operation on Network failed**
 300;20;300;1;Database operation failed, error: %(msg)s
 300;20;300;2;ZVMSDK network error: %(msg)s

--- a/doc/source/zvmsdk.conf.sample
+++ b/doc/source/zvmsdk.conf.sample
@@ -39,6 +39,16 @@
 
 
 # 
+# The maximum time waiting until the guest reachable after started.
+# 
+# When starting a guest, specify the timeout value will check the guest status
+# untils it becames reachable or timeout.
+#     
+# This param is optional
+#reachable_timeout=180
+
+
+# 
 # The interval time between 2 retries, in seconds.
 # 
 # This will take effect only when you set softstop_retries item.
@@ -302,9 +312,11 @@
 # defers to CP's processing.
 # 
 # Usage note:
-#     The default is an empty string (''). When the string is empty, you can't
-#     log on to your instances using the 3270 protocol; When a
-#     non-empty string is provided, blank chars will be used as delimiter,
+#     The default is empty string with nothing set i.e.
+#     default_admin_userid=
+#     '' is an invalid value and it will cause VM deploying failed.
+#     Thus, DO NOT set default_admin_userid=''.
+#     When a non-empty string is provided, blank chars will be used as delimiter,
 #     you can use LOGONBY xxx command to log on the guest using the corresponding
 #     admin userid's password.
 # 
@@ -316,8 +328,7 @@
 # Possible values:
 #     A maximum of 8 blank-delimited strings. Each non-blank string must be a
 #     valid z/VM userid.
-#     e.g  '' is a valid value.
-#          'oper1 oper2' is a valid value.
+#     e.g  'oper1 oper2' is a valid value.
 #          'o1 o2 o3 o4 o5 o6 o7 o8 o9' is NOT a valid value.
 #     
 # This param is optional
@@ -363,7 +374,7 @@
 #     ECKD:diskpo1
 #     FBA:testpool
 #     
-# This param is required
+# This param is optional
 #disk_pool=None
 
 

--- a/zvmconnector/restclient.py
+++ b/zvmconnector/restclient.py
@@ -180,6 +180,7 @@ def req_guests_get_nic_info(start_index, *args, **kwargs):
 def req_guest_start(start_index, *args, **kwargs):
     url = '/guests/%s/action'
     body = {'action': 'start'}
+    fill_kwargs_in_body(body, **kwargs)
     return url, body
 
 

--- a/zvmsdk/api.py
+++ b/zvmsdk/api.py
@@ -81,16 +81,19 @@ class SDKAPI(object):
         self._NetworkDbOperator = database.NetworkDbOperator()
 
     @check_guest_exist()
-    def guest_start(self, userid):
+    def guest_start(self, userid, timeout=0):
         """Power on a virtual machine.
 
         :param str userid: the id of the virtual machine to be power on
+        :param int timeout: the timeout of waiting virtual machine reachable
+                            default as 0, which mean not wait for virtual
+                            machine reachable status
 
         :returns: None
         """
         action = "start guest '%s'" % userid
         with zvmutils.log_and_reraise_sdkbase_error(action):
-            self._vmops.guest_start(userid)
+            self._vmops.guest_start(userid, timeout)
 
     @check_guest_exist()
     def guest_stop(self, userid, **kwargs):

--- a/zvmsdk/config.py
+++ b/zvmsdk/config.py
@@ -270,6 +270,16 @@ Console logs might be transferred to sdk user, this option controls how
 large each file can be. A smaller size may mean more calls will be needed
 to transfer large consoles, which may not be desirable for performance reasons.
     '''),
+    Opt('reachable_timeout',
+        section='guest',
+        default=180,
+        opt_type='int',
+        help='''
+The maximum time waiting until the guest reachable after started.
+
+When starting a guest, specify the timeout value will check the guest status
+untils it becames reachable or timeout.
+    '''),
     Opt('softstop_timeout',
         section='guest',
         default=120,

--- a/zvmsdk/exception.py
+++ b/zvmsdk/exception.py
@@ -255,3 +255,7 @@ class SDKFunctionNotImplementError(SDKBaseException):
         results['strError'] = errormsg
         super(SDKFunctionNotImplementError, self).__init__(results=results,
                                                       message=errormsg)
+
+
+class SDKRetryException(SDKBaseException):
+    pass

--- a/zvmsdk/returncode.py
+++ b/zvmsdk/returncode.py
@@ -171,7 +171,8 @@ errors = {
                    "ignition file is required when deploying RHCOS image"),
                14: ("Failed to deploy image to userid: '%(userid)s', %(msg)s"),
                15: ("Failed to live resize cpus of guest: '%(userid)s', "
-                   "error: enable new defined cpus failed: '%(err)s'.")
+                   "error: enable new defined cpus failed: '%(err)s'."),
+               16: ("Failed to start the guest: '%(userid)s', %(msg)s")
               },
               "Operation on Guest failed"
               ],

--- a/zvmsdk/sdkwsgi/handlers/guest.py
+++ b/zvmsdk/sdkwsgi/handlers/guest.py
@@ -243,6 +243,7 @@ class VMAction(object):
         self.dd_semaphore = threading.BoundedSemaphore(
             value=CONF.wsgi.max_concurrent_deploy_capture)
 
+    @validation.schema(guest.start)
     def start(self, userid, body):
         info = self.client.send_request('guest_start', userid)
 

--- a/zvmsdk/sdkwsgi/schemas/guest.py
+++ b/zvmsdk/sdkwsgi/schemas/guest.py
@@ -291,6 +291,14 @@ nic_DB_info = {
     'additionalProperties': False,
 }
 
+start = {
+    'type': 'object',
+    'properties': {
+        'userid': parameter_types.userid,
+        'timeout': parameter_types.non_negative_integer,
+    },
+    'additionalProperties': False,
+}
 
 stop = {
     'type': 'object',


### PR DESCRIPTION
By adding a timeout parameter to guest_start api. Default timeout
is 0, which means not wait for guest reachable status. If timeout
> 0, will wait guest to reachable status or timeout to return.

Signed-off-by: bjhuangr <bjhuangr@cn.ibm.com>