### PR TITLE
Replace the ':' in the log file name to be '_'

### DIFF
--- a/zthin-parts/zthin/bin/unpackdiskimage
+++ b/zthin-parts/zthin/bin/unpackdiskimage
@@ -150,7 +150,7 @@ function parseArgs {
     fi
   fi
 
-  timestamp=$(date -u --rfc-3339=ns | sed 's/ /-/;s/\.\(...\).*/.\1/')
+  timestamp=$(date -u --rfc-3339=ns | sed 's/ /-/;s/\.\(...\).*/.\1/' | sed 's/:/_/g')
   logFile=/var/log/zthin/unpackdiskimage_trace_${timestamp}.txt
   if [[ $debug ]]; then
     exec 2> >(tee -a $logFile)


### PR DESCRIPTION
Originally the log file of unpackdiskimage is like unpackdiskimage_trace_2021-07-23-08:30:36.812.txt
which can not be parsed by the support system. Change ':' to '_' can solve it.

Signed-off-by: QingFeng Hao <haoqf@linux.vnet.ibm.com>