### PR TITLE
[master]Make maximum reserved memory as 248G

### DIFF
--- a/doc/source/errcode.csv
+++ b/doc/source/errcode.csv
@@ -78,6 +78,7 @@
 409;None;409;18;Failed to live resize memory of guest: '%(userid)s', error: current active memory size: '%(active)i'm is greater than requested size: '%(req)i'm.
 409;None;409;19;Failed to resize memory of guest: '%(userid)s', error: user definition is not in expected format, cann't get the defined/max/reserved storage.
 409;None;409;20;Failed to resize memory of guest: '%(userid)s', error: the requested memory size: '%(req)im' exceeds the maximum memory size defined: '%(max)im'.
+409;None;409;21;Failed to live resize memory of guest: %(userid)s, error: the memory size to be increased: '%(inc)im' is greater than the maximum reserved memory size: '%(max)im'.
 **The operated object is deleted**
 410;None;410;;The operated object is deleted
 **ZVM SDK Internal Error**

--- a/smtLayer/makeVM.py
+++ b/smtLayer/makeVM.py
@@ -23,6 +23,8 @@ from smtLayer.vmUtils import invokeSMCLI
 
 modId = 'MVM'
 version = "1.0.0"
+# make maximum reserved memory value as 248G, 253952M
+MAX_STOR_RESERVED = 253952
 
 """
 List of subfunction handlers.
@@ -457,6 +459,11 @@ def getReservedMemSize(rh, mem, maxMem):
     # So we will use 'M' as suffix unless the gap size exceeds 9999999
     # then convert to Gb.
     gapSize = maxMemMb - memMb
+
+    # make max reserved memory value as 248G
+    if gapSize > MAX_STOR_RESERVED:
+        gapSize = MAX_STOR_RESERVED
+
     if gapSize > 9999999:
         gapSize = gapSize / 1024
         gap = "%iG" % gapSize

--- a/smtLayer/tests/unit/test_makeVM.py
+++ b/smtLayer/tests/unit/test_makeVM.py
@@ -53,11 +53,23 @@ class SMTMakeVMTestCase(base.SMTTestCase):
         self.assertEqual(gap, '0M')
         self.assertEqual(rh.results['overallRC'], 0)
 
+    def test_getReservedMemSize_max_reserved(self):
+        rh = ReqHandle.ReqHandle(captureLogs=False,
+                                 smt=mock.Mock())
+        gap = makeVM.getReservedMemSize(rh, '512m', '256G')
+        self.assertEqual(gap, '253952M')
+        self.assertEqual(rh.results['overallRC'], 0)
+
+    # As maxmimum reserved memory is 248G=253952M,
+    # which can't exceed 9999999M, so this case will
+    # return 253952M. If future the 248G limit is not
+    # there, recover this case.
     def test_getReservedMemSize_gap_G(self):
         rh = ReqHandle.ReqHandle(captureLogs=False,
                                  smt=mock.Mock())
         gap = makeVM.getReservedMemSize(rh, '512m', '9999G')
-        self.assertEqual(gap, '9998G')
+        # self.assertEqual(gap, '9998G')
+        self.assertEqual(gap, '253952M')
         self.assertEqual(rh.results['overallRC'], 0)
 
     @mock.patch("os.write")

--- a/zvmsdk/returncode.py
+++ b/zvmsdk/returncode.py
@@ -314,6 +314,10 @@ errors = {
                   20: ("Failed to resize memory of guest: '%(userid)s', "
                       "error: the requested memory size: '%(req)im' exceeds "
                       "the maximum memory size defined: '%(max)im'."),
+                  21: ("Failed to live resize memory of guest: %(userid)s, "
+                      "error: the memory size to be increased: '%(inc)im' "
+                      "is greater than the maximum reserved memory size: "
+                      "'%(max)im'."),
                   },
                  "The operated object status conflict"
                  ],


### PR DESCRIPTION
If maximum memory is set to a large value such as 256G and
deploy a vm with 4G memory, the reserved memory is 252G,
then zvm guest linux can't start smoothly. Make the reserved
memory value as 248G can work.

To make sure VM can start correctly,
when maximum memory - active memory <= 248G:
    reserved memory = maximum memory - active memory
when maximum memory - active memory > 248G:
    reserved memory = 248G

Signed-off-by: Shu Juan Zhang <zshujuan@cn.ibm.com>