### PR TITLE
refine refreshbootmap code

### DIFF
--- a/zthin-parts/zthin/bin/refresh_bootmap
+++ b/zthin-parts/zthin/bin/refresh_bootmap
@@ -80,11 +80,10 @@ function cleanup_fcpdevices {
   : SOURCE: ${BASH_SOURCE}
   : STACK:  ${FUNCNAME[@]}
   # @Description:
-  inform "Finish disconnecting FCPs."
   inform "Begin to refresh multipath bindings."
   # Don't need to judge if the multipath_enabled exist,
   # if it doesn't exist, the $multipath_enabled will be None.
-  if [[ $multipath_enabled == 1 ]]; then
+  if [[ ( $multipath_enabled == 1 ) && ( "$wwid" != "" ) ]]; then
     inform "Cleaning up multipath bindings and wwids."
     multipath_output=$(multipath -ll 2>&1)
     inform "multipath output: ${multipath_output}."
@@ -166,27 +165,35 @@ function cleanup_fcpdevices {
     inform "multipath output: ${multipath_output}."
   fi
   inform "Finish refreshing multipath bindings."
+
   # Disconnect all FCPs
-  inform "Begin to disconnect FCPs"
-  for i in "${!fcps[@]}"
+  inform "Begin to remove LUN"
+  # loop to do unit_remove to each (fcp, wwpn) in valid_dict and check lun existence
+  # as the unit_add is done with the combinations from valid_dict, so does unit_remove
+  for fcp in ${!valid_dict[*]}
   do
-    if [[ -z "$wwpns" ]];then
-      inform "Setting FCP device ${fcps[$i]} offline."
-      chccwdevDevice ${fcps[$i]} "offline"
-      output=`/opt/zthin/bin/smcli Image_Device_Undedicate -T $zthinUserID -v ${fcps[$i]} 2>&1`
-      if [[ $? != 0 ]]; then
-          inform "Undedicate FCP device ${fcps[$i]} fails, reason: $output"
-      else
-          inform "Undedicate FCP device ${fcps[$i]} successfully."
-      fi
-    else
-      for j in "${!wwpns[@]}"
+      wwpns=(${valid_dict[$fcp]})
+      inform "Removing LUN: $lun from FCP: $fcp and WWPNs: ${wwpns[*]}."
+      for wwpn in "${wwpns[@]}"
       do
-        inform "Disconnect FCP device: ${fcps[$i]}"
-        disconnectFcp ${fcps[$i]} 0x${wwpns[$j]} ${lun}
+          # unit_remove for the path
+          removeLun $fcp 0x${wwpn} ${lun}
+          rc=$?
+          if [[ -d /sys/bus/ccw/devices/0.0.${fcp}/0x${wwpn}/${lun} ]]; then
+              printError "Failed to remove disk on fcp: $fcp and wwpn: $wwpn, rc is $rc."
+          fi
       done
-    fi
   done
+
+  inform "Begin to offline and undedicate FCP devices"
+  # For offline and undedicate FCP, it should be done for all the inputed FCP devices
+  for fcp in "${INPUT_FCPS[@]}"
+  do
+      # dedicate and online FCP device
+      inform "Setting FCP device $fcp offline."
+      offlineUndedicateFcp $fcp 
+  done
+  inform "Finish disconnecting FCP devices."
 } #cleanup_fcpdevices
 
 function printCMDExamples {
@@ -438,7 +445,7 @@ function refreshZIPL {
     done
     # print error log if retry fails
     if [[ ! -e "$devNode" ]]; then
-      printError "devNode ${devNode} doesn't exist. Get fcps: ${fcps[*]} and wwpns: ${wwpns[*]}"
+      printError "devNode ${devNode} doesn't exist."
       printLogs
       exit 6
     fi
@@ -601,6 +608,7 @@ function refreshFCPBootmap {
   local rc
   local errorFile
 
+  # all the input values don't have the prefix 0x
   fcpchannels=$(echo ${fcpchannel} | tr '[:upper:]' '[:lower:]')
   lun=$(echo ${lun} | tr '[:upper:]' '[:lower:]')
   wwpn=$(echo ${wwpn} | tr '[:upper:]' '[:lower:]')
@@ -609,11 +617,14 @@ function refreshFCPBootmap {
   lun=0x$lun
 
   # Split fcpchannels and wwpn by ","
-  IFS=',' read -r -a fcps <<< "$fcpchannels"
-  IFS=',' read -r -a ws <<< "$wwpn"
+  IFS=',' read -r -a INPUT_FCPS <<< "$fcpchannels"
+  IFS=',' read -r -a INPUT_WWPNS <<< "$wwpn"
+  
+  # print the parameters value
+  inform "RefreshFCPBootmap begins. FCP: ${INPUT_FCPS[*]}, WWPNs: ${INPUT_WWPNS[*]}, LUN: $lun."
 
   # Check the count of FCP devices, if greater than 8, report error and exit.
-  fcps_len=${#fcps[@]}
+  fcps_len=${#INPUT_FCPS[@]}
   if [ $fcps_len -gt 8 ]
   then
       printError "ERROR: The FCP channel count $fcps_len is greater than 8."
@@ -635,81 +646,54 @@ function refreshFCPBootmap {
   trap 'cleanup_fcpdevices' EXIT
 
   # Try to find which physical wwpns are being used.
-  for fcp in "${fcps[@]}"
+  for fcp in "${INPUT_FCPS[@]}"
   do
-    # Ignore fcp device firstly
-    /sbin/cio_ignore -r $fcp > /dev/null
-
-    # Convert the fcp device to upper case
-    fcp_device=($(echo "$fcp"| tr 'a-z' 'A-Z'))
-
-    # Execute the vmcp command, don't execute dedicate command
-    # if the fcp device is already dedicate to the compute node,
-    res=`vmcp q fcp | grep FCP| grep "$fcp_device"`
-
-    # The fcp device doesn't dedicate to the compute node so
-    # dedicate it to the compute node.
-    if [[ -z $res ]]; then
-      # Try to connect FCP device and online it.
-      /opt/zthin/bin/smcli Image_Device_Dedicate -T $zthinUserID -v $fcp -r $fcp
-      if [[ $? -ne 0 ]]; then
-        printError "Dedicate fails, maybe other machines use this FCP: ${fcp}"
+    # dedicate and online FCP device
+    dedicateOnlineFcp $fcp
+    rc=$?
+    if [[ $rc -ne 0 ]]; then
+        printError "Failed to dedicate or online FCP: $fcp, rc is $rc."
         exit 3
-      fi
     fi
-
-    chccwdevDevice $fcp "online"
-    if [[ $? -ne 0 ]]; then
-      # Online failed
-      rc=4
-    fi
-    host=`lszfcp | grep "$fcp" | cut -d " " -f 2`
-    echo "- - -" > /sys/class/scsi_host/$host/scan
-    # Use sleep command to make sure all files are generated
-    # by chccwdev command.
-    sleep 1
   done
 
-  # Read and parse "lsluns" output then check command input.
-  # If command inputs, merge "lsluns" output and command input
-  # If not, use "lsluns" parse output directly.
-  wwpns=()
-  wwpn=$(lsluns |grep -E 'at port' | awk -F 'at port' '{print $2}' | sed -e 's/^[ ]*//g' | sed -e 's/\:$//g' | tr ' ' '\n' | sort -u | sed -e 's/[\t]//g' |  tr '\n' ' ')
-  IFS=' ' read -r -a lsluns_wwpns <<< "$wwpn"
-  if [[ ${ws[*]} ]]; then
-    for w in "${lsluns_wwpns[@]}"
-    do
-      w=${w##*0x}
-      if [[ "${ws[@]}" =~ "$w" ]]; then
-        wwpns+=($w)
-      fi
-    done
-  else
-    for i in "${!lsluns_wwpns[@]}"
-    do
-      x=${lsluns_wwpns[i]##*0x}
-      wwpns[$i]=$x
-    done
-  fi
+  # use the `lszfcp -P` cmd to get the valid combinations of (fcp,wwpn)
+  # sample output:
+  #[root@112-cmp-ydy ~]# lszfcp -P
+  # 0.0.1c04/0x5005076306105388 rport-0:0-0
+  # 0.0.1c04/0x5005076306035388 rport-0:0-1
+  # 0.0.1c04/0x500507680b22bac7 rport-0:0-10
+  # 0.0.1c04/0x500507680d760027 rport-0:0-2
+  
+  # sample lszfcp_output:
+  # 0.0.1c04 0x5005076306105388
+  # 0.0.1c04 0x5005076306035388
+  # 0.0.1c04 0x500507680b22bac7
+  # 0.0.1c04 0x500507680d760027
+  lszfcp_output=`lszfcp -P | awk '{print $1}' | awk -F'/' '{print $1,$2}'`
+  declare -A valid_dict
+  # check whether each combination of input fcp and input wwpn is in the lszfcp_output
+  # the valid_dict will contain all the valid combinations of inputed fcps and wwpns in the format:
+  # (["FCP1"]="W1 W2" ["FCP2"]="W3 W4")
+  for fcp in "${INPUT_FCPS[@]}"
+  do
+      for wwpn in "${INPUT_WWPNS[@]}"
+      do
+          fcp_wwpn_str="0.0.${fcp} 0x${wwpn}"
+          if [[ $lszfcp_output =~ $fcp_wwpn_str ]]; then
+              # add this combination into valid_dict
+              if [[ -z ${valid_dict[$fcp]} ]]; then
+                  valid_dict+=([$fcp]="$wwpn")
+              else
+                  old_value=${valid_dict[$fcp]}
+                  new_value=${old_value}" "$wwpn
+                  valid_dict[$fcp]=$new_value
+              fi
+          fi
+      done
+  done
 
-  # Remove duplicates
-  wwpns=($(echo "${wwpns[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
-  if [[ ! $wwpns[0] ]]; then
-    printError "No available WWPN found."
-    lsluns_output=$(lsluns 2>&1)
-    inform "lsluns output: ${lsluns_output}."
-    exit 9
-  fi
-  inform "These WWPNs will be operated: ${wwpns[*]}"
-
-  # Check the count of WWPN, if greater than 8, warning and don't exit.
-  wwpns_len=${#wwpns[@]}
-  if [ $wwpns_len -gt 8 ]
-  then
-      inform "WARNING: The count of WWPN can't greater than 8."
-  fi
-
-  # check and record all the valid path (combinations of FCP and WWPN)
+  # check and record all the existing path (combinations of FCP and WWPN)
   # the paths_dict will be in the format: (["FCP1"]="W1 W2" ["FCP2"]="W3 W4")
   declare -A paths_dict
   paths_count=0
@@ -717,41 +701,52 @@ function refreshFCPBootmap {
   # the first_fcp and first_wwpn will be used in single path scenario (multipathd service not running)
   first_fcp=""
   first_wwpn=""
-  for fcp in "${fcps[@]}"
+  disk_path=""
+  
+  # loop to do unit_add to each (fcp, wwpn) in valid_dict and check lun existence
+  for fcp in ${!valid_dict[*]}
   do
-    for wwpn in "${wwpns[@]}"
+      wwpns=(${valid_dict[$fcp]})
+      inform "valid target ports found on FCP: $fcp are: ${wwpns[*]}."
+      for wwpn in "${wwpns[@]}"
       do
-        x="/dev/disk/by-path/ccw-0.0.${fcp}-zfcp-0x${wwpn}:${lun}"
-        if [[ -e $x ]];then
-          if [[ -z $diskPath ]]; then
-            # set diskPath to the first found valid path
-            # this diskPath will only be used to access volume when multipathd service
-            # is not started. Otherwise it will normally be used to find the multipath disk.
-            diskPath=$x
-            first_fcp=$fcp
-            first_wwpn=$wwpn
-          fi
-          inform "found valid path: $x."
-          # add the paths to the dict
-          if [[ -z ${paths_dict["$fcp"]} ]]; then
-             paths_dict+=([$fcp]="$wwpn")
+          # 1. do connectdisk which will do unit_add
+          addLun $fcp 0x${wwpn} ${lun}
+          rc=$?
+          if [[ $rc -ne 0 ]]; then
+              printError "Failed to connect disk on fcp: $fcp and wwpn: $wwpn, rc is $rc."
           else
-             old_value=${paths_dict["$fcp"]}
-             new_value=${old_value}" "$wwpn
-             paths_dict[$fcp]=$new_value
+              path="/dev/disk/by-path/ccw-0.0.${fcp}-zfcp-0x${wwpn}:${lun}"
+              if [[ -z $diskPath ]]; then
+                  # set diskPath to the first found valid path
+                  # this diskPath will only be used to access volume when multipathd service
+                  # is not started. Otherwise it will normally be used to find the multipath disk.
+                  diskPath=$path
+                  first_fcp=$fcp
+                  first_wwpn=$wwpn
+              fi
+              inform "found valid path: $path."
+              # add the paths to the dict
+              if [[ -z ${paths_dict["$fcp"]} ]]; then
+                  paths_dict+=([$fcp]="$wwpn")
+              else
+                  old_value=${paths_dict["$fcp"]}
+                  new_value=${old_value}" "$wwpn
+                  paths_dict[$fcp]=$new_value
+              fi
+              # the /dev/disk/by-path/ccw-0.0.${fcp}-zfcp-0x${wwpn}:${lun) existence is checked in addLUN
+              # increase paths_count
+              ((paths_count=$paths_count+1))
+              # add this (fcp, wwpn) combinations into the rd_zfcp string which will be used to
+              # set the kernel command line in zipl.conf to refresh zipl
+              rd_zfcp+="rd.zfcp=0.0."$fcp,0x$wwpn,$lun" "
           fi
-          # increase paths_count
-          ((paths_count=$paths_count+1))
-          # add this (fcp, wwpn) combinations into the rd_zfcp string which will be used to
-          # set the kernel command line in zipl.conf to refresh zipl
-          rd_zfcp+="rd.zfcp=0.0."$fcp,0x$wwpn,$lun" "
-        fi
       done
   done
 
   # check whether there is valid paths found
   if [[ -z $diskPath ]]; then
-    printError "No valid paths found for FCP devices: ${fcps[*]} and wwpns: ${wwpns[*]}"
+    printError "No valid paths found between FCP devices: ${INPUT_FCPS[*]} and wwpns: ${INPUT_WWPNS[*]}"
     printLogs
     exit 10
   fi

--- a/zthin-parts/zthin/lib/zthinshellutils
+++ b/zthin-parts/zthin/lib/zthinshellutils
@@ -544,6 +544,80 @@ function dedicateFcp {
 
 ###############################################################################
 
+function dedicateOnlineFcp {
+  : SOURCE: ${BASH_SOURCE}
+  : STACK:  ${FUNCNAME[@]}
+  # @Description:
+  #   Dedicate and online the specified FCP device
+  # @Parameters:
+  local fcpChannel=$1       # FCP device channel to connect to disk.
+
+  # Dedicate FCP channel to zthin
+  local rc=0
+  local zthinUserID=$(vmcp q userid | awk '{printf $1}')
+  # Ignore fcp device firstly
+  /sbin/cio_ignore -r ${fcpChannel} > /dev/null
+  
+  out=`/opt/zthin/bin/smcli Image_Device_Dedicate -T $zthinUserID -v ${fcpChannel} -r ${fcpChannel}`
+  if [[ $? -ne 0 ]]; then
+      printError "An error was encountered while connecting to the dedicate device. Response:\n$out"
+      return 1
+  fi
+
+  # Online the FCP channel
+  chccwdevDevice $fcpChannel "online"
+  if [[ $? -ne 0 ]]; then
+      # Online failed
+      return 2
+  fi
+  
+  return 0
+}
+
+###############################################################################
+
+function addLun {
+  : SOURCE: ${BASH_SOURCE}
+  : STACK:  ${FUNCNAME[@]}
+  # @Description:
+  #   add the scsi disk to the specified fcp and wwpn path
+  # @Parameters:
+  local fcpChannel=$1       # FCP device channel to connect to disk.
+  local wwpn=$2             # World wide port number.
+  local lun=$3              # Logical unit number.
+  overall_rc=0
+
+  # Attach the disk
+  if [[ ! -d /sys/bus/ccw/devices/0.0.${fcpChannel}/${wwpn}/${lun} ]]; then
+      echo "${lun}" > /sys/bus/ccw/devices/0.0.${fcpChannel}/${wwpn}/unit_add
+  fi
+  rc=$?
+  if [[ $rc -ne 0 ]]; then
+      printError "An error was encountered while attaching the disk. rc is $rc."
+  fi
+
+  echo add > /sys/bus/ccw/devices/0.0.${fcpChannel}/uevent
+  which udevadm &> /dev/null && udevadm settle || udevsettle
+
+  # Wait 10s in total until disk shows up 
+  for i in 0.1 0.2 0.2 0.5 1 1 1 2 2 2
+  do
+      if [[ -b /dev/disk/by-path/ccw-0.0.${fcpChannel}-zfcp-${wwpn}:${lun} ]]; then
+          break
+      fi
+      sleep $i
+  done
+
+  if [[ ! -b /dev/disk/by-path/ccw-0.0.${fcpChannel}-zfcp-${wwpn}:${lun} ]]; then
+      printError "An error was encountered while locating disk."
+      overall_rc=1
+  fi
+
+  return $overall_rc
+}
+
+###############################################################################
+
 function connectFcp {
   : SOURCE: ${BASH_SOURCE}
   : STACK:  ${FUNCNAME[@]}
@@ -558,8 +632,8 @@ function connectFcp {
   # Dedicate FCP channel to zthin
   local rc=0
   local zthinUserID=$(vmcp q userid | awk '{printf $1}')
-  out=`/opt/zthin/bin/smcli Image_Device_Dedicate -T $zthinUserID -v ${fcpChannel} -r ${fcpChannel} 0 &`
-  if (( $? )); then
+  out=`/opt/zthin/bin/smcli Image_Device_Dedicate -T $zthinUserID -v ${fcpChannel} -r ${fcpChannel}`
+  if [[ $? -ne 0 ]]; then
     printError "An error was encountered while connecting to the dedicate device. Response:\n$out"
     exit 3
   fi
@@ -578,7 +652,7 @@ function connectFcp {
   if [[ ! -d /sys/bus/ccw/devices/0.0.${fcpChannel}/${wwpn}/${lun} ]]; then
     echo "${lun}" > /sys/bus/ccw/devices/0.0.${fcpChannel}/${wwpn}/unit_add
   fi
-  if (( $? )); then
+  if [[ $? -ne 0 ]]; then
     printError "An error was encountered while attaching the disk."
     local rc=5
   fi
@@ -761,7 +835,98 @@ function getDiskAlias {
 } #getDiskAlias{}
 
 ###############################################################################
+function removeLun {
+  : SOURCE: ${BASH_SOURCE}
+  : STACK:  ${FUNCNAME[@]}
+  # @Description:
+  #   remove the lun from the specified fcp, wwpn path
+  # @Parameters:
+  local fcpChannel=$1       # FCP device channel to connect to disk.
+  local wwpn=$2             # World wide port number.
+  local lun=$3              # Logical unit number.
+  local rc=0
 
+  if [[ -d /sys/bus/ccw/devices/0.0.${fcpChannel}/${wwpn}/${lun} ]]; then
+    local unit_remove_missing=1
+    local lun_missing=1
+    local i
+
+    # Remove the SCSI device
+    local devName=`ls -al /dev/disk/by-path/ccw-0.0.${fcpChannel}-zfcp-${wwpn}:${lun} | tr '/' ' ' | awk '{print \$NF}'`
+    if [[ "$devName" != "" && -e "/sys/block/$devName/device/delete" ]]; then
+        echo 1 > "/sys/block/$devName/device/delete"
+    fi
+
+    # Remove the lun device
+    for i in 1 1 1 2 5 5 5 10 10 10 10
+    do
+        if [[ -e "/sys/bus/ccw/devices/0.0.${fcpChannel}/${wwpn}/unit_remove" ]]; then
+            unit_remove_missing=0
+            echo $lun > "/sys/bus/ccw/devices/0.0.${fcpChannel}/${wwpn}/unit_remove"
+            if [[ $? -eq 0 ]]; then
+                lun_missing=0
+                break;
+            fi
+        fi
+        sleep $i
+    done
+
+    if [[ $lun_missing -eq 1 ]]; then
+        printError "An error was encountered while writing to the unit_remove file."
+        rc=5
+    fi
+    if [[ $unit_remove_missing -eq 1 ]]; then
+        printError "An error was encountered while detaching the disk.  \
+          /sys/bus/ccw/devices/0.0.${fcpChannel}/${wwpn}/unit_remove \
+          does not exist."
+        rc=7
+    fi
+  fi
+  return $rc
+}
+
+###############################################################################
+
+function offlineUndedicateFcp {
+  : SOURCE: ${BASH_SOURCE}
+  : STACK:  ${FUNCNAME[@]}
+  # @Description:
+  #   Offline and detach the FCP device
+  # @Parameters:
+  local fcpChannel=$1       # FCP device channel to connect to disk.
+
+  local rc=0
+  # Offline the FCP channel
+  inform "Trying to offline the FCP: ${fcpChannel}."
+  chccwdevDevice ${fcpChannel} "offline"
+  if [[ $? -ne 0 ]]; then
+      # Offline failed
+      rc=1
+      printError "Failed to offline FCP: ${fcpChannel}, rc is $rc."
+  else
+	  inform "Successfully set FCP: ${fcpChannel} to offline."
+  fi
+
+  # Undedicate FCP channel to zthin
+  local zthinUserID=$(vmcp q userid | awk '{printf $1}')
+  res=`/opt/zthin/bin/smcli Image_Device_Undedicate -T $zthinUserID -v ${fcpChannel}`
+  undedicate_rc=$?
+  if [[ $undedicate_rc -eq 0 ]]; then
+      inform "Successfully detach FCP ${fcpChannel} from userid $zthinUserID."
+  else
+      image_no_exist="Image device does not exist"
+      if [[ $res == *$image_no_exist* ]]; then
+          inform "FCP device $fcpChannel has already detached."
+      else
+          printError "An error was encountered while disconnecting dedicated device because $res."
+          rc=2
+      fi
+  fi
+
+  return $rc
+}
+
+###############################################################################
 function disconnectFcp {
   : SOURCE: ${BASH_SOURCE}
   : STACK:  ${FUNCNAME[@]}


### PR DESCRIPTION
1. use `lszfcp -P` to replace the `lsluns` to find the valid target ports
2. for the valid (fcp, wwpn) combination, do the unit_add/unit_remove to fit the disable of allow_lun_scan
3. fix the issue of wwpns variable be overwritten
4. add util functions in zthinutil to each sub task, eg addlun, removelun, dedicateonlineFCP, offlineUndedicateFCP
5. fix the issue of multiple times offline operation to each FCP device. (previous logs contain many entried like "FCP xxx is already offline")

Signed-off-by: dyyang <dyyang@cn.ibm.com>