### PR TITLE
don't mount the /run folder for chroot zipl

### DIFF
--- a/zthin-parts/zthin/bin/refresh_bootmap
+++ b/zthin-parts/zthin/bin/refresh_bootmap
@@ -67,7 +67,7 @@ function cleanup_umountdir_and_disconnect_fcp {
   inform "Begin to cleanup umount dir."
   umount $deviceMountPoint/proc > /dev/null
   umount $deviceMountPoint/sys > /dev/null
-  umount $deviceMountPoint/run > /dev/null
+  # umount $deviceMountPoint/run > /dev/null
   umount $deviceMountPoint/dev > /dev/null
   umount $deviceMountPoint > /dev/null
   rm -rf $deviceMountPoint
@@ -413,7 +413,7 @@ function refreshZIPL {
   fi
   mount -t proc /proc $deviceMountPoint/proc
   mount -o bind /sys $deviceMountPoint/sys
-  mount -o bind /run $deviceMountPoint/run
+  # mount -o bind /run $deviceMountPoint/run
   mount -o bind /dev $deviceMountPoint/dev
   rc=$?
   if [[ $rc -ne 0 ]]; then


### PR DESCRIPTION
we have find that the mount of /run folder in a chroot case would
cause the system down, (the /run folder files in the system is lost.)

and I checked several pages related to chroot without the mount of /run folder
and some page explicitly mentioned /run is not recommended to be mounted.

so remove the mount of /run from our code.

Signed-off-by: dyyang <dyyang@cn.ibm.com>