### PR TITLE
the sequence of reserved and connections in log was not consistent

### DIFF
--- a/zvmsdk/database.py
+++ b/zvmsdk/database.py
@@ -372,20 +372,20 @@ class FCPDbOperator(object):
         If assigner is None, will get all fcp records.
         Format of return is like :
         [
-          (fcp_id, userid, reserved, connections, path),
-          (u'283c', u'user1', 1, 2, 0),
+          (fcp_id, userid, connections, reserved, path),
+          (u'283c', u'user1', 2, 1, 0),
           (u'483c', u'user2', 0, 0, 1)
         ]
         """
         fcp_info = []
         with get_fcp_conn() as conn:
             if assigner_id:
-                result = conn.execute("SELECT fcp_id, assigner_id, reserved, "
-                        "connections, path FROM fcp WHERE "
+                result = conn.execute("SELECT fcp_id, assigner_id, "
+                        "connections, reserved, path FROM fcp WHERE "
                         "assigner_id=?", (assigner_id,))
             else:
-                result = conn.execute("SELECT fcp_id, assigner_id, reserved, "
-                        "connections, path FROM fcp")
+                result = conn.execute("SELECT fcp_id, assigner_id, "
+                        "connections, reserved, path FROM fcp")
             fcp_info = result.fetchall()
             if not fcp_info:
                 if assigner_id:

--- a/zvmsdk/hostops.py
+++ b/zvmsdk/hostops.py
@@ -50,9 +50,9 @@ class HOSTOps(object):
             ret = []
         # format of the output ret is like:
         # {
-        #   path_id : [ ('fcp id', 'userid', reserved, connections, path) ],
-        #   0: [ ('1a00', 'userid1', 1, 2, 0), ('1a01', 'userid2', 1, 1, 0) ],
-        #   1: [ ('1b00', 'userid1', 1, 2, 1), ('1b01', 'userid2', 1, 1, 1) ]
+        #   path_id : [ ('fcp id', 'userid', connections, reserved, path) ],
+        #   0: [ ('1a00', 'userid1', 2, 1, 0), ('1a01', 'userid2', 1, 1, 0) ],
+        #   1: [ ('1b00', 'userid1', 2, 1, 1), ('1b01', 'userid2', 1, 1, 1) ]
         # }
 
         fcp_info = {}

--- a/zvmsdk/tests/unit/test_database.py
+++ b/zvmsdk/tests/unit/test_database.py
@@ -610,10 +610,10 @@ class FCPDbOperatorTestCase(base.SDKTestCase):
         try:
             res = self.db_op.get_all_fcps_of_assigner()
             # Format of return is like:
-            # [(fcp_id, userid, reserved, connections, path), (...)].
+            # [(fcp_id, userid, connections, reserved, path), (...)].
             self.assertEqual(len(res), 2)
             # connections == 0
-            self.assertEqual(res[0][3], 0)
+            self.assertEqual(res[0][2], 0)
             # path of 1111 is 0
             self.assertEqual(res[0][4], 0)
             # path of 2222 is 1

--- a/zvmsdk/volumeop.py
+++ b/zvmsdk/volumeop.py
@@ -1157,9 +1157,9 @@ class FCPVolumeManager(object):
             [userid, reserved, connections, path].
         For example, the return value format should be:
         {
-          '1a00': ('userid1', 1, 2, 0),
+          '1a00': ('userid1', 2, 1, 0),
           '1a01': ('userid2', 1, 1, 0),
-          '1b00': ('userid1', 1, 2, 1),
+          '1b00': ('userid1', 2, 1, 1),
           '1b01': ('userid2', 1, 1, 1)
         }
         """
@@ -1182,8 +1182,8 @@ class FCPVolumeManager(object):
             [fcp_id, userid, reserved, connections, path].
         For example, the return value format should be:
         {
-          0: [ (u'1a00', 'userid1', 1, 2, 0), (u'1a01', 'userid2', 1, 1, 0) ],
-          1: [ (u'1b00', 'userid1', 1, 2, 1), (u'1b01', 'userid2', 1, 1, 1) ]
+          0: [ (u'1a00', 'userid1', 2, 1, 0), (u'1a01', 'userid2', 1, 1, 0) ],
+          1: [ (u'1b00', 'userid1', 2, 1, 1), (u'1b01', 'userid2', 1, 1, 1) ]
         }
         """
         # get FCP records from database


### PR DESCRIPTION
the output of get_all_fcp_usage is reserved, connections, for exmaple:
```
[2021-11-22 00:53:21] [INFO] Got all fcp usage: [('1d0e', 'YDYD00C9', 0, 0, 1), ('1d0d', 'YDYD00C8', 1, 2, 1),
```
the output of got get_available_fcp is connections,reserved, for example:
```
[2021-11-22 00:53:37] [INFO] Got fcp records [('1b0e', 'YDYD00C8', 2, 1, 0, ''), ('1d0d', 'YDYD00C8', 2, 1, 1, '')]
```

Signed-off-by: cao biao <bjcb@cn.ibm.com>