### PR TITLE
use g instead of d when fdisk

### DIFF
--- a/smtLayer/vmUtils.py
+++ b/smtLayer/vmUtils.py
@@ -451,7 +451,7 @@ def installFS(rh, vaddr, mode, fileSystem, diskType):
     if results['overallRC'] == 0 and diskType == "9336":
         # Delete the existing partition in case the disk already
         # has a partition in it.
-        cmd = "sudo /sbin/fdisk " + device + " << EOF\nd\nw\nEOF"
+        cmd = "sudo /sbin/fdisk " + device + " << EOF\ng\nw\nEOF"
         rh.printSysLog("Invoking: sudo /sbin/fdisk " + device +
             " << EOF\\nd\\nw\\nEOF ")
         try:


### PR DESCRIPTION
previously, we use `d` in fdisk which is delete a parition
```  Generic
   d   delete a partition
```

but this might fail due to multiple partitions existing

so the PR process to recreate the parittion table by using `g` which is 
```
Create a new label
   g   create a new empty GPT partition table
```