### PR TITLE
[master]Write "COMMAND DEF STOR RESERVED 0M" in user direct when creating vm

### DIFF
--- a/smtLayer/makeVM.py
+++ b/smtLayer/makeVM.py
@@ -132,14 +132,19 @@ def createVM(rh):
 
     priMem = rh.parms['priMemSize'].upper()
     maxMem = rh.parms['maxMemSize'].upper()
-    if 'setReservedMem' in rh.parms and (priMem != maxMem):
+    if 'setReservedMem' in rh.parms:
         reservedSize = getReservedMemSize(rh, priMem, maxMem)
         if rh.results['overallRC'] != 0:
             rh.printSysLog("Exit makeVM.createVM, rc: " +
                    str(rh.results['overallRC']))
             return rh.results['overallRC']
-        if reservedSize != '0M':
-            dirLines.append("COMMAND DEF STOR RESERVED %s" % reservedSize)
+        # Even reservedSize is 0M, still write the line "COMMAND DEF
+        # STOR RESERVED 0M" in direct entry, in case cold resize of
+        # memory decreases the defined memory, then reserved memory
+        # size would be > 0, this line in direct entry need be updated.
+        # If no such line defined in user direct, resizing would report
+        # error due to it can't get the original reserved memory value.
+        dirLines.append("COMMAND DEF STOR RESERVED %s" % reservedSize)
 
     if 'loadportname' in rh.parms:
         wwpn = rh.parms['loadportname'].replace("0x", "")

--- a/smtLayer/tests/unit/test_makeVM.py
+++ b/smtLayer/tests/unit/test_makeVM.py
@@ -93,3 +93,37 @@ class SMTMakeVMTestCase(base.SMTTestCase):
         makeVM.createVM(rh)
         write.assert_called_with(mock.ANY, b'USER  pwd 1G 1G G\nCPU 00 BASE\n'
                                     b'MDISK 0102 FB-512 V-DISK 524288 MWV\n')
+
+    @mock.patch("os.write")
+    def test_create_VM_STOR_RESERVED_positive(self, write):
+        rh = ReqHandle.ReqHandle(captureLogs=False,
+                                 smt=mock.Mock())
+        parms = {'pw': 'pwd', 'priMemSize': '1G', 'maxMemSize': '4G',
+                 'privClasses': 'G', 'setReservedMem': ''}
+        rh.parms = parms
+        makeVM.createVM(rh)
+        write.assert_called_with(mock.ANY, b'USER  pwd 1G 4G G\nCPU 00 BASE\n'
+                                    b'COMMAND DEF STOR RESERVED 3072M\n')
+
+    @mock.patch("os.write")
+    def test_create_VM_STOR_RESERVED_0M(self, write):
+        rh = ReqHandle.ReqHandle(captureLogs=False,
+                                 smt=mock.Mock())
+        parms = {'pw': 'pwd', 'priMemSize': '1G', 'maxMemSize': '1G',
+                 'privClasses': 'G', 'setReservedMem': ''}
+        rh.parms = parms
+        makeVM.createVM(rh)
+        write.assert_called_with(mock.ANY, b'USER  pwd 1G 1G G\nCPU 00 BASE\n'
+                                    b'COMMAND DEF STOR RESERVED 0M\n')
+
+    @mock.patch("os.write")
+    def test_create_VM_STOR_RESERVED_0M_diff_unit(self, write):
+        rh = ReqHandle.ReqHandle(captureLogs=False,
+                                 smt=mock.Mock())
+        parms = {'pw': 'pwd', 'priMemSize': '1024M', 'maxMemSize': '1G',
+                 'privClasses': 'G', 'setReservedMem': ''}
+        rh.parms = parms
+        makeVM.createVM(rh)
+        write.assert_called_with(mock.ANY, b'USER  pwd 1024M 1G G\n'
+                                    b'CPU 00 BASE\n'
+                                    b'COMMAND DEF STOR RESERVED 0M\n')

--- a/zvmsdk/tests/unit/sdkclientcases/test_restclient.py
+++ b/zvmsdk/tests/unit/sdkclientcases/test_restclient.py
@@ -498,8 +498,8 @@ class RESTClientTestCase(unittest.TestCase):
         url = '/guests/%s/nic/%s' % (self.fake_userid, '123')
         body = {'info': {'couple': True,
                          'vswitch': 'vswitch1',
-                         'active': False,
-                         'vlan_id': 1234}}
+                         'vlan_id': 1234,
+                         'active': False}}
         body = json.dumps(body)
         header = self.headers
         full_uri = self.base_url + url
@@ -507,7 +507,7 @@ class RESTClientTestCase(unittest.TestCase):
         get_token.return_value = self._tmp_token()
 
         self.client.call("guest_nic_couple_to_vswitch", self.fake_userid,
-                         '123', 'vswitch1', active=False, vlan_id=1234)
+                         '123', 'vswitch1', vlan_id=1234, active=False)
         request.assert_called_with(method, full_uri,
                                    data=body, headers=header,
                                    verify=False)


### PR DESCRIPTION
Currently when creating a VM, when defined memory size equals
max memory size, then reserved memory size is cacluted as 0,
then even setReservedMem is specified, there is not a line"
"COMMAND DEF STOR RESERVED xxx" written into user direct entry.

It causes a problem that when users try to do cold resize to
decrease VM's memory size, then the new defined memory size
< max memory size, reserved memory size > 0. Then a new line
"COMMAND DEF STOR RESERVED xxx" need be added into user direct
entry. Besides, current memory resize implementation would try
to fetch the original reserved memory value from user direct,
if none obtained, resizing reports error.

So to support cold resize working correctly and make things easier,
we write COMMAND DEF STOR RESERVED 0M" in user direct when its
defined memory size equals to max memory size during creating VM.

Signed-off-by: Shu Juan Zhang <zshujuan@cn.ibm.com>