### PR TITLE
Add output into log for debug purpose

### DIFF
--- a/smtLayer/vmUtils.py
+++ b/smtLayer/vmUtils.py
@@ -459,6 +459,8 @@ def installFS(rh, vaddr, mode, fileSystem, diskType):
                 stderr=subprocess.STDOUT,
                 close_fds=True,
                 shell=True)
+            rh.printSysLog("Run `%s` success with output: %s"
+                           % (cmd, out))
             if isinstance(out, bytes):
                 out = bytes.decode(out)
         except CalledProcessError as e:
@@ -489,7 +491,8 @@ def installFS(rh, vaddr, mode, fileSystem, diskType):
                         stderr=subprocess.STDOUT,
                         close_fds=True,
                         shell=True)
-                    rh.printSysLog("Run `%s` successfully." % cmd)
+                    rh.printSysLog("Run `%s` success with output: %s"
+                                   % (cmd, out))
                     break
                 except CalledProcessError as e:
                     if sleep_secs > 0:


### PR DESCRIPTION
The add 9336 function does not contain enough information about fdisk actions result

Signed-off-by: jichenjc <jichenjc@cn.ibm.com>