### PR TITLE
remove udevsettle from addLun and increase the refreshbootmap timeout from 600s to 1200s

### DIFF
--- a/zthin-parts/zthin/lib/zthinshellutils
+++ b/zthin-parts/zthin/lib/zthinshellutils
@@ -596,9 +596,6 @@ function addLun {
       printError "An error was encountered while unit_add the disk. rc is $rc."
   fi
 
-  echo add > /sys/bus/ccw/devices/0.0.${fcpChannel}/uevent
-  which udevadm &> /dev/null && udevadm settle || udevsettle
-
   # Wait 30s in total until disk shows up 
   for i in 0.1 0.2 0.2 0.5 1 1 1 2 2 2 5 5 10
   do

--- a/zvmsdk/config.py
+++ b/zvmsdk/config.py
@@ -481,12 +481,12 @@ SDK will only use the fcp devices in the scope of this value.
         ),
     Opt('refresh_bootmap_timeout',
         section='volume',
-        default=600,
+        default=1200,
         opt_type='int',
         help='''
 The timeout value for waiting refresh_bootmap execution, in seconds.
 
-The default value is 600 seconds, if the execution of refresh_bootmap
+The default value is 1200 seconds, if the execution of refresh_bootmap
 reached the timeout, the process of refresh_bootmap will be stopped.
 '''
         ),

--- a/zvmsdk/tests/unit/test_smtclient.py
+++ b/zvmsdk/tests/unit/test_smtclient.py
@@ -1805,7 +1805,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
                                '--wwpn=5005076802100c1b,5005076802200c1b',
                                '--lun=0000000000000000',
                                '--wwid=600507640083826de00000000000605b']
-        execute.assert_called_once_with(refresh_bootmap_cmd, timeout=600)
+        execute.assert_called_once_with(refresh_bootmap_cmd, timeout=1200)
 
     @mock.patch.object(zvmutils, 'execute')
     def test_refresh_bootmap_return_value_withskip(self, execute):
@@ -1821,7 +1821,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
                                '--wwpn=5005076802100c1b,5005076802200c1b',
                                '--lun=0000000000000000',
                                '--wwid=600507640083826de00000000000605b']
-        execute.assert_called_once_with(refresh_bootmap_cmd, timeout=600)
+        execute.assert_called_once_with(refresh_bootmap_cmd, timeout=1200)
 
     @mock.patch.object(zvmutils, 'get_smt_userid')
     @mock.patch.object(smtclient.SMTClient, '_request')


### PR DESCRIPTION

1. udevadm settle is not required to add a SCSI disk to Linux, the unit_add will wait for that to
be ready.

2. the refrehsbootmap timeout would cause potential side-effects, so enlarge the default timeout value
from 600s to 1200s.

Signed-off-by: dyyang <dyyang@cn.ibm.com>