### PR TITLE
[master] add retry for find devNode file when refresh_bootmap

### DIFF
--- a/zthin-parts/zthin/bin/refresh_bootmap
+++ b/zthin-parts/zthin/bin/refresh_bootmap
@@ -225,6 +225,9 @@ function printLogs {
   # ls /dev/disk/by-path
   disk_by_path_folder=$(ls /dev/disk/by-path/)
   inform "/dev/disk/by-path/ folder content: ${disk_by_path_folder}."
+  # ls /dev/disk/by-id
+  disk_by_id_folder=$(ls /dev/disk/by-id/)
+  inform "/dev/disk/by-id/ folder content: ${disk_by_id_folder}."
   # multipath -ll
   multipath_output=$(multipath -ll 2>&1)
   inform "multipath output: ${multipath_output}."
@@ -297,9 +300,23 @@ function refreshZIPL {
   inform "Begin to refreshZIPL."
 
   if [[ ! -e "$devNode" ]]; then
-    printError "devNode ${devNode} doesn't exist. Get fcps: ${fcps[*]} and wwpns: ${wwpns[*]}"
-    printLogs
-    exit 6
+    inform "devNode file ${devNode} not exist yet. Retrying..."
+    sleepTimes=".001 .01 .1 .5 1 2 3 5 8 15 22 34 60 90 120"
+    # retry, while waiting various durations
+    for seconds in $sleepTimes; do
+      sleep $seconds
+      inform "Retrying with interval as ${seconds} seconds"
+      if [[ -e "$devNode" ]]; then
+        # successful - leave loop
+        break
+      fi
+    done
+    # print error log if retry fails
+    if [[ ! -e "$devNode" ]]; then
+      printError "devNode ${devNode} doesn't exist. Get fcps: ${fcps[*]} and wwpns: ${wwpns[*]}"
+      printLogs
+      exit 6
+    fi
   fi
 
   # Create a mount dir.


### PR DESCRIPTION
### Verified below two cases    
```shell
Add retry below
sleepTimes=".001 .01 .1 .5 1 2 3 5 8 15 22 34 60 90 120"
```
#### case1: 
```shell
1. At the start of refresh_bootmap, mv devNode file to /tmp/refresh/ manually 
    ---------
    [root@113-cmp-wdl-m5403 ~]# while true; do ls -lh /dev/disk/by-id/dm-uuid*; /bin/mv /dev/disk/by-id/dm-uuid-part1-mpath-* /tmp/refresh/; ls -lh /tmp/refresh/; sleep 0.5; done;
    ----------
    -> trigger retry
2. Before retry attempts exhausted, mv devNode file back to /dev/disk/by-id/ 
    -> refresh_bootmap completed 

key related log of /var/log/messages:

refreshZIPL: Begin to refreshZIPL.
refreshZIPL: devNode file /dev/disk/by-id/dm-uuid-part1-mpath-3600507640083826de000000000002192 not exist yet. Retrying...
refreshZIPL: Retrying with interval as .001 seconds
refreshZIPL: Retrying with interval as .01 seconds
refreshZIPL: Retrying with interval as .1 seconds
refreshZIPL: Retrying with interval as .5 seconds
refreshZIPL: Retrying with interval as 1 seconds
refreshZIPL: Retrying with interval as 2 seconds
refreshZIPL: Retrying with interval as 3 seconds
refreshZIPL: Retrying with interval as 5 seconds
refreshZIPL: Retrying with interval as 8 seconds
refreshZIPL: Retrying with interval as 15 seconds
refreshZIPL: Retrying with interval as 22 seconds
refreshZIPL: Retrying with interval as 34 seconds
refreshZIPL: Retrying with interval as 60 seconds
refreshZIPL: Retrying with interval as 90 seconds
refreshZIPL: devNode is: /dev/disk/by-id/dm-uuid-part1-mpath-3600507640083826de000000000002192 point: /mnt/U9kQi
refreshZIPL: Final rd.zfcp value is: rd.zfcp=0.0.1b0f,0x500507680b21bac6,0x0000000000000000 rd.zfcp=0.0.1b0f,0x500507680b21bac7,0x0000000000000000 rd.zfcp=0.0.1b0f,0x500507680b22bac6,0x0000000000000000 rd.zfcp=0.0.1b0f,0x500507680b22bac7,0x0000000000000000 rd.zfcp=0.0.1a0f,0x500507680b21bac6,0x0000000000000000 rd.zfcp=0.0.1a0f,0x500507680b21bac7,0x0000000000000000 rd.zfcp=0.0.1a0f,0x500507680b22bac6,0x0000000000000000 rd.zfcp=0.0.1a0f,0x500507680b22bac7,0x0000000000000000 .
refreshZIPL: Refresh rhel78 zipl.
refreshZIPL: Updating /mnt/U9kQi/etc/fstab
refreshZIPL: Move stale multipath bindings and wwids if any
refreshZIPL: RESULT PATHS: 1a0f:500507680b21bac6 500507680b21bac7 500507680b22bac6 500507680b22bac7,1b0f:500507680b21bac6 500507680b21bac7 500507680b22bac6 500507680b22bac7
```

#### case2: 
```shell
1. At the start of refresh_bootmap, mv devNode file to /tmp/refresh/ manually 
    -> trigger retry
2. Not mv devNode file back to /dev/disk/by-id/ 
    -> retry attempts exhausted 
    -> printLog
    -> refresh_bootmap aborted 

key related log of /var/log/messages:
refreshZIPL: Begin to refreshZIPL.
refreshZIPL: devNode file /dev/disk/by-id/dm-uuid-part1-mpath-3600507640083826de00000000000219d not exist yet. Retrying...
refreshZIPL: Retrying with interval as .001 seconds
refreshZIPL: Retrying with interval as .01 seconds
refreshZIPL: Retrying with interval as .1 seconds
refreshZIPL: Retrying with interval as .5 seconds
refreshZIPL: Retrying with interval as 1 seconds
refreshZIPL: Retrying with interval as 2 seconds
refreshZIPL: Retrying with interval as 3 seconds
refreshZIPL: Retrying with interval as 5 seconds
refreshZIPL: Retrying with interval as 8 seconds
refreshZIPL: Retrying with interval as 15 seconds
refreshZIPL: Retrying with interval as 22 seconds
refreshZIPL: Retrying with interval as 34 seconds
refreshZIPL: Retrying with interval as 60 seconds
refreshZIPL: Retrying with interval as 90 seconds
refreshZIPL: Retrying with interval as 120 seconds
refreshZIPL: devNode /dev/disk/by-id/dm-uuid-part1-mpath-3600507640083826de00000000000219d does not exist. 
                Get fcps: 1b0e 1a0e and wwpns: 500507680b21bac6 500507680b21bac7 500507680b22bac6 500507680b22bac7 500507680b21bac7 500507680b22bac6 500507680b22bac7
printLogs: lszfcp output: 0.0.1a0d host1#012
                0.0.1a0e host3#012
                0.0.1b0d host0#012
                0.0.1b0e host2#012
                0.0.1a0d/0x5005076306035388/0x0000000000000000 1:0:4:0#012
                0.0.1a0d/0x5005076306105388/0x0000000000000000 1:0:5:0#012
                0.0.1a0e/0x500507680b21bac6/0x0000000000000000 3:0:0:0#012
                0.0.1a0e/0x500507680b21bac7/0x0000000000000000 3:0:4:0#012
                0.0.1a0e/0x500507680b22bac6/0x0000000000000000 3:0:5:0#012
                0.0.1a0e/0x500507680b22bac7/0x0000000000000000 3:0:7:0#012
                0.0.1b0d/0x5005076306035388/0x0000000000000000 0:0:0:0#012
                0.0.1b0d/0x5005076306105388/0x0000000000000000 0:0:1:0#012
                0.0.1b0e/0x500507680b21bac6/0x0000000000000000 2:0:1:0#012
                0.0.1b0e/0x500507680b22bac6/0x0000000000000000 2:0:5:0#012
                0.0.1b0e/0x500507680b22bac7/0x0000000000000000 2:0:6:0#012
                0.0.1b0e/0x500507680b21bac7/0x0000000000000000 2:0:7:0.
printLogs: lsluns output: 
                Scanning for LUNs on adapter 0.0.1a0d#012#011
                    at port 0x5005076306035388:#012#011
                    at port 0x5005076306105388:#012#011
                    at port 0x500507680b21bac6:#012#011#011
                        Unable to send the REPORT_LUNS command to LUN.#012#011
                    at port 0x500507680b21bac7:#012#011#011
                        Unable to send the REPORT_LUNS command to LUN.#012#011
                    at port 0x500507680b22bac6:#012#011#011
                        Unable to send the REPORT_LUNS command to LUN.#012#011
                    at port 0x500507680b22bac7:#012#011#011
                        Unable to send the REPORT_LUNS command to LUN.#012#011
                    at port 0x500507680d060027:#012#011#011
                        Unable to send the REPORT_LUNS command to LUN.#012#011
                    at port 0x500507680d120027:#012#011#011
                        Unable to send the REPORT_LUNS command to LUN.#012#011
                    at port 0x500507680d760027:#012#011#011
                        Unable to send the REPORT_LUNS command to LUN.#012#011
                    at port 0x500507680d820027:#012#011#011
                        Unable to send the REPORT_LUNS command to LUN.#012
                Scanning for LUNs on adapter 0.0.1a0e#012#011
                    at port 0x5005076306035388:#012#011
                    at port 0x5005076306105388:#012#011
                    at port 0x500507680b21bac6:#012#011#011
                        0x0000000000000000#012#011
                    at port 0x500507680b21bac7:#012#011#011
                        0x0000000000000000#012#011
                    at port 0x500507680b22bac6:#012#011#011
                        0x000000
printLogs: /dev/disk/by-path/ folder content: 
                ccw-0.0.0100#012
                ccw-0.0.0100-part1#012
                ccw-0.0.1a0d-fc-0x5005076306035388-lun-0#012
                ccw-0.0.1a0d-fc-0x5005076306105388-lun-0#012
                ccw-0.0.1a0d-zfcp-0x5005076306035388:0x0000000000000000#012
                ccw-0.0.1a0d-zfcp-0x5005076306105388:0x0000000000000000#012
                ccw-0.0.1a0e-fc-0x500507680b21bac6-lun-0#012
                ccw-0.0.1a0e-fc-0x500507680b21bac7-lun-0#012
                ccw-0.0.1a0e-fc-0x500507680b22bac6-lun-0#012
                ccw-0.0.1a0e-fc-0x500507680b22bac7-lun-0#012
                ccw-0.0.1a0e-zfcp-0x500507680b21bac6:0x0000000000000000#012
                ccw-0.0.1a0e-zfcp-0x500507680b21bac7:0x0000000000000000#012
                ccw-0.0.1a0e-zfcp-0x500507680b22bac6:0x0000000000000000#012
                ccw-0.0.1a0e-zfcp-0x500507680b22bac7:0x0000000000000000#012
                ccw-0.0.1b0d-fc-0x5005076306035388-lun-0#012
                ccw-0.0.1b0d-fc-0x5005076306105388-lun-0#012
                ccw-0.0.1b0d-zfcp-0x5005076306035388:0x0000000000000000#012
                ccw-0.0.1b0d-zfcp-0x5005076306105388:0x0000000000000000#012
                ccw-0.0.1b0e-fc-0x500507680b21bac6-lun-0#012
                ccw-0.0.1b0e-fc-0x500507680b21bac7-lun-0#012
                ccw-0.0.1b0e-fc-0x500507680b21bac7-lun-0-part
printLogs: /dev/disk/by-id/ folder content: 
                dm-name-mpathi#012dm-name-mpathi1#012
                dm-uuid-mpath-3600507640083826de00000000000219d#012
                scsi-36005076306ffd3880000000000001521#012
                scsi-36005076306ffd388000000000000ffff#012
                scsi-3600507640083826de00000000000219d#012
                scsi-3600507640083826de00000000000219d-part1#012
                scsi-SIBM_2107900_75CPV511521#012
                scsi-SIBM_2145_010020e09b78XX00#012
                scsi-SIBM_2145_010020e09b78XX00-part1#012
                wwn-0x6005076306ffd388000000000000ffff#012
                wwn-0x600507640083826de00000000000219d#012
                wwn-0x600507640083826de00000000000219d-part1.
printLogs: multipath output: 
                mpathi (3600507640083826de00000000000219d) dm-0 IBM,2145#012size=10G features='1 queue_if_no_path' hwhandler='1 alua' wp=rw#012
                |-+- policy='service-time 0' prio=50 status=enabled#012
                | |- 2:0:1:0 sde 8:64 active ready running#012
                | |- 2:0:5:0 sdf 8:80 active ready running#012
                | |- 3:0:0:0 sdi 8:128 active ready running#012
                | `- 3:0:5:0 sdk 8:160 active ready running#012
                `-+- policy='service-time 0' prio=10 status=enabled#012
                |- 2:0:7:0 sdh 8:112 active ready running#012
                |- 2:0:6:0 sdg 8:96 active ready running#012
                |- 3:0:4:0 sdj 8:144 active ready running#012
                `- 3:0:7:0 sdl 8:176 active ready running.
                
cleanup_fcpdevices: Begin to disconnect FCPs
cleanup_fcpdevices: Disconnect FCP device: 1b0e
disconnectFcp: Trying to offline the FCP: 1b0e.
chccwdevDevice: set device 1b0e offline successfully.
disconnectFcp: Successfully set FCP: 1b0e to offline.
disconnectFcp: Successfully detach FCP 1b0e from userid IAAS010B.
cleanup_fcpdevices: Disconnect FCP device: 1b0e
disconnectFcp: Trying to offline the FCP: 1b0e.
chccwdevDevice: Attempt to set device 1b0e offline: device 1b0e not found.
disconnectFcp: FCP device 1b0e has already detached.
cleanup_fcpdevices: Disconnect FCP device: 1b0e
disconnectFcp: Trying to offline the FCP: 1b0e.
chccwdevDevice: Attempt to set device 1b0e offline: device 1b0e not found.
disconnectFcp: FCP device 1b0e has already detached.
cleanup_fcpdevices: Disconnect FCP device: 1b0e
disconnectFcp: Trying to offline the FCP: 1b0e.
chccwdevDevice: Attempt to set device 1b0e offline: device 1b0e not found.
disconnectFcp: FCP device 1b0e has already detached.
cleanup_fcpdevices: Disconnect FCP device: 1a0e
disconnectFcp: Trying to offline the FCP: 1a0e.
chccwdevDevice: set device 1a0e offline successfully.
disconnectFcp: Successfully set FCP: 1a0e to offline.
disconnectFcp: Successfully detach FCP 1a0e from userid IAAS010B.
cleanup_fcpdevices: Disconnect FCP device: 1a0e
disconnectFcp: Trying to offline the FCP: 1a0e.
chccwdevDevice: Attempt to set device 1a0e offline: device 1a0e not found.
disconnectFcp: FCP device 1a0e has already detached.
cleanup_fcpdevices: Disconnect FCP device: 1a0e
disconnectFcp: Trying to offline the FCP: 1a0e.
chccwdevDevice: Attempt to set device 1a0e offline: device 1a0e not found.
disconnectFcp: FCP device 1a0e has already detached.
cleanup_fcpdevices: Disconnect FCP device: 1a0e
disconnectFcp: Trying to offline the FCP: 1a0e.
chccwdevDevice: Attempt to set device 1a0e offline: device 1a0e not found.
disconnectFcp: FCP device 1a0e has already detached.
cleanup_fcpdevices: Finish disconnecting FCPs.
cleanup_fcpdevices: Begin to refresh multipath bindings.
cleanup_fcpdevices: Cleaning up multipath bindings and wwids.
cleanup_fcpdevices: Finish refreshing multipath bindings.
```

#### case3: 
```shell
1. upload qcow2 image with wrong format on purpose
   --------
                                            _ 'wrong format' -> should be 'qcow2'
                                           |
    openstack image create --disk-format=dasd --file=RHEL78GA_vol_wrong_dasd.qcow2 wrong_dasd 
   ----------
2. deploy BFV VM 
    -> trigger retry
    -> retry attempts exhausted 
    -> printLog
    -> refresh_bootmap aborted 

key related log of /var/log/messages:


refreshZIPL: Begin to refreshZIPL.
refreshZIPL: devNode file /dev/disk/by-id/dm-uuid-part1-mpath-3600507640083826de0000000000021a3 not exist yet. Retrying...
refreshZIPL: Retrying with interval as .001 seconds
refreshZIPL: Retrying with interval as .01 seconds
refreshZIPL: Retrying with interval as .1 seconds
refreshZIPL: Retrying with interval as .5 seconds
refreshZIPL: Retrying with interval as 1 seconds
refreshZIPL: Retrying with interval as 2 seconds
refreshZIPL: Retrying with interval as 3 seconds
refreshZIPL: Retrying with interval as 5 seconds
refreshZIPL: Retrying with interval as 8 seconds
refreshZIPL: Retrying with interval as 15 seconds
refreshZIPL: Retrying with interval as 22 seconds
refreshZIPL: Retrying with interval as 34 seconds
refreshZIPL: Retrying with interval as 60 seconds
refreshZIPL: Retrying with interval as 90 seconds
refreshZIPL: Retrying with interval as 120 seconds
refreshZIPL: devNode /dev/disk/by-id/dm-uuid-part1-mpath-3600507640083826de0000000000021a3 does not exist. Get fcps: 1b0e 1a0e and wwpns: 500507680b21bac6 500507680b21bac7 500507680b22bac6 500507680b22bac7 500507680b21bac7 500507680b22bac6 500507680b22bac7
printLogs: lszfcp output: 0.0.1a0d host1#0120.0.1a0e host3#0120.0.1b0d host0#0120.0.1b0e host2#0120.0.1a0d/0x5005076306035388/0x0000000000000000 1:0:4:0#0120.0.1a0d/0x5005076306105388/0x0000000000000000 1:0:5:0#0120.0.1a0e/0x500507680b22bac6/0x0000000000000000 3:0:1:0#0120.0.1a0e/0x500507680b21bac6/0x0000000000000000 3:0:3:0#0120.0.1a0e/0x500507680b21bac7/0x0000000000000000 3:0:4:0#0120.0.1a0e/0x500507680b22bac7/0x0000000000000000 3:0:8:0#0120.0.1b0d/0x5005076306035388/0x0000000000000000 0:0:0:0#0120.0.1b0d/0x5005076306105388/0x0000000000000000 0:0:1:0#0120.0.1b0e/0x500507680b22bac6/0x0000000000000000 2:0:0:0#0120.0.1b0e/0x500507680b21bac6/0x0000000000000000 2:0:1:0#0120.0.1b0e/0x500507680b22bac7/0x0000000000000000 2:0:6:0#0120.0.1b0e/0x500507680b21bac7/0x0000000000000000 2:0:7:0.
printLogs: lsluns output: Scanning for LUNs on adapter 0.0.1a0d#012#011at port 0x5005076306035388:#012#011at port 0x5005076306105388:#012#011at port 0x500507680b21bac6:#012#011#011Unable to send the REPORT_LUNS command to LUN.#012#011at port 0x500507680b21bac7:#012#011#011Unable to send the REPORT_LUNS command to LUN.#012#011at port 0x500507680b22bac6:#012#011#011Unable to send the REPORT_LUNS command to LUN.#012#011at port 0x500507680b22bac7:#012#011#011Unable to send the REPORT_LUNS command to LUN.#012#011at port 0x500507680d060027:#012#011#011Unable to send the REPORT_LUNS command to LUN.#012#011at port 0x500507680d120027:#012#011#011Unable to send the REPORT_LUNS command to LUN.#012#011at port 0x500507680d760027:#012#011#011Unable to send the REPORT_LUNS command to LUN.#012#011at port 0x500507680d820027:#012#011#011Unable to send the REPORT_LUNS command to LUN.#012Scanning for LUNs on adapter 0.0.1a0e#012#011at port 0x5005076306035388:#012#011at port 0x5005076306105388:#012#011at port 0x500507680b21bac6:#012#011#0110x0000000000000000#012#011at port 0x500507680b21bac7:#012#011#0110x0000000000000000#012#011at port 0x500507680b22bac6:#012#011#0110x000000
printLogs: /dev/disk/by-path/ folder content: ccw-0.0.0100#012ccw-0.0.0100-part1#012ccw-0.0.1a0d-fc-0x5005076306035388-lun-0#012ccw-0.0.1a0d-fc-0x5005076306105388-lun-0#012ccw-0.0.1a0d-zfcp-0x5005076306035388:0x0000000000000000#012ccw-0.0.1a0d-zfcp-0x5005076306105388:0x0000000000000000#012ccw-0.0.1a0e-fc-0x500507680b21bac6-lun-0#012ccw-0.0.1a0e-fc-0x500507680b21bac7-lun-0#012ccw-0.0.1a0e-fc-0x500507680b22bac6-lun-0#012ccw-0.0.1a0e-fc-0x500507680b22bac7-lun-0#012ccw-0.0.1a0e-zfcp-0x500507680b21bac6:0x0000000000000000#012ccw-0.0.1a0e-zfcp-0x500507680b21bac7:0x0000000000000000#012ccw-0.0.1a0e-zfcp-0x500507680b22bac6:0x0000000000000000#012ccw-0.0.1a0e-zfcp-0x500507680b22bac7:0x0000000000000000#012ccw-0.0.1b0d-fc-0x5005076306035388-lun-0#012ccw-0.0.1b0d-fc-0x5005076306105388-lun-0#012ccw-0.0.1b0d-zfcp-0x5005076306035388:0x0000000000000000#012ccw-0.0.1b0d-zfcp-0x5005076306105388:0x0000000000000000#012ccw-0.0.1b0e-fc-0x500507680b21bac6-lun-0#012ccw-0.0.1b0e-fc-0x500507680b21bac7-lun-0#012ccw-0.0.1b0e-fc-0x500507680b22bac6-lun-0#012ccw-
printLogs: /dev/disk/by-id/ folder content: dm-name-mpathi#012dm-uuid-mpath-3600507640083826de0000000000021a3#012scsi-36005076306ffd3880000000000001521#012scsi-36005076306ffd388000000000000ffff#012scsi-3600507640083826de0000000000021a3#012scsi-SIBM_2107900_75CPV511521#012scsi-SIBM_2145_010020e09b78XX00#012wwn-0x6005076306ffd388000000000000ffff#012wwn-0x600507640083826de0000000000021a3.
printLogs: multipath output: mpathi (3600507640083826de0000000000021a3) dm-0 IBM,2145#012size=10G features='1 queue_if_no_path' hwhandler='1 alua' wp=rw#012|-+- policy='service-time 0' prio=50 status=active#012| |- 2:0:0:0 sde 8:64 active ready running#012| |- 3:0:1:0 sdf 8:80 active ready running#012| |- 2:0:1:0 sdg 8:96 active ready running#012| `- 3:0:3:0 sdj 8:144 active ready running#012`-+- policy='service-time 0' prio=10 status=enabled#012  |- 2:0:6:0 sdh 8:112 active ready running#012  |- 2:0:7:0 sdi 8:128 active ready running#012  |- 3:0:4:0 sdk 8:160 active ready running#012  - 3:0:8:0 sdl 8:176 active ready running.
cleanup_fcpdevices: Begin to disconnect FCPs
cleanup_fcpdevices: Disconnect FCP device: 1b0e
disconnectFcp: Trying to offline the FCP: 1b0e.
chccwdevDevice: set device 1b0e offline successfully.
disconnectFcp: Successfully set FCP: 1b0e to offline.
disconnectFcp: Successfully detach FCP 1b0e from userid IAAS010B.
cleanup_fcpdevices: Disconnect FCP device: 1b0e
disconnectFcp: Trying to offline the FCP: 1b0e.
chccwdevDevice: Attempt to set device 1b0e offline: device 1b0e not found.
disconnectFcp: FCP device 1b0e has already detached.
cleanup_fcpdevices: Disconnect FCP device: 1b0e
disconnectFcp: Trying to offline the FCP: 1b0e.
chccwdevDevice: Attempt to set device 1b0e offline: device 1b0e not found.
disconnectFcp: FCP device 1b0e has already detached.
cleanup_fcpdevices: Disconnect FCP device: 1b0e
disconnectFcp: Trying to offline the FCP: 1b0e.
chccwdevDevice: Attempt to set device 1b0e offline: device 1b0e not found.
disconnectFcp: FCP device 1b0e has already detached.
cleanup_fcpdevices: Disconnect FCP device: 1a0e
disconnectFcp: Trying to offline the FCP: 1a0e.
chccwdevDevice: set device 1a0e offline successfully.
disconnectFcp: Successfully set FCP: 1a0e to offline.
disconnectFcp: Successfully detach FCP 1a0e from userid IAAS010B.
cleanup_fcpdevices: Disconnect FCP device: 1a0e
disconnectFcp: Trying to offline the FCP: 1a0e.
chccwdevDevice: Attempt to set device 1a0e offline: device 1a0e not found.
disconnectFcp: FCP device 1a0e has already detached.
cleanup_fcpdevices: Disconnect FCP device: 1a0e
disconnectFcp: Trying to offline the FCP: 1a0e.
chccwdevDevice: Attempt to set device 1a0e offline: device 1a0e not found.
disconnectFcp: FCP device 1a0e has already detached.
cleanup_fcpdevices: Disconnect FCP device: 1a0e
disconnectFcp: Trying to offline the FCP: 1a0e.
chccwdevDevice: Attempt to set device 1a0e offline: device 1a0e not found.
disconnectFcp: FCP device 1a0e has already detached.
cleanup_fcpdevices: Finish disconnecting FCPs.
cleanup_fcpdevices: Begin to refresh multipath bindings.
cleanup_fcpdevices: Cleaning up multipath bindings and wwids.
cleanup_fcpdevices: Finish refreshing multipath bindings.
```