### PR TITLE
add APIs of operating FCP usage

### DIFF
--- a/doc/source/parameters.yaml
+++ b/doc/source/parameters.yaml
@@ -1144,6 +1144,21 @@ last_access_time:
   in: body
   required: true
   type: float
+fcp_id:
+  description: |
+    ID of FCP device.
+  in: path
+  required: true
+  type: string
+fcp_usage:
+  description: |
+    FCP usage, contains 3 values [userid, reserved, connections].
+    ``userid`` is the userid this fcp belongs to.
+    ``reserved`` is 0 or 1, represent the fcp is been used or not.
+    ``connections`` is non-negative value, means the count of volumes on this FCP.
+  in: body
+  required: true
+  type: list
 fcp_list:
   description: |
     FCP devices list.
@@ -1195,3 +1210,16 @@ fcp_reserve:
   in: body
   required: true
   type: boolean
+fcp_reserved:
+  description: |
+    If value is 1, means this FCP device is using by one userid.
+    If value is 0, means this FCP device can be operated.
+  in: body
+  required: true
+  type: integer
+fcp_connections:
+  description: |
+    The count of volumes on this FCP device.
+  in: body
+  required: true
+  type: integer

--- a/doc/source/restapi.rst
+++ b/doc/source/restapi.rst
@@ -406,6 +406,85 @@ Get volume connector for z/VM.
 .. literalinclude:: ../../zvmsdk/tests/fvt/api_templates/test_get_volume_connector.tpl
    :language: javascript
 
+Get all FCP Usage of specified userid
+---------------------------------------
+
+**GET /volumes/fcp**
+
+Get all the FCP usage in database for z/VM.
+
+* Request:
+
+.. restapi_parameters:: parameters.yaml
+
+  - userid: guest_userid
+
+* Response code:
+
+  HTTP status code 200 on success.
+
+* Response contents:
+
+.. restapi_parameters:: parameters.yaml
+
+  - output: fcp_usage
+
+* Response sample:
+
+.. literalinclude:: ../../zvmsdk/tests/fvt/api_templates/test_get_all_fcp_usage.tpl
+
+Get FCP Usage
+--------------------
+
+**GET /volumes/fcp/{fcp_id}**
+
+Get the FCP usage in database for z/VM.
+
+* Request:
+
+.. restapi_parameters:: parameters.yaml
+
+  - fcp_id: fcp_id
+
+* Response code:
+
+  HTTP status code 200 on success.
+
+* Response contents:
+
+.. restapi_parameters:: parameters.yaml
+
+  - output: fcp_usage
+
+* Response sample:
+
+.. literalinclude:: ../../zvmsdk/tests/fvt/api_templates/test_get_fcp_usage.tpl
+
+Set FCP Usage
+--------------------
+
+**PUT /volumes/fcp/{fcp_id}**
+
+Set the FCP usage in database for z/VM.
+
+* Request:
+
+.. restapi_parameters:: parameters.yaml
+
+  - fcp_id: fcp_id
+  - userid: guest_userid
+  - reserved: fcp_reserve
+  - connections: fcp_connections
+
+* Response code:
+
+  HTTP status code 200 on success.
+
+* Response contents:
+
+  No response.
+
+
 Get Guests stats including cpu and memory
 -----------------------------------------
 

--- a/zvmconnector/restclient.py
+++ b/zvmconnector/restclient.py
@@ -441,6 +441,30 @@ def req_get_volume_connector(start_index, *args, **kwargs):
     return url, body
 
 
+def req_get_all_fcp_usage(start_index, *args, **kwargs):
+    url = '/volumes/fcp'
+    userid = kwargs.get('userid', None)
+    if userid:
+        url += "?userid=%s" % userid
+    body = None
+    return url, body
+
+
+def req_get_fcp_usage(start_index, *args, **kwargs):
+    url = '/volumes/fcp/%s'
+    body = None
+    return url, body
+
+
+def req_set_fcp_usage(start_index, *args, **kwargs):
+    url = '/volumes/fcp/%s'
+    body = {'info': {'userid': args[start_index],
+                     'reserved': args[start_index + 1],
+                     'connections': args[start_index + 2]}}
+    fill_kwargs_in_body(body['info'], **kwargs)
+    return url, body
+
+
 def req_host_get_info(start_index, *args, **kwargs):
     url = '/host'
     body = None
@@ -811,6 +835,21 @@ DATABASE = {
         'args_required': 1,
         'params_path': 1,
         'request': req_get_volume_connector},
+    'get_all_fcp_usage': {
+        'method': 'GET',
+        'args_required': 0,
+        'params_path': 0,
+        'request': req_get_all_fcp_usage},
+    'get_fcp_usage': {
+        'method': 'GET',
+        'args_required': 1,
+        'params_path': 1,
+        'request': req_get_fcp_usage},
+    'set_fcp_usage': {
+        'method': 'PUT',
+        'args_required': 4,
+        'params_path': 1,
+        'request': req_set_fcp_usage},
     'host_get_info': {
         'method': 'GET',
         'args_required': 0,

--- a/zvmsdk/sdkwsgi/handler.py
+++ b/zvmsdk/sdkwsgi/handler.py
@@ -57,6 +57,13 @@ ROUTE_LIST = (
     ('/volumes/conn/{userid}', {
         'GET': volume.get_volume_connector,
     }),
+     ('/volumes/fcp', {
+        'GET': volume.get_all_fcp_usage,
+    }),
+     ('/volumes/fcp/{fcp_id}', {
+        'GET': volume.get_fcp_usage,
+        'PUT': volume.set_fcp_usage,
+    }),
     ('/volumes/volume_refresh_bootmap', {
         'PUT': volume.volume_refresh_bootmap,
     }),

--- a/zvmsdk/sdkwsgi/schemas/volume.py
+++ b/zvmsdk/sdkwsgi/schemas/volume.py
@@ -51,6 +51,50 @@ detach = {
 }
 
 
+get_fcp_usage = {
+    'type': 'object',
+    'properties': {
+        'fcp_id': parameter_types.fcp_id,
+    },
+    'required': ['fcp_id'],
+    'additionalProperties': False,
+}
+
+
+get_all_fcp_usage = {
+    'type': 'object',
+    'properties': {
+        'userid': parameter_types.userid_list_array,
+    },
+    'additionalProperties': False,
+}
+
+
+set_fcp_usage = {
+    'type': 'object',
+    'properties': {
+        'info': {
+            'type': 'object',
+            'properties': {
+                'userid': parameter_types.userid,
+                'reserved': {
+                    'type': ['integer'],
+                    'minimum': 0,
+                    'maximum': 1,
+                },
+                'connections': {
+                    'type': ['integer'],
+                },
+            },
+            'required': ['reserved', 'connections'],
+            'additionalProperties': False,
+        }
+    },
+    'required': ['info'],
+    'additionalProperties': False,
+}
+
+
 get_volume_connector = {
     'type': 'object',
     'properties': {

--- a/zvmsdk/sdkwsgi/validation/parameter_types.py
+++ b/zvmsdk/sdkwsgi/validation/parameter_types.py
@@ -480,6 +480,13 @@ fcp = {
 
 }
 
+fcp_id = {
+    'type': 'string',
+    'minLength': 4,
+    'maxLength': 4,
+    'pattern': '^[0-9a-fA-F]{4}$'
+}
+
 wwpn = {
     'type': 'array',
     'items': {
@@ -564,7 +571,7 @@ max_cpu = {
 max_mem = {
     'type': 'string',
     'pattern': '^[1-9][0-9]{0,3}[m|M|g|G]$'
-    }
+}
 
 hostname = {
     'oneOf': [

--- a/zvmsdk/tests/fvt/api_templates/test_get_all_fcp_usage.tpl
+++ b/zvmsdk/tests/fvt/api_templates/test_get_all_fcp_usage.tpl
@@ -1,0 +1,12 @@
+{
+    "rs": 0,
+    "overallRC": 0,
+    "modID": null,
+    "rc": 0,
+    "errmsg": "",
+    "output": {
+        '1a11': ['userid', 0, 0],
+        '1a12': ['CBM54019', 0, 0],
+        '1a10': ['CBM5400E', 0, 0]
+    }
+}

--- a/zvmsdk/tests/fvt/api_templates/test_get_fcp_usage.tpl
+++ b/zvmsdk/tests/fvt/api_templates/test_get_fcp_usage.tpl
@@ -1,0 +1,8 @@
+{
+    "rs": 0,
+    "overallRC": 0,
+    "modID": null,
+    "rc": 0,
+    "errmsg": "",
+    "output": ['testid', 1, 3]
+}


### PR DESCRIPTION
this API is used to set connections and reserved values
in database when initialize_connection or terminate_connection fail.

Signed-off-by: SharpRazor <bjcb@cn.ibm.com>