### PR TITLE
[master]Ignore the exit code of multipath -f command to continue clean up the leftover of data volume.

### DIFF
--- a/zvmsdk/volumeops/templates/rhel7_detach_volume.j2
+++ b/zvmsdk/volumeops/templates/rhel7_detach_volume.j2
@@ -45,9 +45,9 @@ fi
 
 echo "exit code for multipath -f: $exit_code"
 # if above code didn't succeed, exit now.
-if [[ $exit_code != 0 ]]; then
-    exit $exit_code
-fi
+#if [[ $exit_code != 0 ]]; then
+#    exit $exit_code
+#fi
 
 
 # flush IO for devices

--- a/zvmsdk/volumeops/templates/rhel8_detach_volume.j2
+++ b/zvmsdk/volumeops/templates/rhel8_detach_volume.j2
@@ -45,9 +45,9 @@ fi
 
 echo "exit code for multipath -f: $exit_code"
 # if above code didn't succeed, exit now.
-if [[ $exit_code != 0 ]]; then
-    exit $exit_code
-fi
+#if [[ $exit_code != 0 ]]; then
+#    exit $exit_code
+#fi
 
 # flush IO for devices
 RealPath=`readlink -f /dev/disk/by-path/$SourceDevice`


### PR DESCRIPTION
No matter the data volume attached is in use or not, will clean up the leftover of data volume to be detached.

Signed-off-by: wgxoyun <wgxoyun@cn.ibm.com>