### PR TITLE
[master]Make user_default_max_memory default value as 64G

### DIFF
--- a/doc/source/zvmsdk.conf.sample
+++ b/doc/source/zvmsdk.conf.sample
@@ -396,13 +396,13 @@
 #remotehost_sshd_port=22
 
 
-#
+# 
 # For swap disk to create from mdisk instead of vdisk.
 # In boot from volume case, there might be no disk pool at all, then
 # the only choice is to use vdisk (or using FCP LUN which is complicated),
 # if customer doesn't want vdisk, then set this value to `True` so
 # VDISK will not be used and in turn it will fail check.
-#
+# 
 # This param is optional
 #swap_force_mdisk=False
 
@@ -418,32 +418,32 @@
 #user_default_max_cpu=32
 
 
-#
+# 
 # The default maximum size of memory the user can define.
 # This value is used as the default value for maximum memory size when
 # create a guest with no max_mem specified.
 # The value can be specified by 1-4 bits of number suffixed by either
 # M (Megabytes) or G (Gigabytes) and the number must be a whole number,
 # values such as 4096.8M or 32.5G are not supported.
-#
+# 
 # The value should be adjusted based on your system capacity.
-#
+# 
 # This param is optional
-#user_default_max_memory=128G
+#user_default_max_memory=64G
 
 
-#
+# 
 # The default maximum size of reserved memory in a vm's direct entry.
 # This value is used as the default value for maximum reserved memory
 # size for a guest.
 # The value can be specified by 1-4 bits of number suffixed by either
 # M (Megabytes) or G (Gigabytes) and the number must be a whole number,
 # values such as 4096.8M or 32.5G are not supported.
-#
+# 
 # The value should be adjusted based on your system capacity.
-#
+# 
 # This param is optional
-#user_default_max_reserved_memory=128G
+#user_default_max_reserved_memory=64G
 
 
 # This param is optional

--- a/smtLayer/tests/unit/test_makeVM.py
+++ b/smtLayer/tests/unit/test_makeVM.py
@@ -26,7 +26,7 @@ class SMTMakeVMTestCase(base.SMTTestCase):
         rh = mock.Mock()
         rh.results = {'overallRC': 0, 'rc': 0, 'rs': 0}
         gap = makeVM.getReservedMemSize(rh, '1024M', '128g')
-        self.assertEqual(gap, '130048M')
+        self.assertEqual(gap, '65536M')
 
     def test_getReservedMemSize_invalid_suffix(self):
         rh = ReqHandle.ReqHandle(captureLogs=False,
@@ -58,7 +58,7 @@ class SMTMakeVMTestCase(base.SMTTestCase):
         rh = ReqHandle.ReqHandle(captureLogs=False,
                                  smt=mock.Mock())
         gap = makeVM.getReservedMemSize(rh, '512m', '256G')
-        self.assertEqual(gap, '131072M')
+        self.assertEqual(gap, '65536M')
         self.assertEqual(rh.results['overallRC'], 0)
 
     # As default maximum reserved memory is 128G,
@@ -70,7 +70,7 @@ class SMTMakeVMTestCase(base.SMTTestCase):
                                  smt=mock.Mock())
         gap = makeVM.getReservedMemSize(rh, '512m', '9999G')
         # self.assertEqual(gap, '9998G')
-        self.assertEqual(gap, '131072M')
+        self.assertEqual(gap, '65536M')
         self.assertEqual(rh.results['overallRC'], 0)
 
     @mock.patch("os.write")

--- a/zvmsdk/config.py
+++ b/zvmsdk/config.py
@@ -188,7 +188,7 @@ The number must be a decimal value between 1 and 64.
 '''),
     Opt('user_default_max_memory',
         section='zvm',
-        default='128G',
+        default='64G',
         help='''
 The default maximum size of memory the user can define.
 This value is used as the default value for maximum memory size when
@@ -201,7 +201,7 @@ The value should be adjusted based on your system capacity.
 '''),
     Opt('user_default_max_reserved_memory',
         section='zvm',
-        default='128G',
+        default='64G',
         help='''
 The default maximum size of reserved memory in a vm's direct entry.
 This value is used as the default value for maximum reserved memory

--- a/zvmsdk/tests/unit/test_api.py
+++ b/zvmsdk/tests/unit/test_api.py
@@ -138,7 +138,7 @@ class SDKAPITestCase(base.SDKTestCase):
         self.api.guest_create(self.userid, vcpus, memory, disk_list,
                               user_profile)
         create_vm.assert_called_once_with(self.userid, vcpus, memory,
-                                          disk_list, user_profile, 32, '128G',
+                                          disk_list, user_profile, 32, '64G',
                                           '', '', '', [], {})
 
     @mock.patch("zvmsdk.vmops.VMOps.create_vm")
@@ -183,7 +183,7 @@ class SDKAPITestCase(base.SDKTestCase):
         self.api.guest_create(self.userid, vcpus, memory, disk_list,
                               user_profile)
         create_vm.assert_called_once_with(self.userid, vcpus, memory,
-                                          disk_list, user_profile, 32, '128G',
+                                          disk_list, user_profile, 32, '64G',
                                           '', '', '', [], {})
 
     @mock.patch("zvmsdk.imageops.ImageOps.image_query")


### PR DESCRIPTION
This commit is to make user_default_max_memory
and user_default_max_reserved_memory default value
as 64G.

Signed-off-by: Shu Juan Zhang <zshujuan@cn.ibm.com>