### PR TITLE
add cpu schedule statement support

### DIFF
--- a/smtLayer/makeVM.py
+++ b/smtLayer/makeVM.py
@@ -82,7 +82,8 @@ keyOpsList = {
         '--loadlun': ['loadlun', 1, 2],
         '--vdisk': ['vdisk', 1, 2],
         '--account': ['account', 1, 2],
-        '--comment': ['comment', 1, 2]},
+        '--comment': ['comment', 1, 2],
+        '--commandSchedule': ['commandSchedule', 1, 2]},
     'HELP': {},
     'VERSION': {},
      }
@@ -124,6 +125,10 @@ def createVM(rh):
     if 'cpuCnt' in rh.parms:
         for i in range(1, rh.parms['cpuCnt']):
             dirLines.append("COMMAND DEFINE CPU %0.2X TYPE IFL" % i)
+
+    if 'commandSchedule' in rh.parms:
+        v = rh.parms['commandSchedule']
+        dirLines.append("COMMAND SCHEDULE * WITHIN POOL %s" % v)
 
     if 'ipl' in rh.parms:
         ipl_string = "IPL %s " % rh.parms['ipl']

--- a/smtLayer/tests/unit/test_makeVM.py
+++ b/smtLayer/tests/unit/test_makeVM.py
@@ -230,3 +230,17 @@ class SMTMakeVMTestCase(base.SMTTestCase):
                                     b'COMMAND DEFINE CPU 00 TYPE IFL\n'
                                     b'* COMMENT1\n'
                                     b'* THIS IS COMMENT2\n')
+
+    @mock.patch("os.write")
+    def test_create_with_cpupool(self, write):
+        rh = ReqHandle.ReqHandle(captureLogs=False,
+                                 smt=mock.Mock())
+        parms = {'pw': 'pwd', 'priMemSize': '1024M', 'maxMemSize': '1G',
+                 'privClasses': 'G',
+                 'commandSchedule': 'POOL1'}
+        rh.parms = parms
+        makeVM.createVM(rh)
+        write.assert_called_with(mock.ANY, b'USER  pwd 1024M 1G G\n'
+                                b'COMMAND SET VCONFIG MODE LINUX\n'
+                                b'COMMAND DEFINE CPU 00 TYPE IFL\n'
+                                b'COMMAND SCHEDULE * WITHIN POOL POOL1\n')

--- a/zvmsdk/api.py
+++ b/zvmsdk/api.py
@@ -779,7 +779,7 @@ class SDKAPI(object):
                      max_mem=CONF.zvm.user_default_max_memory,
                      ipl_from='', ipl_param='', ipl_loadparam='',
                      dedicate_vdevs=None, loaddev={}, account='',
-                     comment_list=None):
+                     comment_list=None, cschedule=''):
         """create a vm in z/VM
 
         :param userid: (str) the userid of the vm to be created
@@ -846,6 +846,7 @@ class SDKAPI(object):
         https://www.ibm.com/docs/en/zvm/6.4?topic=SSB27U_6.4.0/
                 com.ibm.zvm.v640.hcpa5/daccoun.htm#daccoun
         :param comment_list: (array) a list of comment string
+        :param cschedule: a command input for schedule cpu pool
         """
         dedicate_vdevs = dedicate_vdevs or []
 
@@ -931,7 +932,7 @@ class SDKAPI(object):
                                          user_profile, max_cpu, max_mem,
                                          ipl_from, ipl_param, ipl_loadparam,
                                          dedicate_vdevs, loaddev, account,
-                                         comment_list)
+                                         comment_list, cschedule)
 
     @check_guest_exist()
     def guest_live_resize_cpus(self, userid, cpu_cnt):

--- a/zvmsdk/sdkwsgi/handlers/guest.py
+++ b/zvmsdk/sdkwsgi/handlers/guest.py
@@ -73,6 +73,8 @@ class VMHandler(object):
             kwargs_list['loaddev'] = guest['loaddev']
         if 'account' in guest_keys:
             kwargs_list['account'] = guest['account']
+        if 'cschedule' in guest_keys:
+            kwargs_list['cschedule'] = guest['cschedule']
 
         info = self.client.send_request('guest_create', userid, vcpus,
                                         memory, **kwargs_list)

--- a/zvmsdk/sdkwsgi/schemas/guest.py
+++ b/zvmsdk/sdkwsgi/schemas/guest.py
@@ -35,7 +35,8 @@ create = {
                 'dedicate_vdevs': parameter_types.dedicate_vdevs,
                 'loaddev': parameter_types.loaddev,
                 'account': parameter_types.account,
-                'comments': parameter_types.comment_list
+                'comments': parameter_types.comment_list,
+                'cschedule': parameter_types.cpupool
             },
             'required': ['userid', 'vcpus', 'memory'],
             'additionalProperties': False,

--- a/zvmsdk/sdkwsgi/validation/parameter_types.py
+++ b/zvmsdk/sdkwsgi/validation/parameter_types.py
@@ -261,6 +261,14 @@ userid = {
 }
 
 
+cpupool = {
+    'type': ['string'],
+    'minLength': 1,
+    'maxLength': 8,
+    'pattern': '^(\w{,8})$'
+}
+
+
 userid_or_None = {
     'oneOf': [
         {'type': 'null'},

--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -576,7 +576,8 @@ class SMTClient(object):
 
     def create_vm(self, userid, cpu, memory, disk_list, profile,
                   max_cpu, max_mem, ipl_from, ipl_param, ipl_loadparam,
-                  dedicate_vdevs, loaddev, account, comment_list):
+                  dedicate_vdevs, loaddev, account, comment_list,
+                  cschedule=''):
         """ Create VM and add disks if specified. """
         rd = ('makevm %(uid)s directory LBYONLY %(mem)im %(pri)s '
               '--cpus %(cpu)i --profile %(prof)s --maxCPU %(max_cpu)i '
@@ -610,6 +611,9 @@ class SMTClient(object):
 
         if account:
             rd += ' --account "%s"' % account
+
+        if cschedule:
+            rd += ' --commandSchedule %s' % cschedule
 
         comments = ''
         if comment_list is not None:

--- a/zvmsdk/tests/unit/test_api.py
+++ b/zvmsdk/tests/unit/test_api.py
@@ -124,7 +124,7 @@ class SDKAPITestCase(base.SDKTestCase):
                               user_profile, max_cpu, max_mem)
         create_vm.assert_called_once_with(self.userid, vcpus, memory,
                                   disk_list, user_profile, max_cpu, max_mem,
-                                  '', '', '', [], {}, '', None)
+                                  '', '', '', [], {}, '', None, '')
 
     @mock.patch("zvmsdk.vmops.VMOps.create_vm")
     def test_guest_create_with_account(self, create_vm):
@@ -141,7 +141,24 @@ class SDKAPITestCase(base.SDKTestCase):
                               account=account)
         create_vm.assert_called_once_with(self.userid, vcpus, memory,
                                   disk_list, user_profile, max_cpu, max_mem,
-                                  '', '', '', [], {}, account, None)
+                                  '', '', '', [], {}, account, None, '')
+
+    @mock.patch("zvmsdk.vmops.VMOps.create_vm")
+    def test_guest_create_with_cpupool(self, create_vm):
+        vcpus = 1
+        memory = 1024
+        disk_list = []
+        user_profile = 'profile'
+        max_cpu = 10
+        max_mem = '4G'
+        cschedule = 'POOL1'
+
+        self.api.guest_create(self.userid, vcpus, memory, disk_list,
+                              user_profile, max_cpu, max_mem,
+                              cschedule=cschedule)
+        create_vm.assert_called_once_with(self.userid, vcpus, memory,
+                                  disk_list, user_profile, max_cpu, max_mem,
+                                  '', '', '', [], {}, '', None, cschedule)
 
     @mock.patch("zvmsdk.vmops.VMOps.create_vm")
     def test_guest_create_with_comment(self, create_vm):
@@ -158,7 +175,7 @@ class SDKAPITestCase(base.SDKTestCase):
                               comment_list=comment_list)
         create_vm.assert_called_once_with(self.userid, vcpus, memory,
                                   disk_list, user_profile, max_cpu, max_mem,
-                                  '', '', '', [], {}, '', comment_list)
+                                  '', '', '', [], {}, '', comment_list, '')
 
     @mock.patch("zvmsdk.vmops.VMOps.create_vm")
     def test_guest_create_with_default_profile(self, create_vm):
@@ -174,7 +191,7 @@ class SDKAPITestCase(base.SDKTestCase):
                               user_profile, max_cpu, max_mem)
         create_vm.assert_called_once_with(self.userid, vcpus, memory,
                                   disk_list, 'abc', max_cpu, max_mem,
-                                  '', '', '', [], {}, '', None)
+                                  '', '', '', [], {}, '', None, '')
 
     @mock.patch("zvmsdk.vmops.VMOps.create_vm")
     def test_guest_create_with_no_disk_pool(self, create_vm):
@@ -206,7 +223,7 @@ class SDKAPITestCase(base.SDKTestCase):
                               user_profile)
         create_vm.assert_called_once_with(self.userid, vcpus, memory,
                                           disk_list, user_profile, 32, '64G',
-                                          '', '', '', [], {}, '', None)
+                                          '', '', '', [], {}, '', None, '')
 
     @mock.patch("zvmsdk.vmops.VMOps.create_vm")
     def test_guest_create_no_disk_pool_force_mdisk(self, create_vm):
@@ -251,7 +268,7 @@ class SDKAPITestCase(base.SDKTestCase):
                               user_profile)
         create_vm.assert_called_once_with(self.userid, vcpus, memory,
                                           disk_list, user_profile, 32, '64G',
-                                          '', '', '', [], {}, '', None)
+                                          '', '', '', [], {}, '', None, '')
 
     @mock.patch("zvmsdk.imageops.ImageOps.image_query")
     def test_image_query(self, image_query):

--- a/zvmsdk/tests/unit/test_smtclient.py
+++ b/zvmsdk/tests/unit/test_smtclient.py
@@ -520,6 +520,36 @@ class SDKSMTClientTestCases(base.SDKTestCase):
     @mock.patch.object(smtclient.SMTClient, 'add_mdisks')
     @mock.patch.object(smtclient.SMTClient, '_request')
     @mock.patch.object(database.GuestDbOperator, 'add_guest')
+    def test_create_vm_cms_cschedule(self, add_guest, request, add_mdisks):
+        user_id = 'fakeuser'
+        cpu = 2
+        memory = 1024
+        disk_list = [{'size': '1g',
+                      'is_boot_disk': True,
+                      'disk_pool': 'ECKD:eckdpool1',
+                      'format': 'ext3'}]
+        profile = 'osdflt'
+        max_cpu = 10
+        max_mem = '4G'
+        account = "dummy account aaa"
+        base.set_conf('zvm', 'default_admin_userid', 'lbyuser1 lbyuser2')
+        base.set_conf('zvm', 'user_root_vdev', '0100')
+        base.set_conf('zvm', 'disk_pool', 'ECKD:TESTPOOL')
+        rd = ('makevm fakeuser directory LBYONLY 1024m G --cpus 2 '
+              '--profile osdflt --maxCPU 10 --maxMemSize 4G --setReservedMem '
+              '--logonby "lbyuser1 lbyuser2" --ipl cms '
+              '--account "dummy account aaa" '
+              '--commandSchedule CEEPOOL')
+        self._smtclient.create_vm(user_id, cpu, memory, disk_list, profile,
+                                  max_cpu, max_mem, 'cms', '', '', [], {},
+                                  account, [], 'CEEPOOL')
+        request.assert_called_with(rd)
+        add_mdisks.assert_called_with(user_id, disk_list)
+        add_guest.assert_called_with(user_id)
+
+    @mock.patch.object(smtclient.SMTClient, 'add_mdisks')
+    @mock.patch.object(smtclient.SMTClient, '_request')
+    @mock.patch.object(database.GuestDbOperator, 'add_guest')
     def test_create_vm_boot_from_volume(self, add_guest, request, add_mdisks):
         user_id = 'fakeuser'
         cpu = 2

--- a/zvmsdk/tests/unit/test_vmops.py
+++ b/zvmsdk/tests/unit/test_vmops.py
@@ -82,11 +82,11 @@ class SDKVMOpsTestCase(base.SDKTestCase):
         comment_list = ['comment1', 'comment2 is here']
         self.vmops.create_vm(userid, cpu, memory, disk_list, user_profile,
                              max_cpu, max_mem, '', '', '', vdevs, loaddev,
-                             account, comment_list)
+                             account, comment_list, '')
         create_vm.assert_called_once_with(userid, cpu, memory, disk_list,
                                           user_profile, max_cpu, max_mem,
                                           '', '', '', vdevs, loaddev, account,
-                                          comment_list)
+                                          comment_list, '')
         namelistadd.assert_called_once_with('TSTNLIST', userid)
 
     @mock.patch("zvmsdk.smtclient.SMTClient.process_additional_minidisks")

--- a/zvmsdk/vmops.py
+++ b/zvmsdk/vmops.py
@@ -191,7 +191,7 @@ class VMOps(object):
     def create_vm(self, userid, cpu, memory, disk_list,
                   user_profile, max_cpu, max_mem, ipl_from,
                   ipl_param, ipl_loadparam, dedicate_vdevs, loaddev, account,
-                  comment_list):
+                  comment_list, cschedule):
         """Create z/VM userid into user directory for a z/VM instance."""
         LOG.info("Creating the user directory for vm %s", userid)
 
@@ -200,7 +200,7 @@ class VMOps(object):
                                    max_cpu, max_mem, ipl_from,
                                    ipl_param, ipl_loadparam,
                                    dedicate_vdevs, loaddev, account,
-                                   comment_list)
+                                   comment_list, cschedule)
 
         # add userid into smapi namelist
         self._smtclient.namelist_add(self._namelist, userid)


### PR DESCRIPTION
CPU schedule statement is supported so that when a parm is given such as schedule pool1 then
we have following statement in user direct


COMMAND SCHEDULE * WITHIN POOL POOL1


Signed-off-by: jichenjc <jichenjc@cn.ibm.com>