### PR TITLE
[master] Fix duplicated default_admin_userid in zvmsdk.conf

### DIFF
--- a/doc/source/zvmsdk.conf.sample
+++ b/doc/source/zvmsdk.conf.sample
@@ -312,8 +312,7 @@
 # defers to CP's processing.
 # 
 # Usage note:
-#     The default is empty string with nothing set i.e.
-#     default_admin_userid=
+#     The default is empty string with nothing set.
 #     '' is an invalid value and it will cause VM deploying failed.
 #     Thus, DO NOT set default_admin_userid=''.
 #     When a non-empty string is provided, blank chars will be used as delimiter,

--- a/zvmsdk/config.py
+++ b/zvmsdk/config.py
@@ -99,8 +99,7 @@ When an ESM is installed, this parameter only governs when the ESM
 defers to CP's processing.
 
 Usage note:
-    The default is empty string with nothing set i.e.
-    default_admin_userid=
+    The default is empty string with nothing set.
     '' is an invalid value and it will cause VM deploying failed.
     Thus, DO NOT set default_admin_userid=''.
     When a non-empty string is provided, blank chars will be used as delimiter,


### PR DESCRIPTION
Related issue: https://github.ibm.com/zvc/planning/issues/4962
We shouldn't set default_admin_userid in the beginning of a line.

Signed-off-by: QingFeng Hao <haoqf@linux.vnet.ibm.com>