### PR TITLE
update refresh_bootmap for RHCOS4.7

### DIFF
--- a/zthin-parts/zthin/bin/refresh_bootmap
+++ b/zthin-parts/zthin/bin/refresh_bootmap
@@ -288,18 +288,18 @@ function refreshZIPL {
   #   None
   local devNode=$1
 
+  if [[ $skipzipl = 'YES'  ]]; then
+    # this is the part of return info for upper layer(smtclient)
+    inform "RESULT PATHS: $valid_paths_str"
+    return
+  fi
+
   inform "Begin to refreshZIPL."
 
   if [[ ! -e "$devNode" ]]; then
     printError "devNode ${devNode} doesn't exist. Get fcps: ${fcps[*]} and wwpns: ${wwpns[*]}"
     printLogs
     exit 6
-  fi
-
-  if [[ $skipzipl = 'YES'  ]]; then
-    # this is the part of return info for upper layer(smtclient)
-    inform "RESULT PATHS: $valid_paths_str"
-    return
   fi
 
   # Create a mount dir.


### PR DESCRIPTION
From RHCOS4.7, the boot partition became the third partition,
not the first partition. This will cause the error when checking
devnode in refreshzipl of refresh_bootmap script.

In this change, return from refreshzipl directly if skipzipl.

Signed-off-by: bjhuangr <bjhuangr@cn.ibm.com>