### PR TITLE
add wwid as a parameter for refresh_bootmap

### DIFF
--- a/zthin-parts/zthin/bin/refresh_bootmap
+++ b/zthin-parts/zthin/bin/refresh_bootmap
@@ -364,8 +364,8 @@ function printCMDExamples {
   #   printCMDDescription{} in "zthinshellutils".
   # @Code:
   echo "Example:
-  ./refresh_bootmap.sh --fcpchannel="5d71" --wwpn="5005076802100C1B" --lun=0000000000000000
-  ./refresh_bootmap.sh --fcpchannel="5d71,5d72" --wwpn="5005076802100C1B,5005076802200C1B,5005076802300C1B,5005076802400C1B,5005076802400C1A,5005076802300C1A,5005076802200C1A,5005076802100C1A" --lun=0000000000000000" 
+  ./refresh_bootmap.sh --fcpchannel="5d71" --wwpn="5005076802100C1B" --lun="0000000000000000" --wwid="600507640083826de00000000000605b"
+  ./refresh_bootmap.sh --fcpchannel="5d71,5d72" --wwpn="5005076802100C1B,5005076802200C1B,5005076802300C1B,5005076802400C1B,5005076802400C1A,5005076802300C1A,5005076802200C1A,5005076802100C1A" --lun="0000000000000000" --wwid="600507640083826de00000000000605b""
 } #printCMDDescription
 
 function parseArgs {
@@ -382,6 +382,7 @@ function parseArgs {
   isOption -f --fcpchannel "   FCP channel IDs. Support multi fcpchannel, split by ','."
   isOption -w --wwpn "         World Wide Port Name IDs. Support multi wwpn, split by ',' Example: 5005076802400c1b"
   isOption -l --lun "          Logical Unit Number ID. Example: 0000000000000000"
+  isOption -d --wwid "         WWID of the volume, Example: 600507640083826de00000000000605b"
   isOption -i --ignitionurl "  (RHCOS only) The URL or local path that points to RHCOS ignition file"
   isOption -n --nicid "        (RHCOS only) The nic ID. Example: 0.0.1000,0.0.1001,0.0.1002"
   isOption -p --ipconfig "     (RHCOS only) The network configuration info. In format of <client-IP>:[<peer>]:<gateway-IP>:<netmask>:<client_hostname>:<interface>:none[:[<dns1>][:<dns2>]]"
@@ -408,6 +409,10 @@ function parseArgs {
       ;;
       -l|--lun=*)
       lun="${i#*=}"
+      shift # past argument=value
+      ;;
+      -d|--wwid=*)
+      wwid="${i#*=}"
       shift # past argument=value
       ;;
       -i|--ignitionurl=*)
@@ -560,19 +565,21 @@ function probePartition {
     inform "Before partprobe, /dev/mapper/ folder content: ${disk_mapper_folder}."
 
     # get the devPath under /dev/mapper
-    map_name=$(multipath -l $wwid -v 1)
-    rc=$?
-    # probe partition
-    if [[ ( $rc -eq 0 ) && ( "$map_name" != "" ) ]]; then
-        devPath="/dev/mapper/$map_name"
-        probe_partition=$(/usr/sbin/partprobe $devPath 2> /dev/null)
+    if [[ "$wwid" != "" ]]; then
+        map_name=$(multipath -l $wwid -v 1)
         rc=$?
-        inform "Manually run command partprobe on $devPath of wwid $wwid with return code: $rc"
-    else
-        inform "Failed to get map_name before partprobe, call partprobe without parameters."
-        probe_partition=$(/usr/sbin/partprobe 2> /dev/null)
-        rc=$?
-        inform "Manually run command partprobe without parameters return code: $rc"
+        # probe partition
+        if [[ ( $rc -eq 0 ) && ( "$map_name" != "" ) ]]; then
+            devPath="/dev/mapper/$map_name"
+            probe_partition=$(/usr/sbin/partprobe $devPath 2> /dev/null)
+            rc=$?
+            inform "Manually run command partprobe on $devPath of wwid $wwid with return code: $rc"
+        else
+            inform "Failed to get map_name before partprobe, call partprobe without parameters."
+            probe_partition=$(/usr/sbin/partprobe 2> /dev/null)
+            rc=$?
+            inform "Manually run command partprobe without parameters return code: $rc"
+        fi
     fi
 
     # ls /dev/disk/by-path
@@ -884,7 +891,10 @@ function refreshZIPL {
         if [[ ${BLS_file_count} -eq 0 ]]; then
           inform "No BLS files found in ${deviceMountPoint}/${BLS_dir}"
         else
-          wwid=`/usr/lib/udev/scsi_id --whitelisted $diskPath 2> /dev/null`
+          if [[ -z "$wwid" ]]; then
+              wwid=`/usr/lib/udev/scsi_id --whitelisted $diskPath 2> /dev/null`
+              inform "The volume wwid is $wwid."
+          fi
           rootPath="root=\/dev\/disk\/by-id\/dm-uuid-part1-mpath-$wwid "
           # Delete all items start with "rd.zfcp="
           sed -ri 's/rd.zfcp=\S+\s*[[:space:]]//g' ${deviceMountPoint}/${BLS_dir}/*.conf
@@ -969,16 +979,23 @@ function refreshFCPBootmap {
   fcpchannels=$(echo ${fcpchannel} | tr '[:upper:]' '[:lower:]')
   lun=$(echo ${lun} | tr '[:upper:]' '[:lower:]')
   wwpn=$(echo ${wwpn} | tr '[:upper:]' '[:lower:]')
+  wwid=$(echo ${wwid} | tr '[:upper:]' '[:lower:]')
 
   # Add 0x to lun
   lun=0x$lun
+  # The disk path in Linux layer will have a '3' as prefix as shown in following example:
+  # /dev/disk/by-id/dm-uuid-part1-mpath-3600507640083826de00000000000605b 
+  # so, append a '3' as a prefix to the input wwid
+  if [[ "$wwid" != "" ]]; then
+      wwid="3"$wwid
+  fi
 
   # Split fcpchannels and wwpn by ","
   IFS=',' read -r -a INPUT_FCPS <<< "$fcpchannels"
   IFS=',' read -r -a INPUT_WWPNS <<< "$wwpn"
   
   # print the parameters value
-  inform "RefreshFCPBootmap begins. FCP: ${INPUT_FCPS[*]}, WWPNs: ${INPUT_WWPNS[*]}, LUN: $lun."
+  inform "RefreshFCPBootmap begins. FCP: ${INPUT_FCPS[*]}, WWPNs: ${INPUT_WWPNS[*]}, LUN: $lun, WWID: $wwid."
 
   # Check the count of FCP devices, if greater than 8, report error and exit.
   fcps_len=${#INPUT_FCPS[@]}
@@ -1129,10 +1146,11 @@ function refreshFCPBootmap {
   # 1b1b:500507680b21bac6 500507680b21bac7 500507680b22bac6 500507680b22bac7
   inform "valid paths string is: $valid_paths_str."
 
-  # Set devNode according to whether multipath is enabled on the compute node
-  wwid=""
   if [[ $multipath_enabled == 1 ]]; then
-      wwid=`/usr/lib/udev/scsi_id --whitelisted $diskPath 2> /dev/null`
+      if [[ -z "$wwid" ]]; then
+          wwid=`/usr/lib/udev/scsi_id --whitelisted $diskPath 2> /dev/null`
+          inform "The volume wwid is $wwid."
+      fi
       devNode="/dev/disk/by-id/dm-uuid-part1-mpath-$wwid"
       inform "Multipath is enabled, using multipath devNode: $devNode."
   else

--- a/zvmconnector/restclient.py
+++ b/zvmconnector/restclient.py
@@ -416,6 +416,7 @@ def req_volume_refresh_bootmap(start_index, *args, **kwargs):
     fcpchannel = kwargs.get('fcpchannels', None)
     wwpn = kwargs.get('wwpn', None)
     lun = kwargs.get('lun', None)
+    wwid = kwargs.get('wwid', '')
     transportfiles = kwargs.get('transportfiles', '')
     guest_networks = kwargs.get('guest_networks', [])
     body = {'info':
@@ -423,6 +424,7 @@ def req_volume_refresh_bootmap(start_index, *args, **kwargs):
             "fcpchannel": fcpchannel,
             "wwpn": wwpn,
             "lun": lun,
+            "wwid": wwid,
             "transportfiles": transportfiles,
             "guest_networks": guest_networks,
         }

--- a/zvmsdk/api.py
+++ b/zvmsdk/api.py
@@ -1661,12 +1661,14 @@ class SDKAPI(object):
         self._volumeop.attach_volume_to_instance(connection_info)
 
     def volume_refresh_bootmap(self, fcpchannels, wwpns, lun,
+                               wwid='',
                                transportfiles=None, guest_networks=None):
         """ Refresh a volume's bootmap info.
 
         :param list of fcpchannels
         :param list of wwpns
         :param string lun
+        :param wwid: (str) the wwid of the target volume
         :param transportfiles: (str) the files that used to customize the vm
         :param list guest_networks: a list of network info for the guest.
                It has one dictionary that contain some of the below keys for
@@ -1698,6 +1700,7 @@ class SDKAPI(object):
                'nic_vdev': '1003}]
         """
         return self._volumeop.volume_refresh_bootmap(fcpchannels, wwpns, lun,
+                                                wwid=wwid,
                                                 transportfiles=transportfiles,
                                                 guest_networks=guest_networks)
 

--- a/zvmsdk/sdkwsgi/handlers/volume.py
+++ b/zvmsdk/sdkwsgi/handlers/volume.py
@@ -78,10 +78,10 @@ class VolumeAction(object):
                                         fcp, userid, reserved,
                                         connections)
 
-    def volume_refresh_bootmap(self, fcpchannel, wwpn, lun,
+    def volume_refresh_bootmap(self, fcpchannel, wwpn, lun, wwid,
                                transportfiles, guest_networks):
         info = self.client.send_request('volume_refresh_bootmap',
-                                        fcpchannel, wwpn, lun,
+                                        fcpchannel, wwpn, lun, wwid,
                                         transportfiles, guest_networks)
         return info
 
@@ -133,15 +133,16 @@ def volume_detach(req):
 @tokens.validate
 def volume_refresh_bootmap(req):
 
-    def _volume_refresh_bootmap(req, fcpchannel, wwpn, lun,
+    def _volume_refresh_bootmap(req, fcpchannel, wwpn, lun, wwid,
                                 transportfiles, guest_networks):
         action = get_action()
-        return action.volume_refresh_bootmap(fcpchannel, wwpn, lun,
+        return action.volume_refresh_bootmap(fcpchannel, wwpn, lun, wwid,
                                              transportfiles, guest_networks)
 
     body = util.extract_json(req.body)
     info = _volume_refresh_bootmap(req, body['info']['fcpchannel'],
                                    body['info']['wwpn'], body['info']['lun'],
+                                   body['info'].get('wwid', ""),
                                    body['info'].get('transportfiles', ""),
                                    body['info'].get('guest_networks', []))
     info_json = json.dumps(info)

--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -806,7 +806,7 @@ class SMTClient(object):
         finally:
             self._pathutils.clean_temp_folder(iucv_path)
 
-    def volume_refresh_bootmap(self, fcpchannels, wwpns, lun,
+    def volume_refresh_bootmap(self, fcpchannels, wwpns, lun, wwid='',
                                transportfiles=None, guest_networks=None):
         guest_networks = guest_networks or []
         fcps = ','.join(fcpchannels)
@@ -814,7 +814,8 @@ class SMTClient(object):
         fcs = "--fcpchannel=%s" % fcps
         wwpns = "--wwpn=%s" % ws
         lun = "--lun=%s" % lun
-        cmd = ['sudo', '/opt/zthin/bin/refresh_bootmap', fcs, wwpns, lun]
+        wwid = "--wwid=%s" % wwid
+        cmd = ['sudo', '/opt/zthin/bin/refresh_bootmap', fcs, wwpns, lun, wwid]
 
         if guest_networks:
             # prepare additional parameters for RHCOS BFV

--- a/zvmsdk/tests/unit/sdkwsgi/handlers/test_volume.py
+++ b/zvmsdk/tests/unit/sdkwsgi/handlers/test_volume.py
@@ -96,13 +96,15 @@ class HandlersVolumeTest(unittest.TestCase):
         fcpchannels = ['5d71']
         wwpns = ['5005076802100c1b', '5005076802200c1b']
         lun = '0000000000000000'
+        wwid = '600507640083826de00000000000605b'
         info = {"fcpchannel": fcpchannels,
                 "wwpn": wwpns,
-                "lun": lun}
+                "lun": lun,
+                "wwid": wwid}
         body_str = {"info": info}
         self.req.body = json.dumps(body_str)
 
         volume.volume_refresh_bootmap(self.req)
         mock_detach.assert_called_once_with(
             'volume_refresh_bootmap',
-            fcpchannels, wwpns, lun, '', [])
+            fcpchannels, wwpns, lun, wwid, '', [])

--- a/zvmsdk/tests/unit/test_api.py
+++ b/zvmsdk/tests/unit/test_api.py
@@ -516,8 +516,9 @@ class SDKAPITestCase(base.SDKTestCase):
         fcpchannel = ['5d71']
         wwpn = ['5005076802100c1b', '5005076802200c1b']
         lun = '01000000000000'
-        self.api.volume_refresh_bootmap(fcpchannel, wwpn, lun)
-        mock_attach.assert_called_once_with(fcpchannel, wwpn, lun,
+        wwid = '600507640083826de00000000000605b'
+        self.api.volume_refresh_bootmap(fcpchannel, wwpn, lun, wwid)
+        mock_attach.assert_called_once_with(fcpchannel, wwpn, lun, wwid=wwid,
                                     transportfiles=None, guest_networks=None)
 
     @mock.patch("zvmsdk.volumeop.VolumeOperatorAPI."

--- a/zvmsdk/tests/unit/test_smtclient.py
+++ b/zvmsdk/tests/unit/test_smtclient.py
@@ -1796,12 +1796,15 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         fcpchannels = ['5d71']
         wwpns = ['5005076802100c1b', '5005076802200c1b']
         lun = '0000000000000000'
+        wwid = '600507640083826de00000000000605b'
         execute.side_effect = [(0, "")]
-        self._smtclient.volume_refresh_bootmap(fcpchannels, wwpns, lun)
+        self._smtclient.volume_refresh_bootmap(fcpchannels, wwpns, lun,
+                                               wwid=wwid)
         refresh_bootmap_cmd = ['sudo', '/opt/zthin/bin/refresh_bootmap',
                                '--fcpchannel=5d71',
                                '--wwpn=5005076802100c1b,5005076802200c1b',
-                               '--lun=0000000000000000']
+                               '--lun=0000000000000000',
+                               '--wwid=600507640083826de00000000000605b']
         execute.assert_called_once_with(refresh_bootmap_cmd, timeout=600)
 
     @mock.patch.object(zvmutils, 'execute')
@@ -1809,12 +1812,15 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         fcpchannels = ['5d71']
         wwpns = ['5005076802100c1b', '5005076802200c1b']
         lun = '0000000000000000'
+        wwid = '600507640083826de00000000000605b'
         execute.side_effect = [(0, "")]
-        self._smtclient.volume_refresh_bootmap(fcpchannels, wwpns, lun)
+        self._smtclient.volume_refresh_bootmap(fcpchannels, wwpns, lun,
+                                               wwid=wwid)
         refresh_bootmap_cmd = ['sudo', '/opt/zthin/bin/refresh_bootmap',
                                '--fcpchannel=5d71',
                                '--wwpn=5005076802100c1b,5005076802200c1b',
-                               '--lun=0000000000000000']
+                               '--lun=0000000000000000',
+                               '--wwid=600507640083826de00000000000605b']
         execute.assert_called_once_with(refresh_bootmap_cmd, timeout=600)
 
     @mock.patch.object(zvmutils, 'get_smt_userid')

--- a/zvmsdk/volumeop.py
+++ b/zvmsdk/volumeop.py
@@ -87,9 +87,11 @@ class VolumeOperatorAPI(object):
         self._volume_manager.detach(connection_info)
 
     def volume_refresh_bootmap(self, fcpchannel, wwpn, lun,
+                               wwid='',
                                transportfiles='', guest_networks=None):
         return self._volume_manager.volume_refresh_bootmap(fcpchannel, wwpn,
-                                            lun, transportfiles=transportfiles,
+                                            lun, wwid=wwid,
+                                            transportfiles=transportfiles,
                                             guest_networks=guest_networks)
 
     def get_volume_connector(self, assigner_id, reserve):
@@ -855,12 +857,14 @@ class FCPVolumeManager(object):
                  "done." % (fcp_list, assigner_id))
 
     def volume_refresh_bootmap(self, fcpchannels, wwpns, lun,
+                               wwid='',
                                transportfiles=None, guest_networks=None):
         ret = None
         with zvmutils.acquire_lock(self._lock):
             LOG.debug('Enter lock scope of volume_refresh_bootmap.')
             ret = self._smtclient.volume_refresh_bootmap(fcpchannels, wwpns,
-                                        lun, transportfiles=transportfiles,
+                                        lun, wwid=wwid,
+                                        transportfiles=transportfiles,
                                         guest_networks=guest_networks)
         LOG.debug('Exit lock of volume_refresh_bootmap with ret %s.' % ret)
         return ret


### PR DESCRIPTION
Before this change, the wwid is get from the scsi_id cmd on a single path after we find
a valid disk show up on the compute node.

But in some error case that the refreshbootmap may fail in very early stage before we find a valid path, eg
when failed to online some FCPs, or no valid path found on any FCPs, in these cases, the wwid maybe "". Then
when doing cleanup at the exit of refreshbootmap, we cann't get the multipath map name (eg, mpatha) from wwid and
then we cann't do the cleanup of the mpath and disk.

so this change would accept wwid as a parameter and use it directly in the cleanup.

Signed-off-by: dyyang <dyyang@cn.ibm.com>