### PR TITLE
[master]Support disk_pool is None for host_get_diskpool_volumes api

### DIFF
--- a/zvmsdk/api.py
+++ b/zvmsdk/api.py
@@ -306,10 +306,8 @@ class SDKAPI(object):
         # the format must be "ECKD:eckdpool" or "FBA:fbapool".
         disk_pool = disk_pool or CONF.zvm.disk_pool
         if disk_pool is None:
-            errmsg = ("Invalid disk_pool input None, disk_pool should be"
-                      " configured for sdkserver.")
-            LOG.error(errmsg)
-            raise exception.SDKInvalidInputFormat(msg=errmsg)
+            # Support disk_pool not configured, return empty list
+            return {}
         if ':' not in disk_pool:
             msg = ('Invalid input parameter disk_pool, expect ":" in'
                    'disk_pool, eg. ECKD:eckdpool')

--- a/zvmsdk/tests/unit/test_api.py
+++ b/zvmsdk/tests/unit/test_api.py
@@ -620,14 +620,8 @@ class SDKAPITestCase(base.SDKTestCase):
         diskpool_vols.assert_called_once_with('IAS1PL')
         # Test disk_pool is None
         disk_pool = None
-        try:
-            self.api.host_get_diskpool_volumes(disk_pool)
-        except Exception as exc:
-            errmsg = ("Invalid disk_pool input None, disk_pool should be"
-                      " configured for sdkserver.")
-            result = errmsg in six.text_type(exc)
-            self.assertEqual(result, True)
-            pass
+        result = self.api.host_get_diskpool_volumes(disk_pool)
+        self.assertEqual(result, {})
 
     @mock.patch("zvmsdk.hostops.HOSTOps.get_volume_info")
     def test_host_get_volume_info(self, volume_info):


### PR DESCRIPTION
If disk_pool is not configured, host_get_diskpool_volumes api
will return {}, not report error.

Signed-off-by: Xiao Feng Ren <renxiaof@linux.vnet.ibm.com>