### PR TITLE
refresh bootmap for RHCOS

### DIFF
--- a/doc/source/errcode.csv
+++ b/doc/source/errcode.csv
@@ -35,6 +35,7 @@
 300;30;300;7;Refresh bootmap timeout with reason %(msg)s
 300;30;300;8;Failed to attach volume to instance %(userid)s with reason %(msg)s
 300;30;300;9;Failed to detach volume from instance %(userid)s with reason %(msg)s
+300;30;300;10;Failed to refresh bootmap for RHCOS: transportfiles are required
 **Operation on Image failed**
 300;40;300;1;Database operation failed, error: %(msg)s
 300;40;300;2;No image schema found for %(schema)s

--- a/doc/source/parameters.yaml
+++ b/doc/source/parameters.yaml
@@ -682,7 +682,7 @@ export_image_dict:
 transportfiles:
   description: |
     The files path that used to customize the vm. For RHCOS image, the transportfiles
-    should be the ignition file.
+    should be the ignition file and it's required.
   in: body
   required: false
   type: string
@@ -989,6 +989,25 @@ guest_networks_list:
   in: body
   required: true
   type: list
+guest_networks:
+  description: |
+    Required only if refresh volume bootmap for RHCOS.
+    Network info list of guest. It has one dictionary that contain some of the below
+    keys for each interface. All the keys are optional \:
+
+    - ``ip_addr``: the IP address of the interface, ``cidr`` is required if ip address
+      is set
+    - ``dns_addr``: dns addresses list
+    - ``gateway_addr``: gateway address
+    - ``cidr``: cidr format
+    - ``nic_vdev``: nic device number, 1- to 4- hexadecimal digits
+    - ``mac_addr``: mac address
+    - ``nic_id``: nic identifier
+    - ``osa_device``: OSA device number, 1- to 4- hexadecimal digits
+    - ``hostname``: the hostname of the guest
+  in: body
+  required: false
+  type: list
 vswitch_info:
   description: |
     The vswitch update info.
@@ -1215,13 +1234,6 @@ ip_version:
   in: body
   required: true
   type: string
-skipzipl:
-  description: |
-    whether or not to skip the step of refresh bootmap. If true, only return the valid wwpn list.
-    Default value is False.
-  in: body
-  required: false
-  type: bool
 fcp_reserve:
   description: |
     If or not reserve the FCP devices.

--- a/doc/source/restapi.rst
+++ b/doc/source/restapi.rst
@@ -367,7 +367,8 @@ Refresh a volume's bootmap info.
   - fcpchannel: fcp_list
   - wwpn: wwpn_list
   - lun: lun
-  - skipzipl: skipzipl
+  - transportfiles: transportfiles
+  - guest_networks: guest_networks
 
 * Request sample:
 

--- a/zthin-parts/zthin/bin/refresh_bootmap
+++ b/zthin-parts/zthin/bin/refresh_bootmap
@@ -1,6 +1,6 @@
 #!/bin/bash
 ###############################################################################
-# Copyright 2020 IBM Corp.
+# Copyright 2020,2021 IBM Corp.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -257,7 +257,9 @@ function parseArgs {
   isOption -f --fcpchannel "   FCP channel IDs. Support multi fcpchannel, split by ','."
   isOption -w --wwpn "         World Wide Port Name IDs. Support multi wwpn, split by ',' Example: 5005076802400c1b"
   isOption -l --lun "          Logical Unit Number ID. Example: 0000000000000000"
-  isOption -s --skipzipl "     Whether skip ZIPL, if YES, only return physical World Wide Port Name IDs"
+  isOption -i --ignitionurl "  (RHCOS only) The URL or local path that points to RHCOS ignition file"
+  isOption -n --nicid "        (RHCOS only) The nic ID. Example: 0.0.1000,0.0.1001,0.0.1002"
+  isOption -p --ipconfig "     (RHCOS only) The network configuration info. In format of <client-IP>:[<peer>]:<gateway-IP>:<netmask>:<client_hostname>:<interface>:none[:[<dns1>][:<dns2>]]"
 
   if [[ $printHelp ]]; then
     printHelp
@@ -283,8 +285,16 @@ function parseArgs {
       lun="${i#*=}"
       shift # past argument=value
       ;;
-      -s|--skipzipl=*)
-      skipzipl="${i#*=}"
+      -i|--ignitionurl=*)
+      ignitionurl="${i#*=}"
+      shift # past argument=value
+      ;;
+      -n|--nicid=*)
+      nicid="${i#*=}"
+      shift # past argument=value
+      ;;
+      -p|--ipconfig=*)
+      ipconfig="${i#*=}"
       shift # past argument=value
       ;;
       --default)
@@ -322,6 +332,13 @@ function checkSanity {
   else
     printError "Unknown device type."
     exit 5
+  fi
+  if [[ ignitionurl || nicid || ipconfig ]]; then
+    # ignitionurl, nicid and ipconfig are required for RHCOS BFV
+    if [[ ! ignitionurl || ! nicid || ! ipconfig ]]; then
+        printError "Please specify ignitionurl, nicid and ipconfig."
+        exit 6
+    fi
   fi
 } #checkSanity
 
@@ -440,6 +457,128 @@ function probePartition {
     inform "After partprobe, /dev/mapper/ folder content: ${disk_mapper_folder}."
 }
 
+function mount_boot_partition_rhcos {
+    # The location of the mountpoint
+    mountpoint=$1
+
+    if [ ! -d $mountpoint ]; then
+        printError "mountpoint $mountpoint must be a directory"
+        exit 17
+    fi
+
+    # Get the boot partition
+    set -o pipefail
+    let retry=0
+    while true
+    do
+        eval $(lsblk "${DEST_DEV}" --output LABEL,NAME --pairs | grep 'LABEL="boot' | tr ' ' '\n' | tail -n 1)
+        if [[ ${NAME} =~ "mpath" ]]; then
+            mount "/dev/mapper/${NAME}" "$mountpoint"
+        else
+            mount "/dev/${NAME}" "$mountpoint"
+        fi
+        RETCODE=$?
+        if [[ $RETCODE -ne 0 ]]; then
+            if [[ $retry -lt 30 ]]; then
+                # retry and sleep to allow udevd to populate the disk
+                sleep 1
+                let retry=$retry+1
+                continue
+            fi
+            printError "failed mounting boot partition"
+            exit 17
+        fi
+        break;
+    done
+    set +o pipefail
+} #mount_boot_partition_rhcos{}
+
+function update_zipl_bootloader_rhcos {
+    inform "Updating zipl"
+
+    if [[ $paths_count -gt 8 ]]; then
+      inform "valid paths count $paths_count is greater than 8, do truncation to get the rd.zfcp parameter."
+      truncaterdzfcp
+    fi
+    inform "Final rd.zfcp value is: $rd_zfcp."
+
+    # Create a mount dir.
+    rhcosTempDir=$(/usr/bin/mktemp -d /tmp/XXXXX)
+    rc=$?
+    if [[ $rc -ne 0 ]]; then
+      printError "Create mount dir fails, rc: $rc."
+      exit 7
+    fi
+    deviceMountPoint=$rhcosTempDir/boot_partition
+    mkdir -p $deviceMountPoint
+
+    # Register EXIT signal for umount dir and disconnect fcp devices
+    trap 'cleanup_umountdir_and_disconnect_fcp' EXIT
+
+    mount_boot_partition_rhcos $deviceMountPoint
+
+    #Get ignition config file
+    mkdir -p "$deviceMountPoint/ignition"
+    if [ -f "$ignitionurl" ]; then
+        inform "$ignitionurl is FILE"
+        cat $ignitionurl > $deviceMountPoint/ignition/config.ign 2>/dev/null
+    else
+        inform "$ignitionurl is URL"
+        let retry=0
+        while true
+        do
+            curl -Lf $ignitionurl >$deviceMountPoint/ignition/config.ign 2>/dev/null
+            RETCODE=$?
+            if [ $RETCODE -ne 0 ]
+            then
+                if [[ $RETCODE -eq 22 && $retry -lt 5 ]]
+                then
+                    # Network isn't up yet, sleep for a sec and retry
+                    sleep 1
+                    let retry=$retry+1
+                    continue
+                else
+                    printError "failed fetching ignition config from ${ignitionurl}: ${RETCODE}"
+                    exit 17
+                fi
+                inform "fetching ignition config from ${ignitionurl}: ${RETCODE}"
+            else
+                inform "Successfully get the ignition config"
+                break;
+            fi
+        done
+    fi
+
+    blsfile=$(ls $deviceMountPoint/loader/entries/*.conf)
+    #Get zipl config file for parameters
+   
+    nameserver1=$(echo $ipconfig| awk -F: '{print $8}')    
+    nameserver2=$(echo $ipconfig| awk -F: '{print $9}')
+    if [ $nameserver1  ]; then 
+        nameserver1='nameserver='${nameserver1}
+    fi
+    if [ $nameserver2  ]; then 
+        nameserver2='nameserver='${nameserver2}
+    fi
+
+    echo "$(grep options $blsfile | cut -d' ' -f2-) zfcp.allow_lun_scan=0 rw $rd_zfcp rd.znet=qeth,$nicid,layer2=1,portno=0 ignition.firstboot=1 rd.neednet=1 ip=$ipconfig $nameserver1 $nameserver2" > $rhcosTempDir/zipl_prm
+    ziplstr=`cat $rhcosTempDir/zipl_prm`
+    inform "zipl param string: $ziplstr"
+
+    #Run zipl to update bootloader
+    zipl --verbose -p $rhcosTempDir/zipl_prm -i $(ls $deviceMountPoint/ostree/*/*vmlinuz*) -r $(ls $deviceMountPoint/ostree/*/*initramfs*) --target $deviceMountPoint
+    if [[ $? -ne 0 ]]; then
+        printError "failed updating bootloder"
+        exit 17
+    fi
+    #Update BLS config file for reboot
+    sed -i -e 's/ignition.firstboot=1//' $rhcosTempDir/zipl_prm
+    sed -e '/options/d' $blsfile > $rhcosTempDir/blsfile
+    echo "options $(cat $rhcosTempDir/zipl_prm) " >> $rhcosTempDir/blsfile
+    cat $rhcosTempDir/blsfile > $blsfile
+    blockdev --flushbufs ${DEST_DEV} > /dev/null
+} #update_zipl_bootloader_rhcos{}
+
 function refreshZIPL {
   : SOURCE: ${BASH_SOURCE}
   : STACK:  ${FUNCNAME[@]}
@@ -453,14 +592,16 @@ function refreshZIPL {
   zipl_conf='etc/zipl.conf'
   zipl_postfix='_zipl_postfix'
   BLS_dir='boot/loader/entries'
-
-  if [[ $skipzipl = 'YES'  ]]; then
-    # this is the part of return info for upper layer(smtclient)
-    inform "RESULT PATHS: $valid_paths_str"
-    return
-  fi
-
   inform "Begin to refreshZIPL."
+
+  if [[ $ignitionurl ]]; then
+      # refresh bootmap for RHCOS
+      DEST_DEV="/dev/disk/by-path/ccw-0.0.${first_fcp}-zfcp-0x${first_wwpn}:${lun}"
+      inform "refreshing bootmap for RHCOS"
+      update_zipl_bootloader_rhcos
+      inform "RESULT PATHS: $valid_paths_str"
+      exit 0
+  fi
 
   if [[ ! -e "$devNode" ]]; then
     # first, run partprobe to refresh partition table if multipath is enabled
@@ -860,7 +1001,7 @@ function refreshFCPBootmap {
       # For blockdev command use.
       inform "Multipath is not enabled, using single path devNode: $devNode."
   fi
-  
+
   refreshZIPL $devNode
 } #refreshFCPBootmap
 

--- a/zvmconnector/restclient.py
+++ b/zvmconnector/restclient.py
@@ -416,13 +416,15 @@ def req_volume_refresh_bootmap(start_index, *args, **kwargs):
     fcpchannel = kwargs.get('fcpchannels', None)
     wwpn = kwargs.get('wwpn', None)
     lun = kwargs.get('lun', None)
-    skipzipl = kwargs.get('skipzipl', False)
+    transportfiles = kwargs.get('transportfiles', '')
+    guest_networks = kwargs.get('guest_networks', [])
     body = {'info':
         {
             "fcpchannel": fcpchannel,
             "wwpn": wwpn,
             "lun": lun,
-            "skipzipl": skipzipl,
+            "transportfiles": transportfiles,
+            "guest_networks": guest_networks,
         }
     }
     fill_kwargs_in_body(body['info'], **kwargs)

--- a/zvmsdk/api.py
+++ b/zvmsdk/api.py
@@ -1,4 +1,4 @@
-# Copyright 2017,2018 IBM Corp.
+# Copyright 2017,2021 IBM Corp.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -1652,16 +1652,46 @@ class SDKAPI(object):
         """
         self._volumeop.attach_volume_to_instance(connection_info)
 
-    def volume_refresh_bootmap(self, fcpchannels, wwpns, lun, skipzipl=False):
+    def volume_refresh_bootmap(self, fcpchannels, wwpns, lun,
+                               transportfiles=None, guest_networks=None):
         """ Refresh a volume's bootmap info.
 
         :param list of fcpchannels
         :param list of wwpns
         :param string lun
-        :param boolean skipzipl: whether ship zipl, only return valid paths
+        :param transportfiles: (str) the files that used to customize the vm
+        :param list guest_networks: a list of network info for the guest.
+               It has one dictionary that contain some of the below keys for
+               each network, the format is:
+               {'ip_addr': (str) IP address or None,
+               'dns_addr': (list) dns addresses or None,
+               'gateway_addr': (str) gateway address or None,
+               'cidr': (str) cidr format,
+               'nic_vdev': (str)nic VDEV, 1- to 4- hexadecimal digits or None,
+               'nic_id': (str) nic identifier or None,
+               'mac_addr': (str) mac address or None, it is only be used when
+               changing the guest's user direct. Format should be
+               xx:xx:xx:xx:xx:xx, and x is a hexadecimal digit
+               'osa_device': (str) OSA address or None,
+               'hostname': (str) Optional. The hostname of the guest}
+
+               Example for guest_networks:
+               [{'ip_addr': '192.168.95.10',
+               'dns_addr': ['9.0.2.1', '9.0.3.1'],
+               'gateway_addr': '192.168.95.1',
+               'cidr': "192.168.95.0/24",
+               'nic_vdev': '1000',
+               'mac_addr': '02:00:00:12:34:56',
+               'hostname': 'instance-00001'},
+               {'ip_addr': '192.168.96.10',
+               'dns_addr': ['9.0.2.1', '9.0.3.1'],
+               'gateway_addr': '192.168.96.1',
+               'cidr': "192.168.96.0/24",
+               'nic_vdev': '1003}]
         """
         return self._volumeop.volume_refresh_bootmap(fcpchannels, wwpns, lun,
-                                                     skipzipl=skipzipl)
+                                                transportfiles=transportfiles,
+                                                guest_networks=guest_networks)
 
     def volume_detach(self, connection_info):
         """ Detach a volume from a guest. It's prerequisite to active multipath
@@ -1709,7 +1739,8 @@ class SDKAPI(object):
                'mac_addr': (str) mac address or None, it is only be used when
                changing the guest's user direct. Format should be
                xx:xx:xx:xx:xx:xx, and x is a hexadecimal digit
-               'osa_device': (str) OSA address or None}
+               'osa_device': (str) OSA address or None,
+               'hostname': (str) Optional. The hostname of the vm.}
 
                Example for guest_networks:
                [{'ip_addr': '192.168.95.10',
@@ -1717,7 +1748,8 @@ class SDKAPI(object):
                'gateway_addr': '192.168.95.1',
                'cidr': "192.168.95.0/24",
                'nic_vdev': '1000',
-               'mac_addr': '02:00:00:12:34:56'},
+               'mac_addr': '02:00:00:12:34:56',
+               'hostname': 'instance-00001'},
                {'ip_addr': '192.168.96.10',
                'dns_addr': ['9.0.2.1', '9.0.3.1'],
                'gateway_addr': '192.168.96.1',

--- a/zvmsdk/networkops.py
+++ b/zvmsdk/networkops.py
@@ -1,4 +1,4 @@
-# Copyright 2017,2020 IBM Corp.
+# Copyright 2017,2021 IBM Corp.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -107,7 +107,7 @@ class NetworkOPS(object):
                               active=False):
         if self._smtclient.is_rhcos(os_version):
             linuxdist = self._dist_manager.get_linux_dist(os_version)()
-            linuxdist.create_coreos_parameter(network_info, userid)
+            linuxdist.create_coreos_parameter_temp_file(network_info, userid)
         else:
             network_file_path = self._smtclient.get_guest_temp_path(userid)
             LOG.debug('Creating folder %s to contain network configuration '

--- a/zvmsdk/returncode.py
+++ b/zvmsdk/returncode.py
@@ -243,6 +243,8 @@ errors = {
                    "%(userid)s with reason %(msg)s",
                 9: "Failed to detach volume from instance "
                    "%(userid)s with reason %(msg)s",
+                10: "Failed to refresh bootmap for RHCOS: "
+                    "transportfiles are required",
                 },
                "Operation on Volume failed"
                ],

--- a/zvmsdk/sdkwsgi/handlers/volume.py
+++ b/zvmsdk/sdkwsgi/handlers/volume.py
@@ -1,4 +1,4 @@
-# Copyright 2017,2018 IBM Corp.
+# Copyright 2017,2021 IBM Corp.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -78,9 +78,11 @@ class VolumeAction(object):
                                         fcp, userid, reserved,
                                         connections)
 
-    def volume_refresh_bootmap(self, fcpchannel, wwpn, lun, skipzipl):
+    def volume_refresh_bootmap(self, fcpchannel, wwpn, lun,
+                               transportfiles, guest_networks):
         info = self.client.send_request('volume_refresh_bootmap',
-                                        fcpchannel, wwpn, lun, skipzipl)
+                                        fcpchannel, wwpn, lun,
+                                        transportfiles, guest_networks)
         return info
 
 
@@ -131,14 +133,17 @@ def volume_detach(req):
 @tokens.validate
 def volume_refresh_bootmap(req):
 
-    def _volume_refresh_bootmap(req, fcpchannel, wwpn, lun, skipzipl):
+    def _volume_refresh_bootmap(req, fcpchannel, wwpn, lun,
+                                transportfiles, guest_networks):
         action = get_action()
-        return action.volume_refresh_bootmap(fcpchannel, wwpn, lun, skipzipl)
+        return action.volume_refresh_bootmap(fcpchannel, wwpn, lun,
+                                             transportfiles, guest_networks)
 
     body = util.extract_json(req.body)
     info = _volume_refresh_bootmap(req, body['info']['fcpchannel'],
                                    body['info']['wwpn'], body['info']['lun'],
-                                   body['info'].get('skipzipl', False))
+                                   body['info'].get('transportfiles', ""),
+                                   body['info'].get('guest_networks', []))
     info_json = json.dumps(info)
     req.response.body = utils.to_utf8(info_json)
     req.response.content_type = 'application/json'

--- a/zvmsdk/sdkwsgi/validation/parameter_types.py
+++ b/zvmsdk/sdkwsgi/validation/parameter_types.py
@@ -435,6 +435,14 @@ command = {
     'type': 'string'
 }
 
+hostname = {
+    'oneOf': [
+        {'type': 'null'},
+        {'type': 'string', 'minLength': 1, 'maxLength': 255,
+         'pattern': '^[a-zA-Z0-9-._]*$'}
+    ]
+}
+
 network_list = {
     'type': 'array',
     'items': {
@@ -448,7 +456,8 @@ network_list = {
             'cidr': cidr,
             'nic_vdev': vdev,
             'nic_id': {'type': 'string'},
-            'osa_device': vdev},
+            'osa_device': vdev,
+            'hostname': hostname},
         'dependencies': {
             'ip_addr': ['cidr']
         }
@@ -581,14 +590,6 @@ max_cpu = {
 max_mem = {
     'type': 'string',
     'pattern': '^[1-9][0-9]{0,3}[m|M|g|G]$'
-}
-
-hostname = {
-    'oneOf': [
-        {'type': 'null'},
-        {'type': 'string', 'minLength': 1, 'maxLength': 255,
-         'pattern': '^[a-zA-Z0-9-._]*$'}
-    ]
 }
 
 vlan_id_or_minus_1 = {

--- a/zvmsdk/tests/fvt/api_templates/test_refresh_bootmap.tpl
+++ b/zvmsdk/tests/fvt/api_templates/test_refresh_bootmap.tpl
@@ -3,5 +3,27 @@
             "fcpchannel": ['5d71'],
             "wwpn": ['5005076802100c1a', '5005076802200c1b'],
             "lun": '0000000000000000',
+            "transportfiles": "/path/to/transportfiles",
+            "guest_networks": [
+                {   
+                    "ip_addr": "192.168.95.10",
+                    "dns_addr": ["9.0.2.1", "9.0.3.1"],
+                    "gateway_addr": "192.168.95.1",
+                    "cidr": "192.168.95.0/24",
+                    "nic_vdev": "1000",
+                    "mac_addr": "02:00:00:12:34:56",
+                    "nic_id": "111-222-333",
+                    "osa_device": "8080",
+                    "hostname": "hostname"
+                },
+                {
+                    "ip_addr": "192.168.95.11",
+                    "gateway_addr": "192.168.95.1",
+                    "cidr": "192.168.95.0/24",
+                    "nic_vdev": "2000",
+                    "mac_addr": "02:00:00:12:34:78",
+                    "nic_id": "444-555-666"
+                }
+            ],
         }
 }

--- a/zvmsdk/tests/unit/sdkwsgi/handlers/test_volume.py
+++ b/zvmsdk/tests/unit/sdkwsgi/handlers/test_volume.py
@@ -1,4 +1,4 @@
-# Copyright 2017 IBM Corp.
+# Copyright 2017,2021 IBM Corp.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -105,4 +105,4 @@ class HandlersVolumeTest(unittest.TestCase):
         volume.volume_refresh_bootmap(self.req)
         mock_detach.assert_called_once_with(
             'volume_refresh_bootmap',
-            fcpchannels, wwpns, lun, False)
+            fcpchannels, wwpns, lun, '', [])

--- a/zvmsdk/tests/unit/test_api.py
+++ b/zvmsdk/tests/unit/test_api.py
@@ -1,4 +1,4 @@
-# Copyright 2017, 2021 IBM Corp.
+# Copyright 2017,2021 IBM Corp.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -390,7 +390,7 @@ class SDKAPITestCase(base.SDKTestCase):
         lun = '01000000000000'
         self.api.volume_refresh_bootmap(fcpchannel, wwpn, lun)
         mock_attach.assert_called_once_with(fcpchannel, wwpn, lun,
-                                            skipzipl=False)
+                                    transportfiles=None, guest_networks=None)
 
     @mock.patch("zvmsdk.volumeop.VolumeOperatorAPI."
                 "detach_volume_from_instance")

--- a/zvmsdk/tests/unit/test_dist.py
+++ b/zvmsdk/tests/unit/test_dist.py
@@ -1,4 +1,4 @@
-# Copyright 2017,2020 IBM Corp.
+# Copyright 2017,2021 IBM Corp.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -255,7 +255,8 @@ class RHCOS4TestCase(base.SDKTestCase):
                         'nic_id': 'adca70f3-8509-44d4-92d4-2c1c14b3f25e'}]
         userid = "FakeID"
         guest_path.return_value = "/tmp/FakeID"
-        res = self.linux_dist.create_coreos_parameter(network_info, userid)
+        res = self.linux_dist.create_coreos_parameter_temp_file(network_info,
+                                                                userid)
         self.assertEqual(res, True)
 
     @mock.patch.object(smtclient.SMTClient, 'get_guest_path')

--- a/zvmsdk/tests/unit/test_smtclient.py
+++ b/zvmsdk/tests/unit/test_smtclient.py
@@ -1570,15 +1570,12 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         fcpchannels = ['5d71']
         wwpns = ['5005076802100c1b', '5005076802200c1b']
         lun = '0000000000000000'
-        skipzipl = True
         execute.side_effect = [(0, "")]
-        self._smtclient.volume_refresh_bootmap(fcpchannels, wwpns, lun,
-                                               skipzipl)
+        self._smtclient.volume_refresh_bootmap(fcpchannels, wwpns, lun)
         refresh_bootmap_cmd = ['sudo', '/opt/zthin/bin/refresh_bootmap',
                                '--fcpchannel=5d71',
                                '--wwpn=5005076802100c1b,5005076802200c1b',
-                               '--lun=0000000000000000',
-                               '--skipzipl=YES']
+                               '--lun=0000000000000000']
         execute.assert_called_once_with(refresh_bootmap_cmd, timeout=600)
 
     @mock.patch.object(zvmutils, 'get_smt_userid')

--- a/zvmsdk/volumeop.py
+++ b/zvmsdk/volumeop.py
@@ -1,4 +1,4 @@
-#    Copyright 2017 IBM Corp.
+#    Copyright 2017,2021 IBM Corp.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -86,10 +86,11 @@ class VolumeOperatorAPI(object):
     def detach_volume_from_instance(self, connection_info):
         self._volume_manager.detach(connection_info)
 
-    def volume_refresh_bootmap(self, fcpchannel, wwpn, lun, skipzipl=False):
-        return self._volume_manager.volume_refresh_bootmap(fcpchannel,
-                                                           wwpn, lun,
-                                                           skipzipl=skipzipl)
+    def volume_refresh_bootmap(self, fcpchannel, wwpn, lun,
+                               transportfiles='', guest_networks=None):
+        return self._volume_manager.volume_refresh_bootmap(fcpchannel, wwpn,
+                                            lun, transportfiles=transportfiles,
+                                            guest_networks=guest_networks)
 
     def get_volume_connector(self, assigner_id, reserve):
         return self._volume_manager.get_volume_connector(assigner_id, reserve)
@@ -835,20 +836,14 @@ class FCPVolumeManager(object):
         LOG.info("Attaching volume to FCP devices %s on machine %s is "
                  "done." % (fcp_list, assigner_id))
 
-    def volume_refresh_bootmap(self, fcpchannels, wwpns, lun, skipzipl=False):
-        """ Refresh a volume's bootmap info.
-
-        :param list of fcpchannels
-        :param list of wwpns
-        :param string lun
-        :param boolean skipzipl: whether ship zipl, only return physical wwpns
-        """
+    def volume_refresh_bootmap(self, fcpchannels, wwpns, lun,
+                               transportfiles=None, guest_networks=None):
         ret = None
         with zvmutils.acquire_lock(self._lock):
             LOG.debug('Enter lock scope of volume_refresh_bootmap.')
             ret = self._smtclient.volume_refresh_bootmap(fcpchannels, wwpns,
-                                                         lun,
-                                                         skipzipl=skipzipl)
+                                        lun, transportfiles=transportfiles,
+                                        guest_networks=guest_networks)
         LOG.debug('Exit lock of volume_refresh_bootmap with ret %s.' % ret)
         return ret
 


### PR DESCRIPTION
Move the steps in RHCOS BFV from unpackdiskimage to refresh_bootmap:
- inject ignition file onto RHCOS boot partition
- get nicID and ipConfig to construct rd.znet and ip kernel cmdline
  and write into BLS file
- refresh bootmap for RHCOS root volume

Add new parameters to the API volume_refresh_bootmap:
- transportfiles: as ignition file
- guest_networks: for getting network info for kernel cmdline

Add logic to inject ignition file into RHCOS boot partition,
generate kernel cmdline and run zipl to setup bootmap.

Support both RHCOS4.6 and RHCOS4.7

Signed-off-by: bjhuangr <bjhuangr@cn.ibm.com>