### PR TITLE
Add support for COMMAND SET VMRELOCATE * DOMAIN Z15ONLY

### DIFF
--- a/smtLayer/makeVM.py
+++ b/smtLayer/makeVM.py
@@ -84,7 +84,8 @@ keyOpsList = {
         '--account': ['account', 1, 2],
         '--comment': ['comment', 1, 2],
         '--commandSchedule': ['commandSchedule', 1, 2],
-        '--commandSetShare': ['commandSetShare', 1, 2]},
+        '--commandSetShare': ['commandSetShare', 1, 2],
+        '--commandRelocationDomain': ['commandRDomain', 1, 2]},
     'HELP': {},
     'VERSION': {},
      }
@@ -134,6 +135,10 @@ def createVM(rh):
     if 'commandSetShare' in rh.parms:
         v = rh.parms['commandSetShare']
         dirLines.append("COMMAND SET SHARE &USERID %s" % v)
+
+    if 'commandRDomain' in rh.parms:
+        v = rh.parms['commandRDomain']
+        dirLines.append("COMMAND SET VMRELOCATE * DOMAIN %s" % v)
 
     if 'ipl' in rh.parms:
         ipl_string = "IPL %s " % rh.parms['ipl']

--- a/smtLayer/tests/unit/test_makeVM.py
+++ b/smtLayer/tests/unit/test_makeVM.py
@@ -258,3 +258,17 @@ class SMTMakeVMTestCase(base.SMTTestCase):
                                 b'COMMAND SET VCONFIG MODE LINUX\n'
                                 b'COMMAND DEFINE CPU 00 TYPE IFL\n'
                                 b'COMMAND SET SHARE &USERID RELATIVE 125\n')
+
+    @mock.patch("os.write")
+    def test_create_with_rdomain(self, write):
+        rh = ReqHandle.ReqHandle(captureLogs=False,
+                                 smt=mock.Mock())
+        parms = {'pw': 'pwd', 'priMemSize': '1024M', 'maxMemSize': '1G',
+                 'privClasses': 'G',
+                 'commandRDomain': 'Z15ONLY'}
+        rh.parms = parms
+        makeVM.createVM(rh)
+        write.assert_called_with(mock.ANY, b'USER  pwd 1024M 1G G\n'
+                                b'COMMAND SET VCONFIG MODE LINUX\n'
+                                b'COMMAND DEFINE CPU 00 TYPE IFL\n'
+                                b'COMMAND SET VMRELOCATE * DOMAIN Z15ONLY\n')

--- a/zvmsdk/api.py
+++ b/zvmsdk/api.py
@@ -779,7 +779,8 @@ class SDKAPI(object):
                      max_mem=CONF.zvm.user_default_max_memory,
                      ipl_from='', ipl_param='', ipl_loadparam='',
                      dedicate_vdevs=None, loaddev={}, account='',
-                     comment_list=None, cschedule='', cshare=''):
+                     comment_list=None, cschedule='', cshare='',
+                     rdomain=''):
         """create a vm in z/VM
 
         :param userid: (str) the userid of the vm to be created
@@ -848,6 +849,7 @@ class SDKAPI(object):
         :param comment_list: (array) a list of comment string
         :param cschedule: a command input for schedule cpu pool
         :param cshare: a command input for share settings
+        :param rdomain: a command input for relocation domain
         """
         dedicate_vdevs = dedicate_vdevs or []
 
@@ -933,7 +935,8 @@ class SDKAPI(object):
                                          user_profile, max_cpu, max_mem,
                                          ipl_from, ipl_param, ipl_loadparam,
                                          dedicate_vdevs, loaddev, account,
-                                         comment_list, cschedule, cshare)
+                                         comment_list, cschedule, cshare,
+                                         rdomain)
 
     @check_guest_exist()
     def guest_live_resize_cpus(self, userid, cpu_cnt):

--- a/zvmsdk/sdkwsgi/handlers/guest.py
+++ b/zvmsdk/sdkwsgi/handlers/guest.py
@@ -77,6 +77,8 @@ class VMHandler(object):
             kwargs_list['cschedule'] = guest['cschedule']
         if 'cshare' in guest_keys:
             kwargs_list['cshare'] = guest['cshare']
+        if 'rdomain' in guest_keys:
+            kwargs_list['rdomain'] = guest['rdomain']
 
         info = self.client.send_request('guest_create', userid, vcpus,
                                         memory, **kwargs_list)

--- a/zvmsdk/sdkwsgi/schemas/guest.py
+++ b/zvmsdk/sdkwsgi/schemas/guest.py
@@ -37,7 +37,8 @@ create = {
                 'account': parameter_types.account,
                 'comments': parameter_types.comment_list,
                 'cschedule': parameter_types.cpupool,
-                'cshare': parameter_types.share
+                'cshare': parameter_types.share,
+                'rdomain': parameter_types.rdomain
             },
             'required': ['userid', 'vcpus', 'memory'],
             'additionalProperties': False,

--- a/zvmsdk/sdkwsgi/validation/parameter_types.py
+++ b/zvmsdk/sdkwsgi/validation/parameter_types.py
@@ -276,6 +276,13 @@ share = {
     'pattern': '^(\w{,64})$'
 }
 
+rdomain = {
+    'type': ['string'],
+    'minLength': 1,
+    'maxLength': 8,
+    'pattern': '^(\w{,8})$'
+}
+
 
 userid_or_None = {
     'oneOf': [

--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -577,7 +577,7 @@ class SMTClient(object):
     def create_vm(self, userid, cpu, memory, disk_list, profile,
                   max_cpu, max_mem, ipl_from, ipl_param, ipl_loadparam,
                   dedicate_vdevs, loaddev, account, comment_list,
-                  cschedule='', cshare=''):
+                  cschedule='', cshare='', rdomain=''):
         """ Create VM and add disks if specified. """
         rd = ('makevm %(uid)s directory LBYONLY %(mem)im %(pri)s '
               '--cpus %(cpu)i --profile %(prof)s --maxCPU %(max_cpu)i '
@@ -617,6 +617,9 @@ class SMTClient(object):
 
         if cshare:
             rd += ' --commandSetShare "%s"' % cshare
+
+        if rdomain:
+            rd += ' --commandRDomain %s' % rdomain
 
         comments = ''
         if comment_list is not None:

--- a/zvmsdk/tests/unit/test_api.py
+++ b/zvmsdk/tests/unit/test_api.py
@@ -124,7 +124,7 @@ class SDKAPITestCase(base.SDKTestCase):
                               user_profile, max_cpu, max_mem)
         create_vm.assert_called_once_with(self.userid, vcpus, memory,
                                   disk_list, user_profile, max_cpu, max_mem,
-                                  '', '', '', [], {}, '', None, '', '')
+                                  '', '', '', [], {}, '', None, '', '', '')
 
     @mock.patch("zvmsdk.vmops.VMOps.create_vm")
     def test_guest_create_with_account(self, create_vm):
@@ -141,7 +141,8 @@ class SDKAPITestCase(base.SDKTestCase):
                               account=account)
         create_vm.assert_called_once_with(self.userid, vcpus, memory,
                                   disk_list, user_profile, max_cpu, max_mem,
-                                  '', '', '', [], {}, account, None, '', '')
+                                  '', '', '', [], {}, account, None, '', '',
+                                  '')
 
     @mock.patch("zvmsdk.vmops.VMOps.create_vm")
     def test_guest_create_with_cpupool(self, create_vm):
@@ -158,7 +159,8 @@ class SDKAPITestCase(base.SDKTestCase):
                               cschedule=cschedule)
         create_vm.assert_called_once_with(self.userid, vcpus, memory,
                                   disk_list, user_profile, max_cpu, max_mem,
-                                  '', '', '', [], {}, '', None, cschedule, '')
+                                  '', '', '', [], {}, '', None, cschedule, '',
+                                  '')
 
     @mock.patch("zvmsdk.vmops.VMOps.create_vm")
     def test_guest_create_with_share(self, create_vm):
@@ -175,7 +177,25 @@ class SDKAPITestCase(base.SDKTestCase):
                               cshare=cshare)
         create_vm.assert_called_once_with(self.userid, vcpus, memory,
                                   disk_list, user_profile, max_cpu, max_mem,
-                                  '', '', '', [], {}, '', None, '', cshare)
+                                  '', '', '', [], {}, '', None, '', cshare, '')
+
+    @mock.patch("zvmsdk.vmops.VMOps.create_vm")
+    def test_guest_create_with_rdomain(self, create_vm):
+        vcpus = 1
+        memory = 1024
+        disk_list = []
+        user_profile = 'profile'
+        max_cpu = 10
+        max_mem = '4G'
+        rdomain = 'Z15ONLY'
+
+        self.api.guest_create(self.userid, vcpus, memory, disk_list,
+                              user_profile, max_cpu, max_mem,
+                              rdomain=rdomain)
+        create_vm.assert_called_once_with(self.userid, vcpus, memory,
+                                  disk_list, user_profile, max_cpu, max_mem,
+                                  '', '', '', [], {}, '', None, '', '',
+                                  rdomain)
 
     @mock.patch("zvmsdk.vmops.VMOps.create_vm")
     def test_guest_create_with_comment(self, create_vm):
@@ -193,7 +213,7 @@ class SDKAPITestCase(base.SDKTestCase):
         create_vm.assert_called_once_with(self.userid, vcpus, memory,
                                   disk_list, user_profile, max_cpu, max_mem,
                                   '', '', '', [], {}, '', comment_list, '',
-                                  '')
+                                  '', '')
 
     @mock.patch("zvmsdk.vmops.VMOps.create_vm")
     def test_guest_create_with_default_profile(self, create_vm):
@@ -209,7 +229,7 @@ class SDKAPITestCase(base.SDKTestCase):
                               user_profile, max_cpu, max_mem)
         create_vm.assert_called_once_with(self.userid, vcpus, memory,
                                   disk_list, 'abc', max_cpu, max_mem,
-                                  '', '', '', [], {}, '', None, '', '')
+                                  '', '', '', [], {}, '', None, '', '', '')
 
     @mock.patch("zvmsdk.vmops.VMOps.create_vm")
     def test_guest_create_with_no_disk_pool(self, create_vm):
@@ -242,7 +262,7 @@ class SDKAPITestCase(base.SDKTestCase):
         create_vm.assert_called_once_with(self.userid, vcpus, memory,
                                           disk_list, user_profile, 32, '64G',
                                           '', '', '', [], {}, '', None, '',
-                                          '')
+                                          '', '')
 
     @mock.patch("zvmsdk.vmops.VMOps.create_vm")
     def test_guest_create_no_disk_pool_force_mdisk(self, create_vm):
@@ -288,7 +308,7 @@ class SDKAPITestCase(base.SDKTestCase):
         create_vm.assert_called_once_with(self.userid, vcpus, memory,
                                           disk_list, user_profile, 32, '64G',
                                           '', '', '', [], {}, '', None, '',
-                                          '')
+                                          '', '')
 
     @mock.patch("zvmsdk.imageops.ImageOps.image_query")
     def test_image_query(self, image_query):

--- a/zvmsdk/tests/unit/test_smtclient.py
+++ b/zvmsdk/tests/unit/test_smtclient.py
@@ -580,6 +580,36 @@ class SDKSMTClientTestCases(base.SDKTestCase):
     @mock.patch.object(smtclient.SMTClient, 'add_mdisks')
     @mock.patch.object(smtclient.SMTClient, '_request')
     @mock.patch.object(database.GuestDbOperator, 'add_guest')
+    def test_create_vm_cms_rdomain(self, add_guest, request, add_mdisks):
+        user_id = 'fakeuser'
+        cpu = 2
+        memory = 1024
+        disk_list = [{'size': '1g',
+                      'is_boot_disk': True,
+                      'disk_pool': 'ECKD:eckdpool1',
+                      'format': 'ext3'}]
+        profile = 'osdflt'
+        max_cpu = 10
+        max_mem = '4G'
+        account = "dummy account aaa"
+        base.set_conf('zvm', 'default_admin_userid', 'lbyuser1 lbyuser2')
+        base.set_conf('zvm', 'user_root_vdev', '0100')
+        base.set_conf('zvm', 'disk_pool', 'ECKD:TESTPOOL')
+        rd = ('makevm fakeuser directory LBYONLY 1024m G --cpus 2 '
+              '--profile osdflt --maxCPU 10 --maxMemSize 4G --setReservedMem '
+              '--logonby "lbyuser1 lbyuser2" --ipl cms '
+              '--account "dummy account aaa" '
+              '--commandRDomain Z15ONLY')
+        self._smtclient.create_vm(user_id, cpu, memory, disk_list, profile,
+                                  max_cpu, max_mem, 'cms', '', '', [], {},
+                                  account, [], '', '', 'Z15ONLY')
+        request.assert_called_with(rd)
+        add_mdisks.assert_called_with(user_id, disk_list)
+        add_guest.assert_called_with(user_id)
+
+    @mock.patch.object(smtclient.SMTClient, 'add_mdisks')
+    @mock.patch.object(smtclient.SMTClient, '_request')
+    @mock.patch.object(database.GuestDbOperator, 'add_guest')
     def test_create_vm_boot_from_volume(self, add_guest, request, add_mdisks):
         user_id = 'fakeuser'
         cpu = 2

--- a/zvmsdk/tests/unit/test_vmops.py
+++ b/zvmsdk/tests/unit/test_vmops.py
@@ -82,11 +82,11 @@ class SDKVMOpsTestCase(base.SDKTestCase):
         comment_list = ['comment1', 'comment2 is here']
         self.vmops.create_vm(userid, cpu, memory, disk_list, user_profile,
                              max_cpu, max_mem, '', '', '', vdevs, loaddev,
-                             account, comment_list, '', '')
+                             account, comment_list, '', '', '')
         create_vm.assert_called_once_with(userid, cpu, memory, disk_list,
                                           user_profile, max_cpu, max_mem,
                                           '', '', '', vdevs, loaddev, account,
-                                          comment_list, '', '')
+                                          comment_list, '', '', '')
         namelistadd.assert_called_once_with('TSTNLIST', userid)
 
     @mock.patch("zvmsdk.smtclient.SMTClient.process_additional_minidisks")

--- a/zvmsdk/vmops.py
+++ b/zvmsdk/vmops.py
@@ -191,7 +191,7 @@ class VMOps(object):
     def create_vm(self, userid, cpu, memory, disk_list,
                   user_profile, max_cpu, max_mem, ipl_from,
                   ipl_param, ipl_loadparam, dedicate_vdevs, loaddev, account,
-                  comment_list, cschedule, cshare):
+                  comment_list, cschedule, cshare, rdomain):
         """Create z/VM userid into user directory for a z/VM instance."""
         LOG.info("Creating the user directory for vm %s", userid)
 
@@ -200,7 +200,7 @@ class VMOps(object):
                                    max_cpu, max_mem, ipl_from,
                                    ipl_param, ipl_loadparam,
                                    dedicate_vdevs, loaddev, account,
-                                   comment_list, cschedule, cshare)
+                                   comment_list, cschedule, cshare, rdomain)
 
         # add userid into smapi namelist
         self._smtclient.namelist_add(self._namelist, userid)


### PR DESCRIPTION
Add support for COMMAND SET VMRELOCATE * DOMAIN Z15ONLY

so that we can set those domain values in the code to provide granularity