### PR TITLE
only update database when destroy instance

### DIFF
--- a/zvmsdk/sdkwsgi/validation/parameter_types.py
+++ b/zvmsdk/sdkwsgi/validation/parameter_types.py
@@ -575,6 +575,7 @@ connection_info = {
         'multipath': boolean,
         'mount_point': {'type': 'string'},
         'is_root_volume': boolean,
+        'update_connections_only': boolean,
     },
     'required': ['assigner_id', 'zvm_fcp', 'target_wwpn',
                  'target_lun', 'multipath', 'os_version',


### PR DESCRIPTION
only update database when destroy instance and no need rollback in some cases

related issue: https://github.ibm.com/zvc/planning/issues/7111#issuecomment-35536539
Signed-off-by: flytiger <flytiger@flytiger-PC.cn.ibm.com>