### PR TITLE
continue to do the cleanup of multipath/FCP/lun when umount fails

### DIFF
--- a/zthin-parts/zthin/bin/refresh_bootmap
+++ b/zthin-parts/zthin/bin/refresh_bootmap
@@ -89,14 +89,16 @@ function cleanup_umountdir_and_disconnect_fcp {
     out=`umount ${deviceMountPoint} 2>&1`
     rc=$?
     if [[ $rc -ne 0 ]]; then
+      # if the umount failed, we need to continue the cleanup process to clean multipath/lun/FCP from compute node
       printError "Failed to Umount devNode $devNode from $deviceMountPoint. rc: $rc. out: $out."
-      exit 9
+    else
+      inform "Successed to umount devNode $devNode from $deviceMountPoint"
     fi
-    inform "Successed to umount devNode $devNode from $deviceMountPoint"
     # remove the temporary mount point dir
     if [[ -d ${deviceMountPoint} ]]; then
+      # If umount step failed, but the device is still mounted, then the `rm -rf` command will fail like:
+      # rm: cannot remove 'mount_point': Device or resource busy
       rm -rf ${deviceMountPoint}
-      # "rm -fr xxx" return code is always 0
       if [[ ! -e ${deviceMountPoint} ]]; then
         inform "Removed ${deviceMountPoint}"
       fi
@@ -104,7 +106,6 @@ function cleanup_umountdir_and_disconnect_fcp {
     inform "Finish cleanuping umount dir."
   else
     printError "Failed to umount devNode $devNode due to deviceMountPoint not defined."
-    exit 9
   fi
 
   cleanup_fcpdevices


### PR DESCRIPTION
there are some case that the umount may fail, we should continue to do
the cleanup, otherwise the fcps/lun will be left on the compute node.

Signed-off-by: dyyang <dyyang@cn.ibm.com>