### PR TITLE
disable allow_lun_scan when modprobe zfcp

### DIFF
--- a/zthin-parts/zthin/bin/refresh_bootmap
+++ b/zthin-parts/zthin/bin/refresh_bootmap
@@ -710,6 +710,8 @@ function refreshFCPBootmap {
   enable_zfcp_mod=`lsmod | grep zfcp`
   if [ -z "$enable_zfcp_mod" ];then
       modprobe zfcp
+      # disable allow_lun_scan
+      echo N > /sys/module/zfcp/parameters/allow_lun_scan
   fi
 
   local zthinUserID=$(vmcp q userid | awk '{printf $1}')


### PR DESCRIPTION
if zfcp module is manually removed by user, when we add it back, we should disable it.

Signed-off-by: dyyang <dyyang@cn.ibm.com>