### PR TITLE
enhance to leftover handling

### DIFF
--- a/zthin-parts/zthin/bin/refresh_bootmap
+++ b/zthin-parts/zthin/bin/refresh_bootmap
@@ -298,8 +298,10 @@ function cleanup_fcpdevices {
   inform "Checking mpath device's existence again."
   devmapper_content=$(ls /dev/mapper/)
   inform "/dev/mapper/ folder content: $devmapper_content."
-  if [[ ( "$map_name" != "" ) && ( -e /dev/mapper/${map_name} ) ]]; then
-      inform "Checking LVM on volume."
+  multipath_output=$(multipath -ll 2>&1)
+  inform "multipath output: ${multipath_output}."
+  if [[ "$map_name" != "" ]]; then
+      inform "Checking $map_name existence again."
       # Step 1: check whether the volume contains lvm. If yes, then remove the LVs.
       if [[ "$vgs_str" != "" ]]; then
           # re-use the previously found vg name because under the leftover scenario, the vg name cann't be detected any more


### PR DESCRIPTION
previously we will check the mpath existence again after the lun removed
and fcp devices offline, because we have found there's chance that the multipathd
readded the map again after it is flushed.

But the check will based on whether the /dev/mapper/$map_name file exists. Recently
we find that there's scenario the /dev/mapper/$map_name does not exist while it exists
in the output of 'multipath -l'.

So in this fix, we removed the check of '/dev/mapper/$map_name'， just do the leftover
check and flush again at the end, no side-effect of doing this.