### PR TITLE
[master]Update a way to get MAC address info in guest_register

### DIFF
--- a/zvmsdk/tests/unit/test_api.py
+++ b/zvmsdk/tests/unit/test_api.py
@@ -424,25 +424,21 @@ class SDKAPITestCase(base.SDKTestCase):
         mock_detach.assert_called_once_with(connection_info)
 
     @mock.patch("zvmsdk.utils.check_userid_exist")
-    @mock.patch("zvmsdk.vmops.VMOps.get_definition_info")
+    @mock.patch("zvmsdk.smtclient.SMTClient.get_adapters_info")
     @mock.patch("zvmsdk.database.GuestDbOperator.add_guest_registered")
     @mock.patch("zvmsdk.database.NetworkDbOperator.switch_add_record")
     def test_guest_register(self, networkdb_add, guestdb_reg,
-                              get_def_info, chk_usr):
+                              get_adapters_info, chk_usr):
         networkdb_add.return_value = ''
         guestdb_reg.return_value = ''
-        info = {}
-        info['user_direct'] = ['USER FBA LBYONLY 2048m 64G G',
-                               'INCLUDE ZCCDFLT', 'COMMAND DEF STOR '
-                               'RESERVED 57344M',
-                               'CPU 00 BASE', 'CPU 01', 'CPU 02',
-                               'CPU 03', 'IPL 0100',
-                               'LOGONBY IAASADM', 'MACHINE ESA 32',
-                               'NICDEF 1000 TYPE QDIO LAN SYSTEM VSC11590 '
-                               'DEVICES 3 MACID EF5091',
-                               'NICDEF 1000 VLAN 8',
-                               '']
-        get_def_info.return_value = info
+        adapters = [{'adapter_address': '1000',
+                     'adapter_status': '02',
+                     'lan_owner': 'SYSTEM',
+                     'lan_name': 'VSC11590',
+                     'mac_address': '02:55:36:EF:50:91',
+                     'mac_ip_version': '4',
+                     'mac_ip_address': '1.2.3.4'}]
+        get_adapters_info.return_value = adapters
         chk_usr.return_value = True
 
         meta_data = 'rhel7'
@@ -457,29 +453,25 @@ class SDKAPITestCase(base.SDKTestCase):
                                               '-5ac4a42f97e7',
                                               'VSC11590')
         guestdb_reg.assert_called_once_with(self.userid, 'rhel7', '1')
-        get_def_info.assert_called_once_with(self.userid)
+        get_adapters_info.assert_called_once_with(self.userid)
         chk_usr.assert_called_once_with(self.userid)
 
     @mock.patch("zvmsdk.utils.check_userid_exist")
-    @mock.patch("zvmsdk.vmops.VMOps.get_definition_info")
+    @mock.patch("zvmsdk.smtclient.SMTClient.get_adapters_info")
     @mock.patch("zvmsdk.database.GuestDbOperator.add_guest_registered")
     @mock.patch("zvmsdk.database.NetworkDbOperator.switch_add_record")
     def test_guest_register_invalid_portmacs(self, networkdb_add, guestdb_reg,
-                              get_def_info, chk_usr):
+                              get_adapters_info, chk_usr):
         networkdb_add.return_value = ''
         guestdb_reg.return_value = ''
-        info = {}
-        info['user_direct'] = ['USER FBA LBYONLY 2048m 64G G',
-                               'INCLUDE ZCCDFLT',
-                               'COMMAND DEF STOR RESERVED 57344M',
-                               'CPU 00 BASE', 'CPU 01', 'CPU 02',
-                               'CPU 03', 'IPL 0100',
-                               'LOGONBY IAASADM', 'MACHINE ESA 32',
-                               'NICDEF 1000 TYPE QDIO LAN SYSTEM VSC11590 '
-                               'DEVICES 3 MACID EF5091',
-                               'NICDEF 1000 VLAN 8',
-                               '']
-        get_def_info.return_value = info
+        adapters = [{'adapter_address': '1000',
+                     'adapter_status': '02',
+                     'lan_owner': 'SYSTEM',
+                     'lan_name': 'VSC11590',
+                     'mac_address': '02:55:36:EF:50:91',
+                     'mac_ip_version': '4',
+                     'mac_ip_address': '1.2.3.4'}]
+        get_adapters_info.return_value = adapters
         chk_usr.return_value = True
 
         meta_data = 'rhel7'
@@ -491,25 +483,21 @@ class SDKAPITestCase(base.SDKTestCase):
                           self.userid, meta_data, net_set, port_macs)
 
     @mock.patch("zvmsdk.utils.check_userid_exist")
-    @mock.patch("zvmsdk.vmops.VMOps.get_definition_info")
+    @mock.patch("zvmsdk.smtclient.SMTClient.get_adapters_info")
     @mock.patch("zvmsdk.database.GuestDbOperator.add_guest_registered")
     @mock.patch("zvmsdk.database.NetworkDbOperator.switch_add_record")
     def test_guest_register_no_port_macs(self, networkdb_add, guestdb_reg,
-                              get_def_info, chk_usr):
+                              get_adapters_info, chk_usr):
         networkdb_add.return_value = ''
         guestdb_reg.return_value = ''
-        info = {}
-        info['user_direct'] = ['USER FBA LBYONLY 2048m 64G G',
-                               'INCLUDE ZCCDFLT', 'COMMAND DEF STOR '
-                               'RESERVED 57344M',
-                               'CPU 00 BASE', 'CPU 01', 'CPU 02',
-                               'CPU 03', 'IPL 0100',
-                               'LOGONBY IAASADM', 'MACHINE ESA 32',
-                               'NICDEF 1000 TYPE QDIO LAN SYSTEM VSC11590 '
-                               'DEVICES 3 MACID EF5091',
-                               'NICDEF 1000 VLAN 8',
-                               '']
-        get_def_info.return_value = info
+        adapters = [{'adapter_address': '1000',
+                     'adapter_status': '02',
+                     'lan_owner': 'SYSTEM',
+                     'lan_name': 'VSC11590',
+                     'mac_address': '02:55:36:EF:50:91',
+                     'mac_ip_version': '4',
+                     'mac_ip_address': '1.2.3.4'}]
+        get_adapters_info.return_value = adapters
         chk_usr.return_value = True
 
         meta_data = 'rhel7'
@@ -520,11 +508,11 @@ class SDKAPITestCase(base.SDKTestCase):
                                               None,
                                               'VSC11590')
         guestdb_reg.assert_called_once_with(self.userid, 'rhel7', '1')
-        get_def_info.assert_called_once_with(self.userid)
+        get_adapters_info.assert_called_once_with(self.userid)
         chk_usr.assert_called_once_with(self.userid)
 
     @mock.patch("zvmsdk.utils.check_userid_exist")
-    @mock.patch("zvmsdk.vmops.VMOps.get_definition_info")
+    @mock.patch("zvmsdk.smtclient.SMTClient.get_adapters_info")
     @mock.patch("zvmsdk.database.GuestDbOperator.add_guest_registered")
     @mock.patch("zvmsdk.database.NetworkDbOperator.switch_add_record")
     @mock.patch("zvmsdk.database.GuestDbOperator.update_guest_by_userid")
@@ -533,7 +521,7 @@ class SDKAPITestCase(base.SDKTestCase):
     @mock.patch("zvmsdk.database.GuestDbOperator.get_guest_by_userid")
     def test_guest_register_guest_in_db(self, get_guest, get_mig_guest,
                               get_comments, update_guest, networkdb_add,
-                              guestdb_reg, get_def_info, chk_usr):
+                              guestdb_reg, get_adapters_info, chk_usr):
         get_guest.return_value = 'fake_guest'
         get_mig_guest.return_value = self.userid + ' other info'
         get_comments.return_value = {'migrated': 1}
@@ -541,7 +529,7 @@ class SDKAPITestCase(base.SDKTestCase):
         # Below mocks shall not be called
         networkdb_add.return_value = ''
         guestdb_reg.return_value = ''
-        get_def_info.return_value = {}
+        get_adapters_info.return_value = []
         chk_usr.return_value = True
 
         meta_data = 'rhel7'
@@ -557,7 +545,7 @@ class SDKAPITestCase(base.SDKTestCase):
 
         networkdb_add.assert_not_called()
         guestdb_reg.assert_not_called()
-        get_def_info.assert_not_called()
+        get_adapters_info.assert_not_called()
 
     @mock.patch("zvmsdk.vmops.VMOps.check_guests_exist_in_db")
     @mock.patch("zvmsdk.database.NetworkDbOperator."


### PR DESCRIPTION
In guest_register, currently MAC address info is fetched
from NICDEF statements in VM's user direct entry. But it
is possible that NICDEF statements don't contain MAC
address information, which results in port information
not written to switch table in zvmsdk network database.

This commit changes the way of getting MAC address info
by using get_adapters_info, which ensures the MAC address
could always be fetched.

Signed-off-by: Shu Juan Zhang <zshujuan@cn.ibm.com>