### PR TITLE
[master]Add new config item: user_default_max_reserved_memory

### DIFF
--- a/doc/source/errcode.csv
+++ b/doc/source/errcode.csv
@@ -118,8 +118,9 @@
 4;1;4;202;ULTGUT0202E NUM_BLOCKS is not an integer size of blocks.
 4;1;4;203;ULTGUT0203E Failed to convert DISK_SIZE to a number of cylinders.
 4;1;4;204;ULTGUT0204E DISK_SIZE is not an integer size of cylinders.
-4;1;4;205;ULTMVM0204E memory size did not end with suffix 'G' or 'M'.
-4;1;4;206;ULTMVM0204E Max memory size MAX_MEM_SIZE specified is less than initial memory size INIT_MEM_SIZE.
+4;1;4;205;ULTMVM0205E memory size did not end with suffix 'G' or 'M'.
+4;1;4;206;ULTMVM0206E Max memory size MAX_MEM_SIZE specified is less than initial memory size INIT_MEM_SIZE.
+4;1;4;207;ULTMVM0207E VDISK Size (swap disk) is greater than 2G.
 4;1;4;400;ULTGUT0400E The worker script SCRIPT_NAME does not exist.
 4;1;7;401;ULTGUT0401E Failed to punch FILE_LOCATION file to guest: USERID, out: OUTPUT
 4;1;5;402;ULTGUT0402E No information was found for the specified pool(s): DISK_POOL

--- a/doc/source/zvmsdk.conf.sample
+++ b/doc/source/zvmsdk.conf.sample
@@ -418,18 +418,32 @@
 #user_default_max_cpu=32
 
 
-# 
+#
 # The default maximum size of memory the user can define.
 # This value is used as the default value for maximum memory size when
 # create a guest with no max_mem specified.
 # The value can be specified by 1-4 bits of number suffixed by either
 # M (Megabytes) or G (Gigabytes) and the number must be a whole number,
 # values such as 4096.8M or 32.5G are not supported.
-# 
+#
 # The value should be adjusted based on your system capacity.
-# 
+#
 # This param is optional
-#user_default_max_memory=64G
+#user_default_max_memory=128G
+
+
+#
+# The default maximum size of reserved memory in a vm's direct entry.
+# This value is used as the default value for maximum reserved memory
+# size for a guest.
+# The value can be specified by 1-4 bits of number suffixed by either
+# M (Megabytes) or G (Gigabytes) and the number must be a whole number,
+# values such as 4096.8M or 32.5G are not supported.
+#
+# The value should be adjusted based on your system capacity.
+#
+# This param is optional
+#user_default_max_reserved_memory=128G
 
 
 # This param is optional

--- a/smtLayer/makeVM.py
+++ b/smtLayer/makeVM.py
@@ -21,10 +21,12 @@ from smtLayer import generalUtils
 from smtLayer import msgs
 from smtLayer.vmUtils import invokeSMCLI
 
+from zvmsdk import config
+from zvmsdk import utils as zvmutils
+
 modId = 'MVM'
 version = "1.0.0"
-# make maximum reserved memory value as 248G, 253952M
-MAX_STOR_RESERVED = 253952
+
 # max vidks blocks can't exceed 4194296
 MAX_VDISK_BLOCKS = 4194296
 
@@ -483,7 +485,9 @@ def getReservedMemSize(rh, mem, maxMem):
     # then convert to Gb.
     gapSize = maxMemMb - memMb
 
-    # make max reserved memory value as 248G
+    # get make max reserved memory value
+    MAX_STOR_RESERVED = int(zvmutils.convert_to_mb(
+                        config.CONF.zvm.user_default_max_reserved_memory))
     if gapSize > MAX_STOR_RESERVED:
         gapSize = MAX_STOR_RESERVED
 

--- a/smtLayer/tests/unit/test_makeVM.py
+++ b/smtLayer/tests/unit/test_makeVM.py
@@ -53,23 +53,24 @@ class SMTMakeVMTestCase(base.SMTTestCase):
         self.assertEqual(gap, '0M')
         self.assertEqual(rh.results['overallRC'], 0)
 
+    # default maximum reserved memory is 128G=131072M
     def test_getReservedMemSize_max_reserved(self):
         rh = ReqHandle.ReqHandle(captureLogs=False,
                                  smt=mock.Mock())
         gap = makeVM.getReservedMemSize(rh, '512m', '256G')
-        self.assertEqual(gap, '253952M')
+        self.assertEqual(gap, '131072M')
         self.assertEqual(rh.results['overallRC'], 0)
 
-    # As maxmimum reserved memory is 248G=253952M,
+    # As default maximum reserved memory is 128G,
     # which can't exceed 9999999M, so this case will
-    # return 253952M. If future the 248G limit is not
-    # there, recover this case.
+    # return 131072M. If future the maximum reserved
+    # memory limit is not there, recover this case.
     def test_getReservedMemSize_gap_G(self):
         rh = ReqHandle.ReqHandle(captureLogs=False,
                                  smt=mock.Mock())
         gap = makeVM.getReservedMemSize(rh, '512m', '9999G')
         # self.assertEqual(gap, '9998G')
-        self.assertEqual(gap, '253952M')
+        self.assertEqual(gap, '131072M')
         self.assertEqual(rh.results['overallRC'], 0)
 
     @mock.patch("os.write")

--- a/zvmsdk/config.py
+++ b/zvmsdk/config.py
@@ -188,11 +188,24 @@ The number must be a decimal value between 1 and 64.
 '''),
     Opt('user_default_max_memory',
         section='zvm',
-        default='64G',
+        default='128G',
         help='''
 The default maximum size of memory the user can define.
 This value is used as the default value for maximum memory size when
 create a guest with no max_mem specified.
+The value can be specified by 1-4 bits of number suffixed by either
+M (Megabytes) or G (Gigabytes) and the number must be a whole number,
+values such as 4096.8M or 32.5G are not supported.
+
+The value should be adjusted based on your system capacity.
+'''),
+    Opt('user_default_max_reserved_memory',
+        section='zvm',
+        default='128G',
+        help='''
+The default maximum size of reserved memory in a vm's direct entry.
+This value is used as the default value for maximum reserved memory
+size for a guest.
 The value can be specified by 1-4 bits of number suffixed by either
 M (Megabytes) or G (Gigabytes) and the number must be a whole number,
 values such as 4096.8M or 32.5G are not supported.
@@ -633,6 +646,10 @@ class ConfigOpts(object):
                 if (k2 == "user_default_max_memory") and (
                     v2['default'] is not None):
                     self._check_user_default_max_memory(v2['default'])
+                # check user_default_max_reserved_memory
+                if (k2 == "user_default_max_reserved_memory") and (
+                    v2['default'] is not None):
+                    self._check_user_default_max_reserved_memory(v2['default'])
                 # check user_default_max_cpu
                 if (k2 == "user_default_max_cpu") and (
                     v2['default'] is not None):
@@ -650,6 +667,14 @@ class ConfigOpts(object):
         if (suffix not in ['G', 'M']) or (len(size) > 4) or (
             size.strip('0123456789') != ''):
             raise OptFormatError("zvm", "user_default_max_memory", value)
+
+    def _check_user_default_max_reserved_memory(self, value):
+        suffix = value[-1].upper()
+        size = value[:-1]
+        if (suffix not in ['G', 'M']) or (len(size) > 4) or (
+            size.strip('0123456789') != ''):
+            raise OptFormatError("zvm", "user_default_max_reserved_memory",
+                                  value)
 
     def _check_user_default_max_cpu(self, value):
         if (value < 1) or (value > 64):

--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -51,8 +51,6 @@ LOG = log.LOG
 
 _LOCK = threading.Lock()
 CHUNKSIZE = 4096
-# make maximum reserved memory value as 248G, 253952M
-MAX_STOR_RESERVED = 253952
 
 _SMT_CLIENT = None
 
@@ -3692,9 +3690,12 @@ class SMTClient(object):
             action = 1
             # get the new reserved memory size
             new_reserved = max_mem - size
+            # get maximum reserved memory value
+            MAX_STOR_RESERVED = int(zvmutils.convert_to_mb(
+                        CONF.zvm.user_default_max_reserved_memory))
 
-            # when new reserved memory value > 248G, make is as 248G
-            # otherwise RHEL can't start
+            # when new reserved memory value > the MAX_STOR_RESERVED,
+            # make is as the MAX_STOR_RESERVED value
             if new_reserved > MAX_STOR_RESERVED:
                 new_reserved = MAX_STOR_RESERVED
             # prepare the new user entry content
@@ -3808,8 +3809,11 @@ class SMTClient(object):
                                              userid=userid,
                                              active=active_size,
                                              req=size)
+        # get maximum reserved memory value
+        MAX_STOR_RESERVED = int(zvmutils.convert_to_mb(
+                        CONF.zvm.user_default_max_reserved_memory))
         # The maximum increased memory size in one live resizing can't
-        # exceed 248G
+        # exceed MAX_STOR_RESERVED
         increase_size = size - active_size
         if increase_size > MAX_STOR_RESERVED:
             LOG.error("Live memory resize for guest '%s' cann't be done. "

--- a/zvmsdk/tests/unit/test_api.py
+++ b/zvmsdk/tests/unit/test_api.py
@@ -138,7 +138,7 @@ class SDKAPITestCase(base.SDKTestCase):
         self.api.guest_create(self.userid, vcpus, memory, disk_list,
                               user_profile)
         create_vm.assert_called_once_with(self.userid, vcpus, memory,
-                                          disk_list, user_profile, 32, '64G',
+                                          disk_list, user_profile, 32, '128G',
                                           '', '', '', [], {})
 
     @mock.patch("zvmsdk.vmops.VMOps.create_vm")
@@ -183,7 +183,7 @@ class SDKAPITestCase(base.SDKTestCase):
         self.api.guest_create(self.userid, vcpus, memory, disk_list,
                               user_profile)
         create_vm.assert_called_once_with(self.userid, vcpus, memory,
-                                          disk_list, user_profile, 32, '64G',
+                                          disk_list, user_profile, 32, '128G',
                                           '', '', '', [], {})
 
     @mock.patch("zvmsdk.imageops.ImageOps.image_query")

--- a/zvmsdk/tests/unit/test_config.py
+++ b/zvmsdk/tests/unit/test_config.py
@@ -52,6 +52,25 @@ class ZVMConfigTestCases(base.SDKTestCase):
         self.assertRaises(config.OptFormatError,
                           CONFOPTS._check_user_default_max_memory, '12345M')
 
+    def test_check_user_default_max_reserved_memory(self):
+        CONFOPTS._check_user_default_max_reserved_memory('30G')
+        CONFOPTS._check_user_default_max_reserved_memory('1234M')
+
+    def test_check_user_default_max_reserved_err1(self):
+        self.assertRaises(config.OptFormatError,
+                          CONFOPTS._check_user_default_max_reserved_memory,
+                          '12.0G')
+
+    def test_check_user_default_max_reserved_memory_err2(self):
+        self.assertRaises(config.OptFormatError,
+                          CONFOPTS._check_user_default_max_reserved_memory,
+                          '12')
+
+    def test_check_user_default_max_reserved_memory_err3(self):
+        self.assertRaises(config.OptFormatError,
+                          CONFOPTS._check_user_default_max_reserved_memory,
+                          '12345M')
+
     def test_check_user_default_max_cpu(self):
         CONFOPTS._check_user_default_max_cpu(1)
 

--- a/zvmsdk/tests/unit/test_smtclient.py
+++ b/zvmsdk/tests/unit/test_smtclient.py
@@ -3484,18 +3484,80 @@ class SDKSMTClientTestCases(base.SDKTestCase):
     @mock.patch.object(smtclient.SMTClient, '_get_defined_memory')
     @mock.patch.object(smtclient.SMTClient, '_lock_user_direct')
     @mock.patch.object(smtclient.SMTClient, '_replace_user_direct')
-    def test_resize_memory_max_stor_reserved(self, replace_def,
-                                             lock_def, get_def):
+    def test_resize_memory_conf_max_stor_reserved_in_G(self,
+                                            replace_def,
+                                            lock_def, get_def):
         userid = 'testuid'
-        size = '4096M'
-        sample_definition = [u'USER TESTUID LBYONLY 1024M 256G G',
+        size = '32768M'
+        base.set_conf('zvm', 'user_default_max_reserved_memory', '64G')
+        sample_definition = [u'USER TESTUID LBYONLY 65536M 128G G',
                              u'INCLUDE OSDFLT',
-                             u'COMMAND DEF STOR RESERVED 253952M',
+                             u'COMMAND DEF STOR RESERVED 65536M',
                              u'CPU 00 BASE',
                              u'IPL 0100',
                              u'MDISK 0100 3390 5501 5500 OMB1BA MR',
                              u'']
-        get_def.return_value = (1024, 262144, 253952, sample_definition)
+        get_def.return_value = (1024, 131072, 65536, sample_definition)
+        (action, defined_mem, max_mem, user_direct) = \
+            self._smtclient.resize_memory(userid, size)
+        self.assertEqual(action, 1)
+        get_def.assert_called_once_with(userid)
+        lock_def.assert_called_once_with(userid)
+        new_entry = ("USER TESTUID LBYONLY 32768M 128G G\n"
+                     "INCLUDE OSDFLT\n"
+                     "COMMAND DEF STOR RESERVED 65536M\n"
+                     "CPU 00 BASE\n"
+                     "IPL 0100\n"
+                     "MDISK 0100 3390 5501 5500 OMB1BA MR\n")
+        replace_def.assert_called_once_with(userid, new_entry)
+
+    @mock.patch.object(smtclient.SMTClient, '_get_defined_memory')
+    @mock.patch.object(smtclient.SMTClient, '_lock_user_direct')
+    @mock.patch.object(smtclient.SMTClient, '_replace_user_direct')
+    def test_resize_memory_conf_max_stor_reserved_in_M(self,
+                                            replace_def,
+                                            lock_def, get_def):
+        userid = 'testuid'
+        size = '32768M'
+        base.set_conf('zvm', 'user_default_max_reserved_memory', '65536M')
+        sample_definition = [u'USER TESTUID LBYONLY 65536M 128G G',
+                             u'INCLUDE OSDFLT',
+                             u'COMMAND DEF STOR RESERVED 65536M',
+                             u'CPU 00 BASE',
+                             u'IPL 0100',
+                             u'MDISK 0100 3390 5501 5500 OMB1BA MR',
+                             u'']
+        get_def.return_value = (1024, 131072, 65536, sample_definition)
+        (action, defined_mem, max_mem, user_direct) = \
+            self._smtclient.resize_memory(userid, size)
+        self.assertEqual(action, 1)
+        get_def.assert_called_once_with(userid)
+        lock_def.assert_called_once_with(userid)
+        new_entry = ("USER TESTUID LBYONLY 32768M 128G G\n"
+                     "INCLUDE OSDFLT\n"
+                     "COMMAND DEF STOR RESERVED 65536M\n"
+                     "CPU 00 BASE\n"
+                     "IPL 0100\n"
+                     "MDISK 0100 3390 5501 5500 OMB1BA MR\n")
+        replace_def.assert_called_once_with(userid, new_entry)
+
+    @mock.patch.object(smtclient.SMTClient, '_get_defined_memory')
+    @mock.patch.object(smtclient.SMTClient, '_lock_user_direct')
+    @mock.patch.object(smtclient.SMTClient, '_replace_user_direct')
+    def test_resize_memory_default_max_stor_reserved(self,
+                                            replace_def,
+                                            lock_def, get_def):
+        userid = 'testuid'
+        size = '4096M'
+        base.set_conf('zvm', 'user_default_max_reserved_memory', '128G')
+        sample_definition = [u'USER TESTUID LBYONLY 1024M 256G G',
+                             u'INCLUDE OSDFLT',
+                             u'COMMAND DEF STOR RESERVED 131072M',
+                             u'CPU 00 BASE',
+                             u'IPL 0100',
+                             u'MDISK 0100 3390 5501 5500 OMB1BA MR',
+                             u'']
+        get_def.return_value = (1024, 262144, 131072, sample_definition)
         (action, defined_mem, max_mem, user_direct) = \
             self._smtclient.resize_memory(userid, size)
         self.assertEqual(action, 1)
@@ -3503,7 +3565,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         lock_def.assert_called_once_with(userid)
         new_entry = ("USER TESTUID LBYONLY 4096M 256G G\n"
                      "INCLUDE OSDFLT\n"
-                     "COMMAND DEF STOR RESERVED 253952M\n"
+                     "COMMAND DEF STOR RESERVED 131072M\n"
                      "CPU 00 BASE\n"
                      "IPL 0100\n"
                      "MDISK 0100 3390 5501 5500 OMB1BA MR\n")


### PR DESCRIPTION
When reserved memory is too large, VM can't boot.
So we introduce a user_default_max_reserved_memory
config item in zvmsdk.conf. It's default value
is 128G, users can also set it by themselves.

Then when vm is created or resized, the reserved
storage value in user direct entry can't be greater
than user_default_max_reserved_memory value.

Default user_default_max_memory value is also
set to 128G.

Signed-off-by: Shu Juan Zhang <zshujuan@cn.ibm.com>