### PR TITLE
Fix 596/2119 issue

### DIFF
--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -2354,6 +2354,15 @@ class SMTClient(object):
                 LOG.debug("The guest %s deleted with 596/3543" % userid)
                 return
 
+            # The CP or CMS command shown resulted in a non-zero
+            # return code. This message is frequently preceded by
+            # a DMK, HCP, or DMS error message that describes the cause
+            # https://www-01.ibm.com/servers/resourcelink/svc0302a.nsf/
+            # pages/zVMV7R2gc246282/$file/hcpk2_v7r2.pdf
+            if err.results['rc'] == 596 and err.results['rs'] == 2119:
+                LOG.debug("The guest %s deleted with 596/2119" % userid)
+                return
+
             msg = "SMT error: %s" % err.format_message()
             raise exception.SDKSMTRequestFailed(err.results, msg)
 

--- a/zvmsdk/tests/unit/test_smtclient.py
+++ b/zvmsdk/tests/unit/test_smtclient.py
@@ -2240,6 +2240,15 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         request.assert_called_once_with(rd)
 
     @mock.patch.object(smtclient.SMTClient, '_request')
+    def test_delete_userid_with_service_machine_error(self, request):
+        rd = 'deletevm fuser1 directory'
+        results = {'rc': 596, 'rs': 2119, 'logEntries': ''}
+        request.side_effect = exception.SDKSMTRequestFailed(results,
+                                                               "fake error")
+        self._smtclient.delete_userid('fuser1')
+        request.assert_called_once_with(rd)
+
+    @mock.patch.object(smtclient.SMTClient, '_request')
     def test_delete_userid_failed(self, request):
         rd = 'deletevm fuser1 directory'
         results = {'rc': 400, 'rs': 104, 'logEntries': ''}


### PR DESCRIPTION
```
2119T Error in CMS command; RC= rc
from: command parameter_string
at line line.
Explanation:
The CP or CMS command shown resulted in a non-zero
return code. This message is frequently preceded by
a DMK, HCP, or DMS error message that describes
the cause. The most common causes of this problem
(in order) are: (a) one of the service machine's disks
has gotten full, usually the PTH (primary transaction
history) disk or the STH (secondary transaction history
disk) listed in the DVHPROFA file with the service
machine's user ID as the filetype; or (b) the service
machine's virtual storage size is insufficient to process
a particularly large data file; or (c) a long
```

see this error in our test env

Signed-off-by: jichenjc <jichenjc@cn.ibm.com>