### PR TITLE
fix bugs in decrease/increase fcp usage of database

### DIFF
--- a/zvmsdk/database.py
+++ b/zvmsdk/database.py
@@ -439,6 +439,12 @@ class FCPDbOperator(object):
             result = conn.execute("SELECT * FROM fcp WHERE "
                                   "fcp_id=?", (fcp,))
             fcp_list = result.fetchall()
+            if not fcp_list:
+                msg = 'FCP with id: %s does not exist in DB.' % fcp
+                LOG.error(msg)
+                obj_desc = "FCP with id: %s" % fcp
+                raise exception.SDKObjectNotExistError(obj_desc=obj_desc,
+                                                       modID=self._module_id)
             connections = fcp_list[0][2]
             connections += 1
 
@@ -451,6 +457,12 @@ class FCPDbOperator(object):
             result = conn.execute("SELECT * FROM fcp WHERE "
                                   "fcp_id=?", (fcp,))
             fcp_list = result.fetchall()
+            if not fcp_list:
+                msg = 'FCP with id: %s does not exist in DB.' % fcp
+                LOG.error(msg)
+                obj_desc = "FCP with id: %s" % fcp
+                raise exception.SDKObjectNotExistError(obj_desc=obj_desc,
+                                                       modID=self._module_id)
             connections = fcp_list[0][2]
             connections += 1
 
@@ -464,6 +476,12 @@ class FCPDbOperator(object):
             result = conn.execute("SELECT * FROM fcp WHERE "
                                   "fcp_id=?", (fcp,))
             fcp_list = result.fetchall()
+            if not fcp_list:
+                msg = 'FCP with id: %s does not exist in DB.' % fcp
+                LOG.error(msg)
+                obj_desc = "FCP with id: %s" % fcp
+                raise exception.SDKObjectNotExistError(obj_desc=obj_desc,
+                                                       modID=self._module_id)
             connections = fcp_list[0][2]
             if connections == 0:
                 msg = 'FCP with id: %s no connections in DB.' % fcp

--- a/zvmsdk/tests/unit/test_database.py
+++ b/zvmsdk/tests/unit/test_database.py
@@ -568,6 +568,14 @@ class FCPDbOperatorTestCase(base.SDKTestCase):
         finally:
             self.db_op.delete('1111')
 
+    def test_decrease_usage_of_not_exist_fcp(self):
+        self.assertRaises(exception.SDKObjectNotExistError,
+                          self.db_op.decrease_usage, 'xxxx')
+
+    def test_increase_usage_of_not_exist_fcp(self):
+        self.assertRaises(exception.SDKObjectNotExistError,
+                          self.db_op.increase_usage, 'xxxx')
+
     def test_increase_usage_by_assigner(self):
         self.db_op.new('1111', 0)
         try:


### PR DESCRIPTION
when call decreas_usage/increase_usage with a not existing FCP will raise exception 'out of index'.

Signed-off-by: flytiger <flytiger@flytiger-PC.cn.ibm.com>