### PR TITLE
[master]Add interfaces to get disk volumes of the diskpool

### DIFF
--- a/doc/source/parameters.yaml
+++ b/doc/source/parameters.yaml
@@ -541,6 +541,12 @@ disk_info_used:
   in: body
   required: true
   type: int
+diskpool_volumes:
+  description: |
+    The volume list of the diskpool
+  in: body
+  required: true
+  type: string
 image_info:
   description: |
     The image info for specific image or all images, each image has one dict

--- a/doc/source/restapi.rst
+++ b/doc/source/restapi.rst
@@ -1471,6 +1471,34 @@ Get disk pool information on the host.
 .. literalinclude:: ../../zvmsdk/tests/fvt/api_templates/test_host_disk_info.tpl
    :language: javascript
 
+Get host disk pool volume names
+-------------------------------
+
+**GET /host/diskpool_volumes**
+
+Get volume list of the diskpool on the host.
+
+* Request:
+
+.. restapi_parameters:: parameters.yaml
+
+  - poolname: disk_pool
+
+* Response code:
+
+  HTTP status code 200 on success.
+
+* Response contents:
+
+.. restapi_parameters:: parameters.yaml
+
+  - diskpool_volumes: diskpool_volumes
+
+* Response sample:
+
+.. literalinclude:: ../../zvmsdk/tests/fvt/api_templates/test_host_disk_volumes.tpl
+   :language: javascript
+
 Image(s)
 ========
 

--- a/zvmconnector/restclient.py
+++ b/zvmconnector/restclient.py
@@ -453,6 +453,17 @@ def req_host_get_guest_list(start_index, *args, **kwargs):
     return url, body
 
 
+def req_host_get_diskpool_volumes(start_index, *args, **kwargs):
+    url = '/host/diskpool_volumes'
+    poolname = kwargs.get('disk_pool', None)
+    append = ''
+    if poolname is not None:
+        append += "?poolname=%s" % poolname
+    url += append
+    body = None
+    return url, body
+
+
 def req_host_diskpool_get_info(start_index, *args, **kwargs):
     url = '/host/diskpool'
     poolname = kwargs.get('disk_pool', None)
@@ -810,6 +821,11 @@ DATABASE = {
         'args_required': 0,
         'params_path': 0,
         'request': req_host_get_guest_list},
+    'host_get_diskpool_volumes': {
+        'method': 'GET',
+        'args_required': 0,
+        'params_path': 0,
+        'request': req_host_get_diskpool_volumes},
     'host_diskpool_get_info': {
         'method': 'GET',
         'args_required': 0,

--- a/zvmsdk/api.py
+++ b/zvmsdk/api.py
@@ -268,6 +268,40 @@ class SDKAPI(object):
         with zvmutils.log_and_reraise_sdkbase_error(action):
             return self._hostops.get_info()
 
+    def host_get_diskpool_volumes(self, disk_pool=None):
+        """ Retrieve diskpool volumes.
+        :param str disk_pool: the disk pool info. It use ':' to separate
+        disk pool type and pool name, eg "ECKD:eckdpool" or "FBA:fbapool"
+        :returns: Dictionary describing disk pool usage info
+        """
+        # disk_pool is optional. disk_pool default to None because
+        # it is more convenient for users to just type function name when
+        # they want to get the disk pool info of CONF.zvm.disk_pool.
+        # The default value of CONF.zvm.disk_pool is None, if it's configured,
+        # the format must be "ECKD:eckdpool" or "FBA:fbapool".
+        disk_pool = disk_pool or CONF.zvm.disk_pool
+        if disk_pool is None:
+            errmsg = ("Invalid disk_pool input None, disk_pool should be"
+                      " configured for sdkserver.")
+            LOG.error(errmsg)
+            raise exception.SDKInvalidInputFormat(msg=errmsg)
+        if ':' not in disk_pool:
+            msg = ('Invalid input parameter disk_pool, expect ":" in'
+                   'disk_pool, eg. ECKD:eckdpool')
+            LOG.error(msg)
+            raise exception.SDKInvalidInputFormat(msg)
+        diskpool_type = disk_pool.split(':')[0].upper()
+        diskpool_name = disk_pool.split(':')[1].upper()
+        if diskpool_type not in ('ECKD', 'FBA'):
+            msg = ('Invalid disk pool type found in disk_pool, expect'
+                   'disk_pool like ECKD:eckdpool or FBA:fbapool')
+            LOG.error(msg)
+            raise exception.SDKInvalidInputFormat(msg)
+
+        action = "get information of disk pool: '%s'" % disk_pool
+        with zvmutils.log_and_reraise_sdkbase_error(action):
+            return self._hostops.diskpool_get_volumes(diskpool_name)
+
     def host_get_guest_list(self):
         """list names of all the VMs on the host.
         :returns: names of the vm on this hypervisor, in a list.

--- a/zvmsdk/constants.py
+++ b/zvmsdk/constants.py
@@ -44,6 +44,10 @@ DISKPOOL_KEYWORDS = {
     "disk_available": "Free:",
     }
 
+DISKPOOL_VOLUME_KEYWORDS = {
+    "diskpool_volumes": "Diskpool Volumes:",
+    }
+
 SET_VSWITCH_KEYWORDS = ["grant_userid", "user_vlan_id",
                         "revoke_userid", "real_device_address",
                         "port_name", "controller_name",

--- a/zvmsdk/hostops.py
+++ b/zvmsdk/hostops.py
@@ -75,6 +75,11 @@ class HOSTOps(object):
         with zvmutils.expect_invalid_resp_data(guest_list):
             return guest_list
 
+    def diskpool_get_volumes(self, pool_name):
+        diskpool_volume_list = self._smtclient.get_diskpool_volumes(pool_name)
+        with zvmutils.expect_invalid_resp_data(diskpool_volume_list):
+            return diskpool_volume_list
+
     def diskpool_get_info(self, pool):
         dp_info = self._smtclient.get_diskpool_info(pool)
         with zvmutils.expect_invalid_resp_data(dp_info):

--- a/zvmsdk/sdkwsgi/handler.py
+++ b/zvmsdk/sdkwsgi/handler.py
@@ -107,6 +107,9 @@ ROUTE_LIST = (
     ('/host/diskpool', {
         'GET': host.host_get_disk_info,
     }),
+    ('/host/diskpool_volumes', {
+        'GET': host.host_get_diskpool_volumes,
+    }),
     ('/images', {
         'POST': image.image_create,
         'GET': image.image_query

--- a/zvmsdk/sdkwsgi/handlers/host.py
+++ b/zvmsdk/sdkwsgi/handlers/host.py
@@ -47,6 +47,12 @@ class HostAction(object):
         return info
 
     @validation.query_schema(image.diskpool)
+    def get_diskpool_volumes(self, req, poolname):
+        info = self.client.send_request('host_get_diskpool_volumes',
+                                        disk_pool=poolname)
+        return info
+
+    @validation.query_schema(image.diskpool)
     def diskpool_get_info(self, req, poolname):
         info = self.client.send_request('host_diskpool_get_info',
                                         disk_pool=poolname)
@@ -85,6 +91,25 @@ def host_get_guest_list(req):
         return action.get_guest_list()
 
     info = _host_get_guest_list()
+    info_json = json.dumps(info)
+    req.response.body = utils.to_utf8(info_json)
+    req.response.content_type = 'application/json'
+    req.response.status = util.get_http_code_from_sdk_return(info)
+    return req.response
+
+
+@util.SdkWsgify
+@tokens.validate
+def host_get_diskpool_volumes(req):
+
+    def _host_get_diskpool_volumes(req, poolname):
+        action = get_action()
+        return action.get_diskpool_volumes(req, poolname)
+
+    poolname = None
+    if 'poolname' in req.GET:
+        poolname = req.GET['poolname']
+    info = _host_get_diskpool_volumes(req, poolname)
     info_json = json.dumps(info)
     req.response.body = utils.to_utf8(info_json)
     req.response.content_type = 'application/json'

--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -1807,6 +1807,13 @@ class SMTClient(object):
             results = self._request("getvm alldirectory")
         return results.get('response', [])
 
+    def get_diskpool_volumes(self, pool):
+        with zvmutils.log_and_reraise_smt_request_failed():
+            results = self._request("gethost diskpoolvolumes %s" % pool)
+        diskpool_volumes = zvmutils.translate_response_to_dict(
+            '\n'.join(results['response']), const.DISKPOOL_VOLUME_KEYWORDS)
+        return diskpool_volumes
+
     def _delete_nic_active_exception(self, error, userid, vdev):
         if ((error.results['rc'] == 204) and (error.results['rs'] == 28)):
             errmsg = error.format_message()

--- a/zvmsdk/tests/fvt/api_templates/test_host_disk_volumes.tpl
+++ b/zvmsdk/tests/fvt/api_templates/test_host_disk_volumes.tpl
@@ -1,0 +1,11 @@
+{
+    "rs": 0,
+    "overallRC": 0,
+    "modID": null,
+    "rc": 0,
+    "output":
+    {
+         "diskpool_volumes": "IAS100 IAS101",
+    },
+    "errmsg": ""
+}

--- a/zvmsdk/tests/unit/sdkwsgi/handlers/test_host.py
+++ b/zvmsdk/tests/unit/sdkwsgi/handlers/test_host.py
@@ -68,3 +68,12 @@ class HandlersHostTest(unittest.TestCase):
         self.req.GET['poolname'] = 'disk1'
         host.host_get_disk_info(self.req)
         self.assertTrue(mock_get_disk_info.called)
+
+    @mock.patch.object(host.HostAction, 'get_diskpool_volumes')
+    def test_host_get_disk_volumes(self, mock_get_disk_vols):
+
+        mock_get_disk_vols.return_value = ''
+        self.req.GET = {}
+        self.req.GET['poolname'] = 'disk1'
+        host.host_get_diskpool_volumes(self.req)
+        self.assertTrue(mock_get_disk_vols.called)

--- a/zvmsdk/tests/unit/sdkwsgi/test_handler.py
+++ b/zvmsdk/tests/unit/sdkwsgi/test_handler.py
@@ -661,6 +661,19 @@ class HostHandlerTest(unittest.TestCase):
 
             get_disk_info.assert_called_once_with(mock.ANY, None)
 
+    @mock.patch.object(tokens, 'validate')
+    def test_host_get_diskpool_volumes(self, mock_validate):
+        self.env['PATH_INFO'] = '/host/diskpool_volumes'
+        self.env['REQUEST_METHOD'] = 'GET'
+        h = handler.SdkHandler()
+        function = 'zvmsdk.sdkwsgi.handlers.host.HostAction.'\
+                   'get_diskpool_volumes'
+        with mock.patch(function) as get_diskpool_volumes:
+            get_diskpool_volumes.return_value = {'overallRC': 0}
+            h(self.env, dummy)
+
+            get_diskpool_volumes.assert_called_once_with(mock.ANY, None)
+
 
 class VswitchHandlerNegativeTest(unittest.TestCase):
 

--- a/zvmsdk/tests/unit/test_api.py
+++ b/zvmsdk/tests/unit/test_api.py
@@ -12,6 +12,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 import mock
+import six
 
 from zvmsdk import api
 from zvmsdk import exception
@@ -572,6 +573,23 @@ class SDKAPITestCase(base.SDKTestCase):
     def test_host_get_guest_list(self, guest_list):
         self.api.host_get_guest_list()
         guest_list.assert_called_once_with()
+
+    @mock.patch("zvmsdk.hostops.HOSTOps.diskpool_get_volumes")
+    def test_host_get_diskpool_volumes(self, diskpool_vols):
+        base.set_conf('zvm', 'disk_pool', None)
+        disk_pool = 'ECKD:IAS1PL'
+        result = self.api.host_get_diskpool_volumes(disk_pool)
+        diskpool_vols.assert_called_once_with('IAS1PL')
+        # Test disk_pool is None
+        disk_pool = None
+        try:
+            self.api.host_get_diskpool_volumes(disk_pool)
+        except Exception as exc:
+            errmsg = ("Invalid disk_pool input None, disk_pool should be"
+                      " configured for sdkserver.")
+            result = errmsg in six.text_type(exc)
+            self.assertEqual(result, True)
+            pass
 
     @mock.patch("zvmsdk.hostops.HOSTOps.diskpool_get_info")
     def test_host_diskpool_get_info(self, dp_info):

--- a/zvmsdk/tests/unit/test_hostops.py
+++ b/zvmsdk/tests/unit/test_hostops.py
@@ -82,3 +82,12 @@ class SDKHostOpsTestCase(base.SDKTestCase):
         self.assertEqual(dp_info['disk_total'], 406105)
         self.assertEqual(dp_info['disk_used'], 367263)
         self.assertEqual(dp_info['disk_available'], 38)
+
+    @mock.patch("zvmsdk.smtclient.SMTClient.get_diskpool_volumes")
+    def test_diskpool_get_volumes(self, get_diskpool_vols):
+        get_diskpool_vols.return_value = {
+            'diskpool_volumes': 'IAS100 IAS101',
+            }
+        diskpool_vols = self._hostops.diskpool_get_volumes("fakepool")
+        get_diskpool_vols.assert_called_once_with("fakepool")
+        self.assertEqual(diskpool_vols['diskpool_volumes'], 'IAS100 IAS101')

--- a/zvmsdk/tests/unit/test_smtclient.py
+++ b/zvmsdk/tests/unit/test_smtclient.py
@@ -1443,6 +1443,18 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         smt_req.assert_called_once_with('getHost diskpoolspace pool')
         self.assertDictEqual(dp_info, expect)
 
+    @mock.patch.object(smtclient.SMTClient, '_request')
+    def test_get_diskpool_volumes(self, smt_req):
+        resp = {'Diskpool Volumes:' 'IAS100 IAS200'}
+        smt_req.return_value = {'rs': 0, 'errno': 0, 'strError': '',
+                                 'overallRC': 0, 'logEntries': [], 'rc': 0,
+                                 'response': resp}
+        expect = {'diskpool_volumes': 'IAS100 IAS200'}
+        diskpool_vols = self._smtclient.get_diskpool_volumes('fakepool')
+
+        smt_req.assert_called_once_with('gethost diskpoolvolumes fakepool')
+        self.assertDictEqual(diskpool_vols, expect)
+
     @mock.patch.object(zvmutils, 'get_smt_userid')
     @mock.patch.object(smtclient.SMTClient, '_request')
     def test_get_vswitch_list(self, request, get_smt_userid):


### PR DESCRIPTION

for which we can match the volumes with the one in the vm user direct.
So add these interfaces to get the disk volumes of the diskpool.

If the diskpool is provided, query the voluems of the pool, if not,
the CONF.zvm.disk_pool will be used.

Signed-off-by: Xiao Feng Ren <renxiaof@linux.vnet.ibm.com>