### PR TITLE
To fix the error when mount RHCOS partition with mpath enabled

### DIFF
--- a/zthin-parts/zthin/bin/unpackdiskimage
+++ b/zthin-parts/zthin/bin/unpackdiskimage
@@ -497,7 +497,11 @@ function mount_boot_partition {
     while true
     do
         eval $(lsblk "${DEST_DEV}" --output LABEL,NAME --pairs | grep 'LABEL="boot' | tr ' ' '\n' | tail -n 1)
-        mount "/dev/${NAME}" "$mountpoint"
+        if [[ ${NAME} =~ "mpath" ]]; then
+            mount "/dev/mapper/${NAME}" "$mountpoint"
+        else
+            mount "/dev/${NAME}" "$mountpoint"
+        fi
         RETCODE=$?
         if [[ $RETCODE -ne 0 ]]; then
             if [[ $retry -lt 30 ]]; then


### PR DESCRIPTION
With mpath enabled, the dev node should be "/dev/mapper/mpathXN",
where "X" is dev and "N" is partition. For example,
"/dev/mapper/mpatha3". In this change, will check mpath enabled or
not, then set the dev node string accordingly.

Signed-off-by: bjhuangr <bjhuangr@cn.ibm.com>