### PR TITLE
disable lvmetad to avoid bfv vm enter emergency mode

### DIFF
--- a/zthin-parts/zthin/bin/refresh_bootmap
+++ b/zthin-parts/zthin/bin/refresh_bootmap
@@ -857,6 +857,12 @@ function refreshZIPL {
     inform "Successed to execute zipl on $os. Output: $out_zipl"
   fi
   
+  # disable lvmetad service for RHEL 7
+  # RHEL 8 does not have lvmetad
+  if [[ ($os == rhel7*) && (-f ${deviceMountPoint}/etc/lvm/lvm.conf) ]]; then
+      sed -i 's/use_lvmetad = 1/use_lvmetad = 0/g' ${deviceMountPoint}/etc/lvm/lvm.conf
+  fi
+
   # Sync to ensure cached date writen back to target disk
   blockdev --flushbufs $diskPath > /dev/null
 


### PR DESCRIPTION
when lvmetad is enabled, the vm with lvm disklayout would sometimes
enter emergenecy mode during reboot.
This commit set the use_lvmetad as 0 at the refreshbootmap stage.

Signed-off-by: dyyang <dyyang@cn.ibm.com>