### PR TITLE
Fix the ci failure

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.6]
+        python-version: [ 3.6 ]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Remove the python version 2.7 check test as the CI python 2.7 env cannot run py36 test.

The python version 3.6 check test in github action still can run both py27 and py36 test.
https://github.com/openmainframeproject/feilong/runs/2031436212?check_suite_focus=true
The HTML pages are in doc/build/html.
___________________________________ summary ____________________________________
  pep8: commands succeeded
  py27: commands succeeded
  py36: commands succeeded
  docs: commands succeeded
  congratulations :)
