### PR TITLE
ignore 596/3543 warnning

### DIFF
--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -2207,6 +2207,12 @@ class SMTClient(object):
                 LOG.warning("The guest %s deleted with 596/6831" % userid)
                 return
 
+            # ignore delete VM with VDISK format error
+            # DirMaint does not support formatting TDISK or VDISK extents.
+            if err.results['rc'] == 596 and err.results['rs'] == 3543:
+                LOG.debug("The guest %s deleted with 596/3543" % userid)
+                return
+
             msg = "SMT error: %s" % err.format_message()
             raise exception.SDKSMTRequestFailed(err.results, msg)
 

--- a/zvmsdk/tests/unit/test_smtclient.py
+++ b/zvmsdk/tests/unit/test_smtclient.py
@@ -1867,6 +1867,15 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         request.assert_called_once_with(rd)
 
     @mock.patch.object(smtclient.SMTClient, '_request')
+    def test_delete_userid_with_vdisk_warning(self, request):
+        rd = 'deletevm fuser1 directory'
+        results = {'rc': 596, 'rs': 3543, 'logEntries': ''}
+        request.side_effect = exception.SDKSMTRequestFailed(results,
+                                                               "fake error")
+        self._smtclient.delete_userid('fuser1')
+        request.assert_called_once_with(rd)
+
+    @mock.patch.object(smtclient.SMTClient, '_request')
     def test_delete_userid_failed(self, request):
         rd = 'deletevm fuser1 directory'
         results = {'rc': 400, 'rs': 104, 'logEntries': ''}


### PR DESCRIPTION
596/3543 is actually a supported behavior, which is , delete a VM with  VDISK might lead to this warning
if cleanup is set to true, so ignore the warning