### PR TITLE
detect mpath befor flush the mpath

### DIFF
--- a/zthin-parts/zthin/bin/unpackdiskimage
+++ b/zthin-parts/zthin/bin/unpackdiskimage
@@ -1333,6 +1333,9 @@ function cleanup {
     if [[ $multipath_enabled == 1 ]]; then
       fcp_disk_path=/dev/disk/by-path/ccw-0.0.${fcpChannel}-zfcp-${wwpn}:${lun}
       wwid=`/usr/lib/udev/scsi_id --whitelisted ${fcp_disk_path} 2> /dev/null`
+
+      # discover mpath before flush
+      multipath
       map_name=$(multipath -l $wwid -v 1)
 
       inform "Cleaning up multipath bindings and wwids: ${map_name} ${wwid}"


### PR DESCRIPTION
The change is for RHCOS boot from volume. In cleanup, sometimes
can not get mpath map name. Add a "multipath" before the
"multipath -f" to make sure the mapth discovered.

Signed-off-by: bjhuangr <bjhuangr@cn.ibm.com>