### PR TITLE
add multiple paths for single fcp into rhcos kernel cmdline

### DIFF
--- a/zthin-parts/zthin/bin/unpackdiskimage
+++ b/zthin-parts/zthin/bin/unpackdiskimage
@@ -798,6 +798,30 @@ function deployDiskImage {
 
   function update_zipl_bootloader_fcp {
     inform "Updating zipl"
+
+    local rd_zfcp=""
+
+    # discover other valid wwpns
+    local ActiveWWPNs=$(ls /sys/bus/ccw/drivers/zfcp/0.0.$fcp/ | grep 0x)
+    inform "All wwpns: ${ActiveWWPNs}"
+    for w in ${ActiveWWPNs}
+    do
+      echo "$lun" > /sys/bus/ccw/drivers/zfcp/0.0.$fcp/${w}/unit_add
+    done
+    # wait paths ready
+    echo add > /sys/bus/ccw/devices/0.0.${fcpChannel}/uevent
+    which udevadm &> /dev/null && udevadm settle || udevsettle
+
+    local lszfcp_output=$(lszfcp -HD 2>&1)
+    inform "lszfcp output: ${lszfcp_output}"
+
+    local valid_wwpns=`lszfcp -HD | grep ${fcpChannel} | tail -n +2 | awk -F'/' '{print $2}'`
+    inform "All valid wwpns: ${valid_wwpns}"
+    for ww in ${valid_wwpns}
+    do
+      rd_zfcp+="rd.zfcp=0.0."$fcpChannel,$ww,$lun" "
+    done
+
     mkdir -p /tmp/$fcpChannel/boot_partition
     mount_boot_partition /tmp/$fcpChannel/boot_partition
     trap 'umount /tmp/$fcpChannel/boot_partition; trap - RETURN' RETURN
@@ -845,8 +869,8 @@ function deployDiskImage {
     if [ $nameserver2  ]; then 
         nameserver2='nameserver='${nameserver2}
     fi
-    
-    echo "$(grep options $blsfile | cut -d' ' -f2-) rd.zfcp=0.0.$fcpChannel,$wwpn,$lun rd.znet=qeth,$nicID,layer2=1,portno=0 ignition.firstboot=1 rd.neednet=1 ip=$ipConfig $nameserver1 $nameserver2" > /tmp/$fcpChannel/zipl_prm
+
+    echo "$(grep options $blsfile | cut -d' ' -f2-) zfcp.allow_lun_scan=0 rw $rd_zfcp rd.znet=qeth,$nicID,layer2=1,portno=0 ignition.firstboot=1 rd.neednet=1 ip=$ipConfig $nameserver1 $nameserver2" > /tmp/$fcpChannel/zipl_prm
     #Run zipl to update bootloader
     zipl --verbose -p /tmp/$fcpChannel/zipl_prm -i $(ls /tmp/$fcpChannel/boot_partition/ostree/*/*vmlinuz*) -r $(ls /tmp/$fcpChannel/boot_partition/ostree/*/*initramfs*) --target /tmp/$fcpChannel/boot_partition
     if [[ $? -ne 0 ]]; then


### PR DESCRIPTION
Indicate all valid wwpns by trying unit_add, add all valid paths
as rd.zfcp parameter in rhcos kernel cmdline.

unit_remove will be handled in following PR.

Signed-off-by: bjhuangr <bjhuangr@cn.ibm.com>