### PR TITLE
Add support of comment of user direct

### DIFF
--- a/doc/source/parameters.yaml
+++ b/doc/source/parameters.yaml
@@ -139,6 +139,12 @@ guest_account:
   in: body
   required: false
   type: string
+guest_comment_list:
+  description: |
+    comment of the user direct.
+  in: body
+  required: false
+  type: list
 user_profile_guest:
   description: |
     Profile of guest, ``null`` is also allowed.

--- a/doc/source/restapi.rst
+++ b/doc/source/restapi.rst
@@ -149,6 +149,7 @@ Create a vm in z/VM
   - dedicate_vdevs: guest_dedicate_vdevs
   - loaddev: guest_loaddev
   - account: guest_account
+  - comment_list: guest_comment_list
 
 
 * Request sample:

--- a/smtLayer/makeVM.py
+++ b/smtLayer/makeVM.py
@@ -81,7 +81,8 @@ keyOpsList = {
         '--loadportname': ['loadportname', 1, 2],
         '--loadlun': ['loadlun', 1, 2],
         '--vdisk': ['vdisk', 1, 2],
-        '--account': ['account', 1, 2]},
+        '--account': ['account', 1, 2],
+        '--comment': ['comment', 1, 2]},
     'HELP': {},
     'VERSION': {},
      }
@@ -196,6 +197,11 @@ def createVM(rh):
             blocks = MAX_VDISK_BLOCKS
 
         dirLines.append("MDISK %s FB-512 V-DISK %s MWV" % (v[0], blocks))
+
+    if 'comment' in rh.parms:
+        for comment in rh.parms['comment'].split("$@$@$"):
+            if comment:
+                dirLines.append("* %s" % comment.upper())
 
     # Construct the temporary file for the USER entry.
     fd, tempFile = mkstemp()

--- a/smtLayer/tests/unit/test_makeVM.py
+++ b/smtLayer/tests/unit/test_makeVM.py
@@ -189,3 +189,18 @@ class SMTMakeVMTestCase(base.SMTTestCase):
                                     b'COMMAND SET VCONFIG MODE LINUX\n'
                                     b'COMMAND DEFINE CPU 00 TYPE IFL\n'
                                     b'COMMAND DEF STOR RESERVED 0M\n')
+
+    @mock.patch("os.write")
+    def test_create_with_profile(self, write):
+        rh = ReqHandle.ReqHandle(captureLogs=False,
+                                 smt=mock.Mock())
+        parms = {'pw': 'pwd', 'priMemSize': '1024M', 'maxMemSize': '1G',
+                 'privClasses': 'G',
+                 'comment': 'comment1$@$@$this is comment2$@$@$'}
+        rh.parms = parms
+        makeVM.createVM(rh)
+        write.assert_called_with(mock.ANY, b'USER  pwd 1024M 1G G\n'
+                                    b'COMMAND SET VCONFIG MODE LINUX\n'
+                                    b'COMMAND DEFINE CPU 00 TYPE IFL\n'
+                                    b'* COMMENT1\n'
+                                    b'* THIS IS COMMENT2\n')

--- a/zvmsdk/api.py
+++ b/zvmsdk/api.py
@@ -774,7 +774,8 @@ class SDKAPI(object):
                      max_cpu=CONF.zvm.user_default_max_cpu,
                      max_mem=CONF.zvm.user_default_max_memory,
                      ipl_from='', ipl_param='', ipl_loadparam='',
-                     dedicate_vdevs=None, loaddev={}, account=''):
+                     dedicate_vdevs=None, loaddev={}, account='',
+                     comment_list=None):
         """create a vm in z/VM
 
         :param userid: (str) the userid of the vm to be created
@@ -840,6 +841,7 @@ class SDKAPI(object):
         :param account: (str) account string, see
         https://www.ibm.com/docs/en/zvm/6.4?topic=SSB27U_6.4.0/
                 com.ibm.zvm.v640.hcpa5/daccoun.htm#daccoun
+        :param comment_list: (array) a list of comment string
         """
         dedicate_vdevs = dedicate_vdevs or []
 
@@ -924,7 +926,8 @@ class SDKAPI(object):
             return self._vmops.create_vm(userid, vcpus, memory, disk_list,
                                          user_profile, max_cpu, max_mem,
                                          ipl_from, ipl_param, ipl_loadparam,
-                                         dedicate_vdevs, loaddev, account)
+                                         dedicate_vdevs, loaddev, account,
+                                         comment_list)
 
     @check_guest_exist()
     def guest_live_resize_cpus(self, userid, cpu_cnt):

--- a/zvmsdk/sdkwsgi/schemas/guest.py
+++ b/zvmsdk/sdkwsgi/schemas/guest.py
@@ -34,7 +34,8 @@ create = {
                 'ipl_loadparam': parameter_types.ipl_loadparam,
                 'dedicate_vdevs': parameter_types.dedicate_vdevs,
                 'loaddev': parameter_types.loaddev,
-                'account': parameter_types.account
+                'account': parameter_types.account,
+                'comments': parameter_types.comment_list
             },
             'required': ['userid', 'vcpus', 'memory'],
             'additionalProperties': False,

--- a/zvmsdk/sdkwsgi/validation/parameter_types.py
+++ b/zvmsdk/sdkwsgi/validation/parameter_types.py
@@ -356,6 +356,13 @@ disk_list = {
     }
 }
 
+comment_list = {
+    'type': 'array',
+    'items': {
+        'type': 'string'
+    }
+}
+
 live_migrate_parms = {
     'type': 'object',
     'properties': {

--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -576,7 +576,7 @@ class SMTClient(object):
 
     def create_vm(self, userid, cpu, memory, disk_list, profile,
                   max_cpu, max_mem, ipl_from, ipl_param, ipl_loadparam,
-                  dedicate_vdevs, loaddev, account):
+                  dedicate_vdevs, loaddev, account, comment_list):
         """ Create VM and add disks if specified. """
         rd = ('makevm %(uid)s directory LBYONLY %(mem)im %(pri)s '
               '--cpus %(cpu)i --profile %(prof)s --maxCPU %(max_cpu)i '
@@ -610,6 +610,17 @@ class SMTClient(object):
 
         if account:
             rd += ' --account "%s"' % account
+
+        comments = ''
+        for comment in comment_list:
+            comments += comment
+            # This s a dummy spliter and will be used for split
+            # the comment, for example, input comment is
+            # comment1,comment2, it will be constructed into
+            # comment1$@$@$comment2 and send to smtLayer to handle
+            comments += '$@$@$'
+        if comments:
+            rd += ' --comment "%s"' % comments
 
         if loaddev:
             if 'portname' in loaddev:

--- a/zvmsdk/tests/unit/test_api.py
+++ b/zvmsdk/tests/unit/test_api.py
@@ -108,7 +108,7 @@ class SDKAPITestCase(base.SDKTestCase):
                               user_profile, max_cpu, max_mem)
         create_vm.assert_called_once_with(self.userid, vcpus, memory,
                                   disk_list, user_profile, max_cpu, max_mem,
-                                  '', '', '', [], {}, '')
+                                  '', '', '', [], {}, '', None)
 
     @mock.patch("zvmsdk.vmops.VMOps.create_vm")
     def test_guest_create_with_account(self, create_vm):
@@ -125,7 +125,24 @@ class SDKAPITestCase(base.SDKTestCase):
                               account=account)
         create_vm.assert_called_once_with(self.userid, vcpus, memory,
                                   disk_list, user_profile, max_cpu, max_mem,
-                                  '', '', '', [], {}, account)
+                                  '', '', '', [], {}, account, None)
+
+    @mock.patch("zvmsdk.vmops.VMOps.create_vm")
+    def test_guest_create_with_comment(self, create_vm):
+        vcpus = 1
+        memory = 1024
+        disk_list = []
+        user_profile = 'profile'
+        max_cpu = 10
+        max_mem = '4G'
+        comment_list = ["dummy account", "this is a test"]
+
+        self.api.guest_create(self.userid, vcpus, memory, disk_list,
+                              user_profile, max_cpu, max_mem,
+                              comment_list=comment_list)
+        create_vm.assert_called_once_with(self.userid, vcpus, memory,
+                                  disk_list, user_profile, max_cpu, max_mem,
+                                  '', '', '', [], {}, '', comment_list)
 
     @mock.patch("zvmsdk.vmops.VMOps.create_vm")
     def test_guest_create_with_default_profile(self, create_vm):
@@ -141,7 +158,7 @@ class SDKAPITestCase(base.SDKTestCase):
                               user_profile, max_cpu, max_mem)
         create_vm.assert_called_once_with(self.userid, vcpus, memory,
                                   disk_list, 'abc', max_cpu, max_mem,
-                                  '', '', '', [], {}, '')
+                                  '', '', '', [], {}, '', None)
 
     @mock.patch("zvmsdk.vmops.VMOps.create_vm")
     def test_guest_create_with_no_disk_pool(self, create_vm):
@@ -173,7 +190,7 @@ class SDKAPITestCase(base.SDKTestCase):
                               user_profile)
         create_vm.assert_called_once_with(self.userid, vcpus, memory,
                                           disk_list, user_profile, 32, '64G',
-                                          '', '', '', [], {}, '')
+                                          '', '', '', [], {}, '', None)
 
     @mock.patch("zvmsdk.vmops.VMOps.create_vm")
     def test_guest_create_no_disk_pool_force_mdisk(self, create_vm):
@@ -218,7 +235,7 @@ class SDKAPITestCase(base.SDKTestCase):
                               user_profile)
         create_vm.assert_called_once_with(self.userid, vcpus, memory,
                                           disk_list, user_profile, 32, '64G',
-                                          '', '', '', [], {}, '')
+                                          '', '', '', [], {}, '', None)
 
     @mock.patch("zvmsdk.imageops.ImageOps.image_query")
     def test_image_query(self, image_query):

--- a/zvmsdk/tests/unit/test_smtclient.py
+++ b/zvmsdk/tests/unit/test_smtclient.py
@@ -156,7 +156,8 @@ class SDKSMTClientTestCases(base.SDKTestCase):
               '--profile osdflt --maxCPU 10 --maxMemSize 4G --setReservedMem '
               '--logonby "lbyuser1 lbyuser2" --ipl 0100')
         self._smtclient.create_vm(user_id, cpu, memory, disk_list, profile,
-                                   max_cpu, max_mem, '', '', '', [], {}, '')
+                                  max_cpu, max_mem, '', '', '', [], {}, '',
+                                  [])
         request.assert_called_with(rd)
         add_mdisks.assert_called_with(user_id, disk_list)
         add_guest.assert_called_with(user_id)
@@ -185,7 +186,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
               '--logonby "lbyuser1 lbyuser2" --ipl 0100')
         self._smtclient.create_vm(user_id, cpu, memory, disk_list,
                                   profile, max_cpu, max_mem, '',
-                                  '', '', [], {}, '')
+                                  '', '', [], {}, '', [])
         request.assert_called_with(rd)
         add_mdisks.assert_called_with(user_id, disk_list)
         add_guest.assert_called_with(user_id)
@@ -216,7 +217,8 @@ class SDKSMTClientTestCases(base.SDKTestCase):
               '--profile osdflt --maxCPU 10 --maxMemSize 4G --setReservedMem '
               '--logonby "lbyuser1 lbyuser2" --ipl 0100')
         self._smtclient.create_vm(user_id, cpu, memory, disk_list, profile,
-                                  max_cpu, max_mem, '', '', '', [], {}, '')
+                                  max_cpu, max_mem, '', '', '', [], {}, '',
+                                  [])
         request.assert_called_with(rd)
         add_mdisks.assert_called_with(user_id, disk_list)
         add_guest.assert_called_with(user_id)
@@ -241,7 +243,8 @@ class SDKSMTClientTestCases(base.SDKTestCase):
               '--profile osdflt --maxCPU 10 --maxMemSize 4G --setReservedMem '
               '--logonby "lbyuser1 lbyuser2" --vdisk 0100:512M')
         r = self._smtclient.create_vm(user_id, cpu, memory, disk_list, profile,
-                                      max_cpu, max_mem, '', '', '', [], {}, '')
+                                      max_cpu, max_mem, '', '', '', [], {}, '',
+                                      [])
         request.assert_called_with(rd)
         add_mdisks.assert_not_called()
         add_guest.assert_called_with(user_id)
@@ -268,7 +271,8 @@ class SDKSMTClientTestCases(base.SDKTestCase):
               '--profile osdflt --maxCPU 10 --maxMemSize 4G --setReservedMem '
               '--logonby "lbyuser1 lbyuser2" --vdisk 0100:1G')
         r = self._smtclient.create_vm(user_id, cpu, memory, disk_list, profile,
-                                      max_cpu, max_mem, '', '', '', [], {}, '')
+                                      max_cpu, max_mem, '', '', '', [], {}, '',
+                                      [])
         request.assert_called_with(rd)
         add_mdisks.assert_not_called()
         add_guest.assert_called_with(user_id)
@@ -296,7 +300,8 @@ class SDKSMTClientTestCases(base.SDKTestCase):
               '--profile osdflt --maxCPU 10 --maxMemSize 4G --setReservedMem '
               '--logonby "lbyuser1 lbyuser2" --vdisk 0100:2048M')
         r = self._smtclient.create_vm(user_id, cpu, memory, disk_list, profile,
-                                      max_cpu, max_mem, '', '', '', [], {}, '')
+                                      max_cpu, max_mem, '', '', '', [], {}, '',
+                                      [])
         request.assert_called_with(rd)
         add_mdisks.assert_not_called()
         add_guest.assert_called_with(user_id)
@@ -323,7 +328,8 @@ class SDKSMTClientTestCases(base.SDKTestCase):
               '--profile osdflt --maxCPU 10 --maxMemSize 4G --setReservedMem '
               '--logonby "lbyuser1 lbyuser2" --vdisk 0100:2G')
         r = self._smtclient.create_vm(user_id, cpu, memory, disk_list, profile,
-                                      max_cpu, max_mem, '', '', '', [], {}, '')
+                                      max_cpu, max_mem, '', '', '', [], {}, '',
+                                      [])
         request.assert_called_with(rd)
         add_mdisks.assert_not_called()
         add_guest.assert_called_with(user_id)
@@ -349,7 +355,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         self.assertRaises(exception.SDKInvalidInputFormat,
                           self._smtclient.create_vm, user_id, cpu, memory,
                           disk_list, profile, max_cpu, max_mem,
-                          '', '', '', [], {}, '')
+                          '', '', '', [], {}, '', [])
         add_mdisks.assert_not_called()
 
     @mock.patch.object(smtclient.SMTClient, 'add_mdisks')
@@ -371,7 +377,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         self.assertRaises(exception.SDKInvalidInputFormat,
                           self._smtclient.create_vm, user_id, cpu, memory,
                           disk_list, profile, max_cpu, max_mem,
-                          '', '', '', [], {}, '')
+                          '', '', '', [], {}, '', [])
         add_mdisks.assert_not_called()
 
     @mock.patch.object(smtclient.SMTClient, 'add_mdisks')
@@ -393,7 +399,8 @@ class SDKSMTClientTestCases(base.SDKTestCase):
               '--profile osdflt --maxCPU 10 --maxMemSize 4G --setReservedMem '
               '--logonby "lbyuser1 lbyuser2"')
         self._smtclient.create_vm(user_id, cpu, memory, disk_list, profile,
-                                   max_cpu, max_mem, '', '', '', [], {}, '')
+                                  max_cpu, max_mem, '', '', '', [], {}, '',
+                                  [])
         request.assert_called_with(rd)
         add_mdisks.assert_not_called()
         add_guest.assert_called_with(user_id)
@@ -417,7 +424,8 @@ class SDKSMTClientTestCases(base.SDKTestCase):
               '--profile osdflt --maxCPU 10 --maxMemSize 4G --setReservedMem '
               '--logonby "lbyuser1 lbyuser2"')
         self._smtclient.create_vm(user_id, cpu, memory, disk_list, profile,
-                                   max_cpu, max_mem, '', '', '', [], {}, '')
+                                  max_cpu, max_mem, '', '', '', [], {}, '',
+                                  [])
         request.assert_called_with(rd)
         add_mdisks.assert_called_with(user_id, disk_list)
         add_guest.assert_called_with(user_id)
@@ -443,7 +451,8 @@ class SDKSMTClientTestCases(base.SDKTestCase):
               '--profile osdflt --maxCPU 10 --maxMemSize 4G --setReservedMem '
               '--logonby "lbyuser1 lbyuser2" --ipl cms')
         self._smtclient.create_vm(user_id, cpu, memory, disk_list, profile,
-                                  max_cpu, max_mem, 'cms', '', '', [], {}, '')
+                                  max_cpu, max_mem, 'cms', '', '', [], {}, '',
+                                  [])
         request.assert_called_with(rd)
         add_mdisks.assert_called_with(user_id, disk_list)
         add_guest.assert_called_with(user_id)
@@ -472,7 +481,38 @@ class SDKSMTClientTestCases(base.SDKTestCase):
               '--account "dummy account aaa"')
         self._smtclient.create_vm(user_id, cpu, memory, disk_list, profile,
                                   max_cpu, max_mem, 'cms', '', '', [], {},
-                                  account)
+                                  account, [])
+        request.assert_called_with(rd)
+        add_mdisks.assert_called_with(user_id, disk_list)
+        add_guest.assert_called_with(user_id)
+
+    @mock.patch.object(smtclient.SMTClient, 'add_mdisks')
+    @mock.patch.object(smtclient.SMTClient, '_request')
+    @mock.patch.object(database.GuestDbOperator, 'add_guest')
+    def test_create_vm_cms_comment(self, add_guest, request, add_mdisks):
+        user_id = 'fakeuser'
+        cpu = 2
+        memory = 1024
+        disk_list = [{'size': '1g',
+                      'is_boot_disk': True,
+                      'disk_pool': 'ECKD:eckdpool1',
+                      'format': 'ext3'}]
+        profile = 'osdflt'
+        max_cpu = 10
+        max_mem = '4G'
+        account = "dummy account aaa"
+        comment_list = ["comment1", "comment2 is comment"]
+        base.set_conf('zvm', 'default_admin_userid', 'lbyuser1 lbyuser2')
+        base.set_conf('zvm', 'user_root_vdev', '0100')
+        base.set_conf('zvm', 'disk_pool', 'ECKD:TESTPOOL')
+        rd = ('makevm fakeuser directory LBYONLY 1024m G --cpus 2 '
+              '--profile osdflt --maxCPU 10 --maxMemSize 4G --setReservedMem '
+              '--logonby "lbyuser1 lbyuser2" --ipl cms '
+              '--account "dummy account aaa" '
+              '--comment "comment1$@$@$comment2 is comment$@$@$"')
+        self._smtclient.create_vm(user_id, cpu, memory, disk_list, profile,
+                                  max_cpu, max_mem, 'cms', '', '', [], {},
+                                  account, comment_list)
         request.assert_called_with(rd)
         add_mdisks.assert_called_with(user_id, disk_list)
         add_guest.assert_called_with(user_id)
@@ -504,7 +544,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
               '--loadlun 0000000000000000')
         self._smtclient.create_vm(user_id, cpu, memory, disk_list, profile,
                                    max_cpu, max_mem, ipl_from, '', '',
-                                   dedicate_vdevs, loaddev, '')
+                                   dedicate_vdevs, loaddev, '', [])
         request.assert_called_with(rd)
         add_mdisks.assert_called_with(user_id, disk_list)
         add_guest.assert_called_with(user_id)
@@ -535,7 +575,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
               '--loadlun 0000000000000000')
         self._smtclient.create_vm(user_id, cpu, memory, disk_list, profile,
                                    max_cpu, max_mem, ipl_from, '', '',
-                                   dedicate_vdevs, loaddev, '')
+                                   dedicate_vdevs, loaddev, '', [])
         request.assert_called_with(rd)
         add_mdisks.assert_not_called()
         add_guest.assert_called_with(user_id)
@@ -565,7 +605,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
               '--iplLoadparam load=1')
         self._smtclient.create_vm(user_id, cpu, memory, disk_list, profile,
                                   max_cpu, max_mem, 'cms', ipl_param,
-                                  ipl_loadparam, [], {}, '')
+                                  ipl_loadparam, [], {}, '', [])
         request.assert_called_with(rd)
         add_mdisks.assert_called_with(user_id, disk_list)
         add_guest.assert_called_with(user_id)

--- a/zvmsdk/tests/unit/test_vmops.py
+++ b/zvmsdk/tests/unit/test_vmops.py
@@ -67,12 +67,14 @@ class SDKVMOpsTestCase(base.SDKTestCase):
         vdevs = ['1234']
         loaddev = {'portname': '5678', 'lun': '0000000000000000'}
         account = "dummy dummy"
+        comment_list = ['comment1', 'comment2 is here']
         self.vmops.create_vm(userid, cpu, memory, disk_list, user_profile,
                              max_cpu, max_mem, '', '', '', vdevs, loaddev,
-                             account)
+                             account, comment_list)
         create_vm.assert_called_once_with(userid, cpu, memory, disk_list,
                                           user_profile, max_cpu, max_mem,
-                                          '', '', '', vdevs, loaddev, account)
+                                          '', '', '', vdevs, loaddev, account,
+                                          comment_list)
         namelistadd.assert_called_once_with('TSTNLIST', userid)
 
     @mock.patch("zvmsdk.smtclient.SMTClient.process_additional_minidisks")

--- a/zvmsdk/vmops.py
+++ b/zvmsdk/vmops.py
@@ -189,7 +189,8 @@ class VMOps(object):
 
     def create_vm(self, userid, cpu, memory, disk_list,
                   user_profile, max_cpu, max_mem, ipl_from,
-                  ipl_param, ipl_loadparam, dedicate_vdevs, loaddev, account):
+                  ipl_param, ipl_loadparam, dedicate_vdevs, loaddev, account,
+                  comment_list):
         """Create z/VM userid into user directory for a z/VM instance."""
         LOG.info("Creating the user directory for vm %s", userid)
 
@@ -197,7 +198,8 @@ class VMOps(object):
                                    disk_list, user_profile,
                                    max_cpu, max_mem, ipl_from,
                                    ipl_param, ipl_loadparam,
-                                   dedicate_vdevs, loaddev, account)
+                                   dedicate_vdevs, loaddev, account,
+                                   comment_list)
 
         # add userid into smapi namelist
         self._smtclient.namelist_add(self._namelist, userid)


### PR DESCRIPTION
with the feature introduced here, we are able to provision VM by adding a comment like
`* ABCD this is a comment ` into user direct 