### PR TITLE
[master] zipl without chroot

### DIFF
--- a/zthin-parts/zthin/bin/refresh_bootmap
+++ b/zthin-parts/zthin/bin/refresh_bootmap
@@ -63,15 +63,49 @@ function cleanup_umountdir_and_disconnect_fcp {
   : SOURCE: ${BASH_SOURCE}
   : STACK:  ${FUNCNAME[@]}
   # @Description:
-  #   Umount dir and cleanup all FCP devices.
-  inform "Begin to cleanup umount dir."
-  umount $deviceMountPoint/proc > /dev/null
-  umount $deviceMountPoint/sys > /dev/null
-  # umount $deviceMountPoint/run > /dev/null
-  umount $deviceMountPoint/dev > /dev/null
-  umount $deviceMountPoint > /dev/null
-  rm -rf $deviceMountPoint
-  inform "Finish cleanuping umount dir."
+  
+  if [[ -n ${deviceMountPoint} ]]; then
+    if [[ -n ${zipl_conf} && -n ${BLS_dir} && -n ${zipl_postfix} ]]; then
+      # remove the temporary copy of zipl.conf
+      if [[ -f ${deviceMountPoint}/${zipl_conf}${zipl_postfix} ]]; then
+        rm -fr ${deviceMountPoint}/${zipl_conf}${zipl_postfix}
+        # "rm -fr xxx" return code is always 0
+        if [[ ! -e ${deviceMountPoint}/${zipl_conf}${zipl_postfix} ]]; then
+          inform "Removed ${deviceMountPoint}/${zipl_conf}${zipl_postfix}"
+        fi
+      fi
+      # remove the temporary copy of BLS_dir
+      if [[ -d ${deviceMountPoint}/${BLS_dir}${zipl_postfix} ]]; then
+        rm -fr ${deviceMountPoint}/${BLS_dir}${zipl_postfix}
+        # "rm -fr xxx" return code is always 0
+        if [[ ! -e ${deviceMountPoint}/${BLS_dir}${zipl_postfix} ]]; then
+          inform "Removed ${deviceMountPoint}/${BLS_dir}${zipl_postfix}"
+        fi
+      fi
+    fi
+
+    # Umount dir and cleanup all FCP devices.
+    inform "Begin to cleanup umount dir."
+    out=`umount ${deviceMountPoint} 2>&1`
+    rc=$?
+    if [[ $rc -ne 0 ]]; then
+      printError "Failed to Umount devNode $devNode from $deviceMountPoint. rc: $rc. out: $out."
+      exit 9
+    fi
+    inform "Successed to umount devNode $devNode from $deviceMountPoint"
+    # remove the temporary mount point dir
+    if [[ -d ${deviceMountPoint} ]]; then
+      rm -rf ${deviceMountPoint}
+      # "rm -fr xxx" return code is always 0
+      if [[ ! -e ${deviceMountPoint} ]]; then
+        inform "Removed ${deviceMountPoint}"
+      fi
+    fi
+    inform "Finish cleanuping umount dir."
+  else
+    printError "Failed to umount devNode $devNode due to deviceMountPoint not defined."
+    exit 9
+  fi
 
   cleanup_fcpdevices
 } # cleanup_umountdir_and_disconnect_fcp
@@ -416,6 +450,9 @@ function refreshZIPL {
   # @Returns:
   #   None
   local devNode=$1
+  zipl_conf='etc/zipl.conf'
+  zipl_postfix='_zipl_postfix'
+  BLS_dir='boot/loader/entries'
 
   if [[ $skipzipl = 'YES'  ]]; then
     # this is the part of return info for upper layer(smtclient)
@@ -452,7 +489,7 @@ function refreshZIPL {
   fi
 
   # Create a mount dir.
-  deviceMountPoint=$(/usr/bin/mktemp -d /mnt/XXXXX)
+  deviceMountPoint=$(/usr/bin/mktemp -d /tmp/XXXXX)
   rc=$?
   if [[ $rc -ne 0 ]]; then
     printError "Create mount dir fails, rc: $rc."
@@ -463,27 +500,41 @@ function refreshZIPL {
   trap 'cleanup_umountdir_and_disconnect_fcp' EXIT
 
   # Try to mount fcp device.
-  inform "devNode is: $devNode point: $deviceMountPoint"
-  mount $devNode $deviceMountPoint
+  inform "devNode is: $devNode point: ${deviceMountPoint}"
+  mount $devNode ${deviceMountPoint}
   rc=$?
   if [[ $rc -ne 0 ]]; then
     printError "Mount devNode fails. rc: $rc."
     exit 8
   fi
-  mount -t proc /proc $deviceMountPoint/proc
-  mount -o bind /sys $deviceMountPoint/sys
-  # mount -o bind /run $deviceMountPoint/run
-  mount -o bind /dev $deviceMountPoint/dev
-  rc=$?
-  if [[ $rc -ne 0 ]]; then
-    printError "Mount bind fails. rc: $rc."
-    exit 8
+
+  # Remove dirty data in /etc/fstab left by the previous vm deploy
+  # remove lines containing "/mnt/ephemeral" or " swap swap "
+  # TODO: need to update the implementation method when later the ephemeral
+  # mount point maybe changed to user configurable, to not hardcode to /mnt/ephemeralxxx
+  inform "Updating ${deviceMountPoint}/etc/fstab"
+  sed -i '/\/mnt\/ephemeral/d' ${deviceMountPoint}/etc/fstab
+  sed -i '/ swap swap /d' ${deviceMountPoint}/etc/fstab
+
+  # Remove stale /etc/multipath/bindings and /etc/multipath/wwids
+  # These files may contain the old info of the captured base vm,
+  # which disrupts the volume bindings of the new vm deployed from above captured image, resulting
+  #  a. mpath name inconsistent between 'df' and 'multipath'
+  #  b. in some scenairo, boot-volume extend partition fail due to 'a'
+  # By removing them, they can be recreated later with correct volume bindings
+  # when multipathd start at vm boot time.
+  inform "Move stale multipath bindings and wwids if any"
+  if [[ -r "${deviceMountPoint}/etc/multipath/bindings" ]]; then
+    mv ${deviceMountPoint}/etc/multipath/bindings ${deviceMountPoint}/etc/multipath/bindings.bak
+  fi
+  if [[ -r "${deviceMountPoint}/etc/multipath/wwids" ]]; then
+    mv ${deviceMountPoint}/etc/multipath/wwids ${deviceMountPoint}/etc/multipath/wwids.bak
   fi
 
   # Get target os version
-  local osRelease="$deviceMountPoint/etc/os-release"
-  local slesRelease="$deviceMountPoint/etc/SuSE-release"
-  local rhelRelease="$deviceMountPoint/etc/redhat-release"
+  local osRelease="${deviceMountPoint}/etc/os-release"
+  local slesRelease="${deviceMountPoint}/etc/SuSE-release"
+  local rhelRelease="${deviceMountPoint}/etc/redhat-release"
 
   if [[ -e $osRelease ]]; then
     os=`cat $osRelease | grep "^ID=" | sed \
@@ -515,79 +566,104 @@ function refreshZIPL {
   fi
   inform "Final rd.zfcp value is: $rd_zfcp."
 
-  # Exec zipl command to prepare device for initial problem load
-  if [[ $os == rhel7* ]]; then
+  # Exec zipl command to prepare device for initial program load
+  if [[ ($os == rhel7*) || ($os == rhel8*) ]]; then
     inform "Refresh $os zipl."
-    zipl_conf='etc/zipl.conf'
-    
-    ### Delete all items start with "rd.zfcp="
-    sed -ri 's/rd.zfcp=\S+\s*[[:space:]]//g' ${deviceMountPoint}/$zipl_conf
-    
-    # Remove quote
-    sed -i 's/\"$//g' ${deviceMountPoint}/$zipl_conf
-    
-    # Remove quote
-    sed -i 's/[ \t]*$//g' ${deviceMountPoint}/$zipl_conf
-    
-    # Append rd.zfcp= string to "parameters=" line.
-    sed -i "/^[[:space:]]parameters=/ s/$/ $rd_zfcp/" ${deviceMountPoint}/$zipl_conf
-    
-    # Append quote to "parameters=" line
-    sed -i "/^[[:space:]]parameters=/ s/$/\"/" ${deviceMountPoint}/$zipl_conf
+    if [[ ! -e ${deviceMountPoint}/${zipl_conf} ]]; then
+      printError "Failed to execute zipl on $os due to ${deviceMountPoint}/${zipl_conf} not exist."
+      exit 13
+    else
+      # Delete all items start with "rd.zfcp="
+      sed -ri 's/rd.zfcp=\S+\s*[[:space:]]//g' ${deviceMountPoint}/${zipl_conf}
+      # Remove quote
+      sed -i 's/\"$//g' ${deviceMountPoint}/${zipl_conf}
+      # Remove trailing space
+      sed -i 's/[ \t]*$//g' ${deviceMountPoint}/${zipl_conf}
+      # Append rd.zfcp= string to "parameters=" line.
+      sed -i "/^[[:space:]]parameters=/ s/$/ $rd_zfcp/" ${deviceMountPoint}/${zipl_conf}
+      # Append quote to "parameters=" line
+      sed -i "/^[[:space:]]parameters=/ s/$/\"/" ${deviceMountPoint}/${zipl_conf}
 
-  elif [[ $os == rhel8* ]]; then
-    inform "Refresh $os zipl."
-    kernel_version_conf_files=`find $deviceMountPoint/boot/loader/entries/ -name '*.conf'`
-    wwid=`/usr/lib/udev/scsi_id --whitelisted $diskPath 2> /dev/null`
-    rootPath="root=\/dev\/disk\/by-id\/dm-uuid-part1-mpath-$wwid "
-    # The Volume may be contains several kernel version conf files.
-    # So every conf file needs to be changed.
-    for confFile in $kernel_version_conf_files; do
-       # Delete all items start with "rd.zfcp="
-       sed -ri 's/rd.zfcp=\S+\s*[[:space:]]//g' $confFile
-       # Remove trailing space
-       sed -i 's/[ \t]*$//g' $confFile
-       # Update the root file system target path
-       sed -ri "s/root=\S+\s*[[:space:]]/$rootPath /g" $confFile
-       # Append rd.zfcp= string to "options root=" line.
-       sed -i "/^options root=/ s/$/ $rd_zfcp/" $confFile
-    done
+      # Create a copy of zipl_conf to be used by zipl command later
+      out=`/usr/bin/cp -a ${deviceMountPoint}/${zipl_conf} ${deviceMountPoint}/${zipl_conf}${zipl_postfix} 2>&1`
+      if [[ $? -ne 0 ]]; then
+        printError "Failed to create a copy of zipl_conf due to ${out}."
+        exit 14
+      fi
+      # Add ${deviceMountPoint} as prefix of "target=|image=|randisk=" to the copy of zipl_conf
+      sed -i "s|target[[:space:]]*=[[:space:]]*|target=${deviceMountPoint}|" ${deviceMountPoint}/${zipl_conf}${zipl_postfix}
+      sed -i "s|image[[:space:]]*=[[:space:]]*|image=${deviceMountPoint}|" ${deviceMountPoint}/${zipl_conf}${zipl_postfix}
+      sed -i "s|ramdisk[[:space:]]*=[[:space:]]*|ramdisk=${deviceMountPoint}|" ${deviceMountPoint}/${zipl_conf}${zipl_postfix}
+
+      # Refresh bootmap without chroot
+      if [[ $os == rhel7* ]]; then
+        # zipl for RHEL7 NOT support BLS(BootLoaderSpec) file
+        cmd_zipl="${deviceMountPoint}/usr/sbin/zipl -V -c ${deviceMountPoint}/${zipl_conf}${zipl_postfix} 2>&1"
+        out_zipl=`eval ${cmd_zipl}`
+        rc_zipl=$?
+      else
+        # zipl for RHEL8 support BLS(BootLoaderSpec) files.
+        # Files that contain BLS snippets can have any name, but must have the file extension .conf.
+        # /boot/loader/entries/ is the default directory containing BLS files.
+        BLS_file_count=`ls -1 ${deviceMountPoint}/${BLS_dir}/*.conf 2>/dev/null | wc -l`
+        if [[ ${BLS_file_count} -eq 0 ]]; then
+          inform "No BLS files found in ${deviceMountPoint}/${BLS_dir}"
+        else
+          wwid=`/usr/lib/udev/scsi_id --whitelisted $diskPath 2> /dev/null`
+          rootPath="root=\/dev\/disk\/by-id\/dm-uuid-part1-mpath-$wwid "
+          # Delete all items start with "rd.zfcp="
+          sed -ri 's/rd.zfcp=\S+\s*[[:space:]]//g' ${deviceMountPoint}/${BLS_dir}/*.conf
+          # Remove trailing space
+          sed -i 's/[ \t]*$//g' ${deviceMountPoint}/${BLS_dir}/*.conf
+          # Update the root file system target path
+          sed -ri "s/root=\S+\s*[[:space:]]/$rootPath /g" ${deviceMountPoint}/${BLS_dir}/*.conf
+          # Append rd.zfcp= string to "options root=" line.
+          sed -i "/^options root=/ s/$/ $rd_zfcp/" ${deviceMountPoint}/${BLS_dir}/*.conf
+
+          # Create a copy of BLS_dir to be used by zipl command later
+          out=`mkdir ${deviceMountPoint}/${BLS_dir}${zipl_postfix} 2>&1`
+          if [[ ! -d ${deviceMountPoint}/${BLS_dir}${zipl_postfix} ]]; then
+            printError "Failed to create a copy of BLS_dir due to ${out}"
+            exit 15
+          fi
+          # Copy BLS files to the copy of BLS_dir
+          out=`/usr/bin/cp -a ${deviceMountPoint}/${BLS_dir}/*.conf ${deviceMountPoint}/${BLS_dir}${zipl_postfix} 2>&1`
+          if [[ $? -ne 0 ]]; then
+            printError "Failed to copy BLS files to ${BLS_dir}${zipl_postfix} due to ${out}."
+            exit 16
+          fi
+          # Add ${deviceMountPoint} as prefix of "linux | initrd" to BLS files of the copy of BLS_dir
+          sed -i "s|linux[[:space:]]\+/|linux ${deviceMountPoint}/|" ${deviceMountPoint}/${BLS_dir}${zipl_postfix}/*.conf
+          sed -i "s|initrd[[:space:]]\+/|initrd ${deviceMountPoint}/|" ${deviceMountPoint}/${BLS_dir}${zipl_postfix}/*.conf
+        fi
+        # Refresh bootmap without chroot
+        # -b <BLS DIRECTORY>: To parse BootLoaderSpec config files.
+        #                     If none is supplied, the /boot/loader/entries directory is used.
+        cmd_zipl="${deviceMountPoint}/usr/sbin/zipl -V -c ${deviceMountPoint}/${zipl_conf}${zipl_postfix} -b ${deviceMountPoint}/${BLS_dir}${zipl_postfix} 2>&1"
+        out_zipl=`eval ${cmd_zipl}`
+        rc_zipl=$?
+      fi
+    fi
   elif [[ $os == "" ]]; then
     inform "This is not the root disk, zipl will not be executed on it"
   else
     inform "The os version is: $os, this is not a supported linux distro"
   fi
 
-  # Remove dirty data in /etc/fstab left by the previous vm deploy
-  # remove lines containing "/mnt/ephemeral" or " swap swap "
-  # TODO: need to update the implementation method when later the ephemeral
-  # mount point maybe changed to user configurable, to not hardcode to /mnt/ephemeralxxx
-  inform "Updating ${deviceMountPoint}/etc/fstab"
-  sed -i '/\/mnt\/ephemeral/d' ${deviceMountPoint}/etc/fstab
-  sed -i '/ swap swap /d' ${deviceMountPoint}/etc/fstab
+  # Log zipl command
+  inform "zipl command: $cmd_zipl"
+  # Log zipl.conf
+  out=`cat ${deviceMountPoint}/${zipl_conf}`
+  inform "zipl.conf content: $out"
 
-  # Remove stale /etc/multipath/bindings and /etc/multipath/wwids
-  # These files may contain the old info of the captured base vm,
-  # which disrupts the volume bindings of the new vm deployed from above captured image, resulting
-  #  a. mpath name inconsistent between 'df' and 'multipath'
-  #  b. in some scenairo, boot-volume extend partition fail due to 'a'
-  # By removing them, they can be recreated later with correct volume bindings
-  # when multipathd start at vm boot time.
-  inform "Move stale multipath bindings and wwids if any"
-  if [[ -r "${deviceMountPoint}/etc/multipath/bindings" ]]; then
-    mv ${deviceMountPoint}/etc/multipath/bindings ${deviceMountPoint}/etc/multipath/bindings.bak
-  fi
-  if [[ -r "${deviceMountPoint}/etc/multipath/wwids" ]]; then
-    mv ${deviceMountPoint}/etc/multipath/wwids ${deviceMountPoint}/etc/multipath/wwids.bak
-  fi
-
-  # Refresh bootmap
-  out=`chroot $deviceMountPoint /sbin/zipl 2>&1`
-  rc=$?
-  if [[ $rc -ne 0 ]]; then
-    printError "Failed to execute zipl on $os due to $out."
+  # Check zipl result
+  if [[ $rc_zipl -ne 0 ]]; then
+    printError "Failed to execute zipl on $os due to $out_zipl."
     return 1
+  else
+    inform "Successed to execute zipl on $os. Output: $out_zipl"
   fi
+  
   # Sync to ensure cached date writen back to target disk
   blockdev --flushbufs $diskPath > /dev/null
 


### PR DESCRIPTION
In the current refreshbootmap implementation, we use chroot to do zipl to refresh the bootloader of guest vm. In order to be able to chroot, we need to bind mount several system dirs of the compute node

This implementation has been proofed to sometimes cause the compute system down：

It is dangerous to mount system dirs and chroot. And zipl command has the support of specifying the initramfs/kernel path parameter to refresh bootloader.

With this PR:
- it changes temporary mount point from /mnt to /tmp
- it enable zipl for RHEL7/RHEL8 without chroot by specifing the path of zipl.conf and BootLoaderSpec dir.
```shell
#RHEL8 support use -b to specify BootLoaderSpec files
  ${deviceMountPoint}/usr/sbin/zipl -V \
    -c ${deviceMountPoint}/etc/zipl.conf \
    -b ${deviceMountPoint}/boot/loader/entries
#RHEL7
  ${deviceMountPoint}/usr/sbin/zipl -V \
    -c ${deviceMountPoint}/etc/zipl.conf
```
