### PR TITLE
[master] Add check if user directory exists in guest_get_power_state

### DIFF
--- a/doc/source/errcode.csv
+++ b/doc/source/errcode.csv
@@ -62,6 +62,7 @@
 **The operated object does not exist**
 404;None;404;1;%(obj_desc)s does not exist.
 404;None;404;2;Not found error: '%(msg)s'
+404;None;404;3;%(obj_desc)s does not exist in directory although it is in DB. The guest could have been deleted out of z/VM Cloud Connector.
 **The operated object status conflict**
 409;None;409;1;Guest '%(userid)s' is not in active status.
 409;None;409;2;Failed to live resize cpus of guest: '%(userid)s', error: current active cpu count: '%(active)i' is greater than requested count: '%(req)i'.

--- a/doc/source/restapi.rst
+++ b/doc/source/restapi.rst
@@ -1398,6 +1398,8 @@ Get power state of the guest.
 * Response code:
 
   HTTP status code 200 on success.
+  HTTP status code 404 if guest is not in zcc database
+  or it is in zcc database but its user directory does not exist.
 
 * Response contents:
 

--- a/zvmsdk/api.py
+++ b/zvmsdk/api.py
@@ -200,6 +200,12 @@ class SDKAPI(object):
     @check_guest_exist()
     def guest_get_power_state(self, userid):
         """Returns power state."""
+        if not zvmutils.check_userid_exist(userid.upper()):
+            LOG.error("User directory of '%s' does not exist "
+                      "although it is in DB. The guest could have been "
+                      "deleted out of z/VM Cloud Connector." % userid)
+            raise exception.SDKObjectNotExistError(
+                    obj_desc=("Guest '%s'" % userid), modID='guest', rs=3)
         action = "get power state of guest '%s'" % userid
         with zvmutils.log_and_reraise_sdkbase_error(action):
             return self._vmops.get_power_state(userid)

--- a/zvmsdk/exception.py
+++ b/zvmsdk/exception.py
@@ -186,12 +186,12 @@ class SDKConflictError(SDKBaseException):
 
 
 class SDKObjectNotExistError(SDKBaseException):
-    def __init__(self, obj_desc, modID='zvmsdk'):
+    def __init__(self, obj_desc, modID='zvmsdk', rs=1):
         rc = returncode.errors['notExist']
         results = rc[0]
         results['modID'] = returncode.ModRCs[modID]
-        results['rs'] = 1
-        errormsg = rc[1][1] % {'obj_desc': obj_desc}
+        results['rs'] = rs
+        errormsg = rc[1][rs] % {'obj_desc': obj_desc}
         super(SDKObjectNotExistError, self).__init__(results=results,
                                                      message=errormsg)
 

--- a/zvmsdk/returncode.py
+++ b/zvmsdk/returncode.py
@@ -273,7 +273,10 @@ errors = {
 # 'rs' is always 1
     'notExist': [{'overallRC': 404, 'modID': None, 'rc': 404},
                  {1: "%(obj_desc)s does not exist.",
-                  2: "Not found error: '%(msg)s'"},
+                  2: "Not found error: '%(msg)s'",
+                  3: ("%(obj_desc)s does not exist in directory "
+                      "although it is in DB. The guest could have been "
+                      "deleted out of z/VM Cloud Connector.")},
                  "The operated object does not exist"
                  ],
 # Conflict Error (The to-be-updated object status conflict)

--- a/zvmsdk/tests/unit/test_api.py
+++ b/zvmsdk/tests/unit/test_api.py
@@ -42,6 +42,22 @@ class SDKAPITestCase(base.SDKTestCase):
         self.api.guest_get_power_state_real(self.userid)
         gstate.assert_called_once_with(self.userid)
 
+    @mock.patch("zvmsdk.utils.check_userid_exist")
+    @mock.patch("zvmsdk.vmops.VMOps.get_power_state")
+    def test_guest_get_power_state(self, gstate, chk_uid):
+        chk_uid.return_value = True
+        self.api.guest_get_power_state(self.userid)
+        chk_uid.assert_called_once_with(self.userid)
+        gstate.assert_called_once_with(self.userid)
+
+        chk_uid.reset_mock()
+        gstate.reset_mock()
+        chk_uid.return_value = False
+        self.assertRaises(exception.SDKObjectNotExistError,
+                          self.api.guest_get_power_state, self.userid)
+        chk_uid.assert_called_once_with(self.userid)
+        gstate.assert_not_called()
+
     @mock.patch("zvmsdk.vmops.VMOps.get_info")
     def test_guest_get_info(self, ginfo):
         self.api.guest_get_info(self.userid)


### PR DESCRIPTION
Currently guest_get_power_state returns shutdown if the guest userid
exists in DB but does not exist in user directory (e.g. it has been
deleted through smcli directly), and this is wrong which could cause
confusion and unexpected result.
Also because if the userid does not exist in DB, it returns 404.
Hence, the fix returns 404 to caller in this case.

Signed-off-by: QingFeng Hao <haoqf@linux.vnet.ibm.com>