### PR TITLE
[master] fix debug dasd

### DIFF
--- a/zthin-parts/zthin/bin/unpackdiskimage
+++ b/zthin-parts/zthin/bin/unpackdiskimage
@@ -390,8 +390,6 @@ function resizeECKD {
     # Note: We will see a message indicating that "device is not fully formatted".
     #       We will ignore that because we are redoing the parition to take 
     #       advantage of the increased size.
-    # Add dasdview to debug, currently zCC only supports CDL disk layout.
-    dasdview -x ${devNode}
     out=`fdasd -a ${devNode}`
     rc=$?
     if (( rc != 0 )); then

--- a/zthin-parts/zthin/bin/unpackdiskimage
+++ b/zthin-parts/zthin/bin/unpackdiskimage
@@ -390,6 +390,8 @@ function resizeECKD {
     # Note: We will see a message indicating that "device is not fully formatted".
     #       We will ignore that because we are redoing the parition to take 
     #       advantage of the increased size.
+    # Add dasdview to debug, currently zCC only supports CDL disk layout.
+    dasdview -x ${devNode}
     out=`fdasd -a ${devNode}`
     rc=$?
     if (( rc != 0 )); then

--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -887,6 +887,12 @@ class SMTClient(object):
             LOG.info(msg)
             image_file = '/'.join([self._get_image_path_by_name(image_name),
                                    CONF.zvm.user_root_vdev])
+            cmd = ['/usr/bin/hexdump', '-C', '-n', '64', image_file]
+            with zvmutils.expect_and_reraise_internal_error(modID='guest'):
+                (rc, output) = zvmutils.execute(cmd)
+                msg = ('Image header info in guest_deploy: rc: %d, header:\n%s'
+                       % (rc, output))
+                LOG.info(msg)
             # Unpack image file to root disk
             vdev = vdev or CONF.zvm.user_root_vdev
             cmd = ['sudo', '/opt/zthin/bin/unpackdiskimage', userid, vdev,

--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -877,17 +877,6 @@ class SMTClient(object):
                      remotehost=None, vdev=None, skipdiskcopy=False):
         """ Deploy image and punch config driver to target """
         # (TODO: add the support of multiple disks deploy)
-        image_file = '/'.join([self._get_image_path_by_name(image_name),
-                               CONF.zvm.user_root_vdev])
-        # Run 'hexdump -C -n 64 redhat84_eckd_iso_new_zvmguestconfigure.img' to
-        # parse the image header
-        cmd = ['/usr/bin/hexdump', '-C', '-n', '64', image_file]
-        with zvmutils.expect_and_reraise_internal_error(modID='guest'):
-            (rc, output) = zvmutils.execute(cmd)
-            msg = ('Image header info in guest_deploy: rc: %d, header: %s'
-                   % (rc, output))
-            LOG.info(msg)
-
         if skipdiskcopy:
             msg = ('Start guest_deploy without unpackdiskimage, guest: %(vm)s'
                    'os_version: %(img)s' % {'img': image_name, 'vm': userid})
@@ -896,6 +885,8 @@ class SMTClient(object):
             msg = ('Start to deploy image %(img)s to guest %(vm)s'
                 % {'img': image_name, 'vm': userid})
             LOG.info(msg)
+            image_file = '/'.join([self._get_image_path_by_name(image_name),
+                                   CONF.zvm.user_root_vdev])
             # Unpack image file to root disk
             vdev = vdev or CONF.zvm.user_root_vdev
             cmd = ['sudo', '/opt/zthin/bin/unpackdiskimage', userid, vdev,

--- a/zvmsdk/tests/unit/test_smtclient.py
+++ b/zvmsdk/tests/unit/test_smtclient.py
@@ -15,7 +15,6 @@
 
 import os
 import mock
-from mock import call
 import tempfile
 import time
 import subprocess
@@ -844,7 +843,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
     def test_guest_deploy(self, get_image_path, request, execute, mkdtemp,
                           cleantemp, guestauth, image_query, guest_update):
         base.set_conf("zvm", "user_root_vdev", "0100")
-        execute.side_effect = [(0, ""), (0, ""), (0, "")]
+        execute.side_effect = [(0, ""), (0, "")]
         mkdtemp.return_value = '/tmp/tmpdir'
         image_query.return_value = [{'imageosdistro': 'fakeos'}]
         userid = 'fakeuser'
@@ -1070,13 +1069,10 @@ class SDKSMTClientTestCases(base.SDKTestCase):
                            self._smtclient.guest_deploy, userid, image_name,
                            transportfiles)
         get_image_path.assert_called_once_with(image_name)
-        imagefile = '/var/lib/zvmsdk/images/netboot/rhel7/fakeimg/0100'
         unpack_cmd = ['sudo', '/opt/zthin/bin/unpackdiskimage', 'fakeuser',
                       '0100',
-                      imagefile]
-        execute.assert_has_calls([call(['/usr/bin/hexdump',
-                                  '-C', '-n', '64', imagefile]),
-                                  call(unpack_cmd)])
+                     '/var/lib/zvmsdk/images/netboot/rhel7/fakeimg/0100']
+        execute.assert_called_once_with(unpack_cmd)
 
     @mock.patch.object(zvmutils.PathUtils, 'clean_temp_folder')
     @mock.patch.object(tempfile, 'mkdtemp')
@@ -1088,7 +1084,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         base.set_conf("zvm", "user_root_vdev", "0100")
         cp_error = ("/usr/bin/cp: cannot stat '/faketran': "
                     "No such file or directory\n")
-        execute.side_effect = [(0, "hexdump"), (0, ""), (1, cp_error)]
+        execute.side_effect = [(0, ""), (1, cp_error)]
         mkdtemp.return_value = '/tmp/tmpdir'
         userid = 'fakeuser'
         image_name = 'fakeimg'
@@ -1122,7 +1118,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         fake_smt_results = {'rs': 8, 'errno': 0, 'strError': 'Failed',
                              'overallRC': 3, 'rc': 400, 'logEntries': '',
                              'response': ['(Error) output and error info']}
-        execute.side_effect = [(0, ""), (0, ""), (0, "")]
+        execute.side_effect = [(0, ""), (0, "")]
         request.side_effect = [None,
                                exception.SDKSMTRequestFailed(
                                    fake_smt_results, 'fake error')]

--- a/zvmsdk/tests/unit/test_smtclient.py
+++ b/zvmsdk/tests/unit/test_smtclient.py
@@ -15,6 +15,7 @@
 
 import os
 import mock
+from mock import call
 import tempfile
 import time
 import subprocess
@@ -843,7 +844,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
     def test_guest_deploy(self, get_image_path, request, execute, mkdtemp,
                           cleantemp, guestauth, image_query, guest_update):
         base.set_conf("zvm", "user_root_vdev", "0100")
-        execute.side_effect = [(0, ""), (0, "")]
+        execute.side_effect = [(0, ""), (0, ""), (0, "")]
         mkdtemp.return_value = '/tmp/tmpdir'
         image_query.return_value = [{'imageosdistro': 'fakeos'}]
         userid = 'fakeuser'
@@ -1069,10 +1070,13 @@ class SDKSMTClientTestCases(base.SDKTestCase):
                            self._smtclient.guest_deploy, userid, image_name,
                            transportfiles)
         get_image_path.assert_called_once_with(image_name)
+        imagefile = '/var/lib/zvmsdk/images/netboot/rhel7/fakeimg/0100'
         unpack_cmd = ['sudo', '/opt/zthin/bin/unpackdiskimage', 'fakeuser',
                       '0100',
-                     '/var/lib/zvmsdk/images/netboot/rhel7/fakeimg/0100']
-        execute.assert_called_once_with(unpack_cmd)
+                     imagefile]
+        execute.assert_has_calls([call(['/usr/bin/hexdump',
+                                  '-C', '-n', '64', imagefile]),
+                                  call(unpack_cmd)])
 
     @mock.patch.object(zvmutils.PathUtils, 'clean_temp_folder')
     @mock.patch.object(tempfile, 'mkdtemp')
@@ -1084,7 +1088,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         base.set_conf("zvm", "user_root_vdev", "0100")
         cp_error = ("/usr/bin/cp: cannot stat '/faketran': "
                     "No such file or directory\n")
-        execute.side_effect = [(0, ""), (1, cp_error)]
+        execute.side_effect = [(0, "hexdump"), (0, ""), (1, cp_error)]
         mkdtemp.return_value = '/tmp/tmpdir'
         userid = 'fakeuser'
         image_name = 'fakeimg'
@@ -1118,7 +1122,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         fake_smt_results = {'rs': 8, 'errno': 0, 'strError': 'Failed',
                              'overallRC': 3, 'rc': 400, 'logEntries': '',
                              'response': ['(Error) output and error info']}
-        execute.side_effect = [(0, ""), (0, "")]
+        execute.side_effect = [(0, ""), (0, ""), (0, "")]
         request.side_effect = [None,
                                exception.SDKSMTRequestFailed(
                                    fake_smt_results, 'fake error')]


### PR DESCRIPTION
Fix for https://github.com/openmainframeproject/feilong/pull/511/files#r707124523
Local test passed:
[2021-09-13 05:11:49] [INFO] Image header info in guest_deploy: rc: 0, header:
00000000  78 43 41 54 20 43 4b 44  20 44 69 73 6b 20 49 6d  |xCAT CKD Disk Im|
00000010  61 67 65 3a 20 20 20 20  20 20 20 31 34 35 36 34  |age:       14564|
00000020  20 43 59 4c 20 48 4c 65  6e 3a 20 30 30 35 35 20  | CYL HLen: 0055 |
00000030  47 5a 49 50 3a 20 36 20  20 20 20 20 20 20 20 20  |GZIP: 6         |
00000040
