### PR TITLE
[master] fix live migrate

### DIFF
--- a/smtLayer/migrateVM.py
+++ b/smtLayer/migrateVM.py
@@ -349,10 +349,10 @@ def moveVM(rh):
     if 'forcestorage' in rh.parms:
         forceOption = forceOption + "STORAGE "
     if forceOption != '':
-        parms.extend(["-k", "\'force=" + forceOption + "\'"])
+        parms.extend(["-k", "force=" + forceOption])
 
     if 'immediate' in rh.parms:
-        parms.extend(["-k", "\'immediate=YES"])
+        parms.extend(["-k", "immediate=YES"])
 
     if 'maxQuiesce' in rh.parms:
         if rh.parms['maxQuiesce'] == -1:

--- a/zvmsdk/api.py
+++ b/zvmsdk/api.py
@@ -747,14 +747,6 @@ class SDKAPI(object):
                 LOG.error(errmsg)
                 raise exception.SDKMissingRequiredInput(msg=errmsg)
 
-            # Add authorization for new zcc.
-            cmd = ('echo -n %s > /etc/iucv_authorized_userid\n' %
-                                                    dest_zcc_userid)
-            rc = self._smtclient.execute_cmd(userid, cmd)
-            if rc != 0:
-                err_msg = ("Add authorization for new zcc failed")
-                LOG.error(err_msg)
-
             # Live_migrate the guest
             operation = "Move guest '%s' to SSI '%s'" % (userid, destination)
             with zvmutils.log_and_reraise_sdkbase_error(operation):
@@ -766,6 +758,15 @@ class SDKAPI(object):
             with zvmutils.log_and_reraise_sdkbase_error(action):
                 self._GuestDbOperator.update_guest_by_userid(userid,
                                                     comments=comments)
+            # Add authorization for new zcc.
+            # This should be done after migration succeeds.
+            cmd = ('echo -n %s > /etc/iucv_authorized_userid\n' %
+                                                    dest_zcc_userid)
+            rc = self._smtclient.execute_cmd(userid, cmd)
+            if rc != 0:
+                err_msg = ("Add authorization for new zcc failed")
+                LOG.error(err_msg)
+
         if lgr_action.lower() == 'test':
             operation = "Test move guest '%s' to SSI '%s'" % (userid,
                                                     destination)

--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -524,9 +524,9 @@ class SMTClient(object):
               {'uid': userid, 'dest': destination})
 
         if 'maxtotal' in parms:
-            rd += ('--maxtotal ' + str(parms['maxTotal']))
+            rd += ('--maxtotal ' + str(parms['maxtotal']))
         if 'maxquiesce' in parms:
-            rd += ('--maxquiesce ' + str(parms['maxquiesce']))
+            rd += (' --maxquiesce ' + str(parms['maxquiesce']))
         if 'immediate' in parms:
             rd += " --immediate"
         if 'forcearch' in parms:


### PR DESCRIPTION
The destination ID in the virtual machine's /etc/iucv_authorized_userid
    should be set to the target compute node's after the migration succeeds.
    Otherwise, it will cause trouble if migration fails.
 There are errors in the arguments' handling of maxtotal, maxquiesce,
    force and immediate.
    The fix makes them work.
