### PR TITLE
[master] Try get os version when capture shutoff vm

### DIFF
--- a/zvmsdk/database.py
+++ b/zvmsdk/database.py
@@ -831,6 +831,13 @@ class GuestDbOperator(object):
             conn.execute(
                 "DELETE FROM guests WHERE userid=?", (userid,))
 
+    def get_guest_metadata_with_userid(self, userid):
+        with get_guest_conn() as conn:
+            res = conn.execute("SELECT metadata FROM guests "
+                               "WHERE userid=?", (userid,))
+            guests = res.fetchall()
+        return guests
+
     def update_guest_by_id(self, uuid, userid=None, meta=None, net_set=None,
                            comments=None):
         if ((userid is None) and (meta is None) and

--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -1030,6 +1030,21 @@ class SMTClient(object):
                                   'vdev': vdev})
         LOG.info(msg)
 
+    def get_os_version_from_userid(self, userid):
+        """Get the os_verison of guests from userid.
+        return os_version or UNKNOWN"""
+        action = "get guests os_version from userid."
+        with zvmutils.log_and_reraise_sdkbase_error(action):
+            guests_in_db = self._GuestDbOperator.\
+                get_guest_metadata_with_userid(userid)
+        # db query return metadata in tuple (metadata)
+        os_version = 'UNKNOWN'
+        for g in guests_in_db:
+            if 'os_version='.upper() in g[0].upper():
+                os_version = g[0].upper().strip().split('=')[1]
+            break
+        return os_version
+
     def guest_capture(self, userid, image_name, capture_type='rootonly',
                       compress_level=6, capture_device_assign=None):
         if capture_type == "alldisks":
@@ -1104,7 +1119,7 @@ class SMTClient(object):
             # keep restart flag used after capture.
             restart_flag = True
         else:
-            os_version = 'UNKNOWN'
+            os_version = self.get_os_version_from_userid(userid)
             # Capture_device_assign as assign capture disk.
             # Input should be string to identity disk.
             # use force_capture_disk value first if

--- a/zvmsdk/tests/unit/test_database.py
+++ b/zvmsdk/tests/unit/test_database.py
@@ -653,6 +653,28 @@ class GuestDbOperatorTestCase(base.SDKTestCase):
         guests = self.db_op.get_guest_list()
         self.assertListEqual([], guests)
 
+    @mock.patch.object(uuid, 'uuid4')
+    def test_get_guest_metadata_with_userid_exist(self, get_uuid):
+        meta = 'os_version=rhel8.3'
+        get_uuid.return_value = u'ad8f352e-4c9e-4335-aafa-4f4eb2fcc77c'
+        self.db_op.add_guest(self.userid, meta=meta)
+        # Delete
+        guest = self.db_op.get_guest_metadata_with_userid(self.userid)
+        self.assertListEqual([(u'os_version=rhel8.3',)], guest)
+        self.db_op.delete_guest_by_id('ad8f352e-4c9e-4335-aafa-4f4eb2fcc77c')
+        guests = self.db_op.get_guest_metadata_with_userid(self.userid)
+        self.assertListEqual([], guests)
+
+    @mock.patch.object(uuid, 'uuid4')
+    def test_get_guest_metadata_with_userid_no_exist(self, get_uuid):
+        meta = u''
+        get_uuid.return_value = u'ad8f352e-4c9e-4335-aafa-4f4eb2fcc77c'
+        self.db_op.add_guest(self.userid, meta=meta)
+        guest = self.db_op.get_guest_metadata_with_userid(self.userid)
+        self.assertListEqual([(u'',)], guest)
+        # Delete
+        self.db_op.delete_guest_by_id('ad8f352e-4c9e-4335-aafa-4f4eb2fcc77c')
+
     def test_delete_guest_by_userid_not_exist(self):
         self.db_op.delete_guest_by_id(self.userid)
 


### PR DESCRIPTION
code change:  try get os version from guest db  when try capture shutoff status instance.

Signed-off-by: wngzhe <wngzhe@cn.ibm.com>