### PR TITLE
add min_fcp_path_count to handle some FCP not available

### DIFF
--- a/doc/source/errcode.csv
+++ b/doc/source/errcode.csv
@@ -36,6 +36,7 @@
 300;30;300;8;Failed to attach volume to instance %(userid)s with reason %(msg)s
 300;30;300;9;Failed to detach volume from instance %(userid)s with reason %(msg)s
 300;30;300;10;Failed to refresh bootmap for RHCOS: transportfiles are required
+300;30;300;11;Failed to get volume connector of %(userid)s because %(msg)s
 **Operation on Image failed**
 300;40;300;1;Database operation failed, error: %(msg)s
 300;40;300;2;No image schema found for %(schema)s

--- a/doc/source/zvmsdk.conf.sample
+++ b/doc/source/zvmsdk.conf.sample
@@ -244,13 +244,26 @@
 
 
 # 
+# The minimum number of FCP paths that should be defined to a vm when attaching
+#  a data volume to a vm or BFV (deploying a vm from SCSI image).
+# 
+# The default value would be the path count of the current fcp_list.
+# 
+# If there is no this count of FCP paths available, the attach volume or BFV
+#  would fail.
+# 
+# This param is optional
+#min_fcp_paths_count=None
+
+
+# 
 # The timeout value for waiting refresh_bootmap execution, in seconds.
 # 
-# The default value is 600 seconds, if the execution of refresh_bootmap
+# The default value is 1200 seconds, if the execution of refresh_bootmap
 # reached the timeout, the process of refresh_bootmap will be stopped.
 # 
 # This param is optional
-#refresh_bootmap_timeout=600
+#refresh_bootmap_timeout=1200
 
 
 [wsgi]

--- a/zthin-parts/zthin/bin/refresh_bootmap
+++ b/zthin-parts/zthin/bin/refresh_bootmap
@@ -366,8 +366,8 @@ function printCMDExamples {
   #   printCMDDescription{} in "zthinshellutils".
   # @Code:
   echo "Example:
-  ./refresh_bootmap.sh --fcpchannel="5d71" --wwpn="5005076802100C1B" --lun="0000000000000000" --wwid="600507640083826de00000000000605b"
-  ./refresh_bootmap.sh --fcpchannel="5d71,5d72" --wwpn="5005076802100C1B,5005076802200C1B,5005076802300C1B,5005076802400C1B,5005076802400C1A,5005076802300C1A,5005076802200C1A,5005076802100C1A" --lun="0000000000000000" --wwid="600507640083826de00000000000605b""
+  ./refresh_bootmap.sh --fcpchannel="5d71" --wwpn="5005076802100C1B" --lun="0000000000000000" --wwid="600507640083826de00000000000605b" --minfcp="1"
+  ./refresh_bootmap.sh --fcpchannel="5d71,5d72" --wwpn="5005076802100C1B,5005076802200C1B,5005076802300C1B,5005076802400C1B,5005076802400C1A,5005076802300C1A,5005076802200C1A,5005076802100C1A" --lun="0000000000000000" --wwid="600507640083826de00000000000605b" --minfcp="2""
 } #printCMDDescription
 
 function parseArgs {
@@ -385,6 +385,7 @@ function parseArgs {
   isOption -w --wwpn "         World Wide Port Name IDs. Support multi wwpn, split by ',' Example: 5005076802400c1b"
   isOption -l --lun "          Logical Unit Number ID. Example: 0000000000000000"
   isOption -d --wwid "         WWID of the volume, Example: 600507640083826de00000000000605b"
+  isOption -m --minfcp "      The minimum acceptable FCP count should be defined to the target vm."
   isOption -i --ignitionurl "  (RHCOS only) The URL or local path that points to RHCOS ignition file"
   isOption -n --nicid "        (RHCOS only) The nic ID. Example: 0.0.1000,0.0.1001,0.0.1002"
   isOption -p --ipconfig "     (RHCOS only) The network configuration info. In format of <client-IP>:[<peer>]:<gateway-IP>:<netmask>:<client_hostname>:<interface>:none[:[<dns1>][:<dns2>]]"
@@ -417,6 +418,10 @@ function parseArgs {
       wwid="${i#*=}"
       shift # past argument=value
       ;;
+      -m|--minfcp=*)
+      minfcp="${i#*=}"
+      shift # past argument=value
+      ;;
       -i|--ignitionurl=*)
       ignitionurl="${i#*=}"
       shift # past argument=value
@@ -434,7 +439,7 @@ function parseArgs {
       shift # past argument with no value
       ;;
       *)
-      printError "Unknow option: $i." 
+      printError "Exit MSG: Unknow option: $i." 
       exit 3
       ;;
   esac
@@ -453,7 +458,7 @@ function checkSanity {
   #   be expected.
   if [[ $device_type = 'fcp' ]]; then
     if [[ ! $lun || ! $fcpchannel ]];then
-        printError "Please specify lun and fcpchannel."
+        printError "Exit MSG: Please specify lun and fcpchannel."
         exit 4
     fi
     # Intentionally non-local variable.
@@ -462,13 +467,13 @@ function checkSanity {
     # We don't support fba now.
     :
   else
-    printError "Unknown device type."
+    printError "Exit MSG: Unknown device type."
     exit 5
   fi
   if [[ ignitionurl || nicid || ipconfig ]]; then
     # ignitionurl, nicid and ipconfig are required for RHCOS BFV
     if [[ ! ignitionurl || ! nicid || ! ipconfig ]]; then
-        printError "Please specify ignitionurl, nicid and ipconfig."
+        printError "Exit MSG: Please specify ignitionurl, nicid and ipconfig."
         exit 6
     fi
   fi
@@ -600,7 +605,7 @@ function mount_boot_partition_rhcos {
     mountpoint=$1
 
     if [ ! -d $mountpoint ]; then
-        printError "mountpoint $mountpoint must be a directory"
+        printError "Exit MSG: mountpoint $mountpoint must be a directory."
         exit 17
     fi
 
@@ -623,7 +628,7 @@ function mount_boot_partition_rhcos {
                 let retry=$retry+1
                 continue
             fi
-            printError "failed mounting boot partition"
+            printError "Exit MSG: failed mounting boot partition"
             exit 17
         fi
         break;
@@ -644,7 +649,7 @@ function update_zipl_bootloader_rhcos {
     rhcosTempDir=$(/usr/bin/mktemp -d /tmp/XXXXX)
     rc=$?
     if [[ $rc -ne 0 ]]; then
-      printError "Create mount dir fails, rc: $rc."
+      printError "Exit MSG: Create mount dir fails, rc: $rc."
       exit 7
     fi
     deviceMountPoint=$rhcosTempDir/boot_partition
@@ -676,7 +681,7 @@ function update_zipl_bootloader_rhcos {
                     let retry=$retry+1
                     continue
                 else
-                    printError "failed fetching ignition config from ${ignitionurl}: ${RETCODE}"
+                    printError "Exit MSG: failed fetching ignition config from ${ignitionurl}: ${RETCODE}"
                     exit 17
                 fi
                 inform "fetching ignition config from ${ignitionurl}: ${RETCODE}"
@@ -706,7 +711,7 @@ function update_zipl_bootloader_rhcos {
     #Run zipl to update bootloader
     zipl --verbose -p $rhcosTempDir/zipl_prm -i $(ls $deviceMountPoint/ostree/*/*vmlinuz*) -r $(ls $deviceMountPoint/ostree/*/*initramfs*) --target $deviceMountPoint
     if [[ $? -ne 0 ]]; then
-        printError "failed updating bootloder"
+        printError "Exit MSG: failed updating bootloder"
         exit 17
     fi
     #Update BLS config file for reboot
@@ -761,7 +766,7 @@ function refreshZIPL {
     done
     # print error log if retry fails
     if [[ ! -e "$devNode" ]]; then
-      printError "devNode ${devNode} doesn't exist."
+      printError "Exit MSG: devNode ${devNode} doesn't exist."
       printLogs
       exit 6
     fi
@@ -771,7 +776,7 @@ function refreshZIPL {
   deviceMountPoint=$(/usr/bin/mktemp -d /tmp/XXXXX)
   rc=$?
   if [[ $rc -ne 0 ]]; then
-    printError "Create mount dir fails, rc: $rc."
+    printError "Exit MSG: Create mount dir fails, rc: $rc."
     exit 7
   fi
 
@@ -783,7 +788,7 @@ function refreshZIPL {
   mount $devNode ${deviceMountPoint}
   rc=$?
   if [[ $rc -ne 0 ]]; then
-    printError "Mount devNode fails. rc: $rc."
+    printError "Exit MSG: Mount devNode fails. rc: $rc."
     exit 8
   fi
 
@@ -854,7 +859,7 @@ function refreshZIPL {
   if [[ ($os == rhel7*) || ($os == rhel8*) ]]; then
     inform "Refresh $os zipl."
     if [[ ! -e ${deviceMountPoint}/${zipl_conf} ]]; then
-      printError "Failed to execute zipl on $os due to ${deviceMountPoint}/${zipl_conf} not exist."
+      printError "Exit MSG: Failed to execute zipl on $os due to ${deviceMountPoint}/${zipl_conf} not exist."
       exit 13
     else
       # Get root path with wwid, instead of using the UUID
@@ -879,7 +884,7 @@ function refreshZIPL {
       # Create a copy of zipl_conf to be used by zipl command later
       out=`/usr/bin/cp -a ${deviceMountPoint}/${zipl_conf} ${deviceMountPoint}/${zipl_conf}${zipl_postfix} 2>&1`
       if [[ $? -ne 0 ]]; then
-        printError "Failed to create a copy of zipl_conf due to ${out}."
+        printError "Exit MSG: Failed to create a copy of zipl_conf due to ${out}."
         exit 14
       fi
       # Add ${deviceMountPoint} as prefix of "target=|image=|randisk=" to the copy of zipl_conf
@@ -913,13 +918,13 @@ function refreshZIPL {
           # Create a copy of BLS_dir to be used by zipl command later
           out=`mkdir ${deviceMountPoint}/${BLS_dir}${zipl_postfix} 2>&1`
           if [[ ! -d ${deviceMountPoint}/${BLS_dir}${zipl_postfix} ]]; then
-            printError "Failed to create a copy of BLS_dir due to ${out}"
+            printError "Exit MSG: Failed to create a copy of BLS_dir due to ${out}"
             exit 15
           fi
           # Copy BLS files to the copy of BLS_dir
           out=`/usr/bin/cp -a ${deviceMountPoint}/${BLS_dir}/*.conf ${deviceMountPoint}/${BLS_dir}${zipl_postfix} 2>&1`
           if [[ $? -ne 0 ]]; then
-            printError "Failed to copy BLS files to ${BLS_dir}${zipl_postfix} due to ${out}."
+            printError "Exit MSG: Failed to copy BLS files to ${BLS_dir}${zipl_postfix} due to ${out}."
             exit 16
           fi
           # Add ${deviceMountPoint} as prefix of "linux | initrd" to BLS files of the copy of BLS_dir
@@ -948,7 +953,7 @@ function refreshZIPL {
 
   # Check zipl result
   if [[ $rc_zipl -ne 0 ]]; then
-    printError "Failed to execute zipl on $os due to $out_zipl."
+    printError "Exit MSG: Failed to execute zipl on $os due to $out_zipl."
     return 1
   else
     inform "Successed to execute zipl on $os. Output: $out_zipl"
@@ -1000,13 +1005,13 @@ function refreshFCPBootmap {
   IFS=',' read -r -a INPUT_WWPNS <<< "$wwpn"
   
   # print the parameters value
-  inform "RefreshFCPBootmap begins. FCP: ${INPUT_FCPS[*]}, WWPNs: ${INPUT_WWPNS[*]}, LUN: $lun, WWID: $wwid."
+  inform "RefreshFCPBootmap begins. FCP: ${INPUT_FCPS[*]}, WWPNs: ${INPUT_WWPNS[*]}, LUN: $lun, WWID: $wwid, minfcp: $minfcp."
 
   # Check the count of FCP devices, if greater than 8, report error and exit.
   fcps_len=${#INPUT_FCPS[@]}
   if [ $fcps_len -gt 8 ]
   then
-      printError "ERROR: The FCP channel count $fcps_len is greater than 8."
+      printError "Exit MSG: The FCP channel count $fcps_len is greater than 8."
       exit 12
   fi
 
@@ -1026,7 +1031,9 @@ function refreshFCPBootmap {
   # Register EXIT sigual for cleanup FCP devices.
   trap 'cleanup_fcpdevices' EXIT
 
-  # Try to find which physical wwpns are being used.
+  # Dedicate and online each FCP device. Record the number of available FCP devices
+  onlinefcpscount=0
+  onlinefcps=""
   for fcp in "${INPUT_FCPS[@]}"
   do
     # dedicate and online FCP device
@@ -1034,9 +1041,34 @@ function refreshFCPBootmap {
     rc=$?
     if [[ $rc -ne 0 ]]; then
         printError "Failed to dedicate or online FCP: $fcp, rc is $rc."
-        exit 3
+    else
+        ((onlinefcpscount=$onlinefcpscount+1))
+        onlinefcps+="$fcp "
     fi
   done
+
+  # Print info of each FCP
+  for fcp in "${INPUT_FCPS[@]}"
+  do
+      # print the output of `systool -c fc_host` for debug
+      host=$(lszfcp | grep -i $fcp | awk -F' ' '{print $2}')
+      if [[ -n "$host" ]]; then
+          port_state=$(systool -c fc_host -v $host | grep port_state | awk -F'"' '{print $2}')
+          inform "Port state of fcp: $fcp is: $port_state."
+          host_info=$(systool -c fc_host -v $host)
+          inform "Port detail info of fcp: $fcp is: $host_info."
+      else
+          inform "Failed to find host of fcp: $fcp from the lszfcp output, cann't get port state."
+      fi
+  done
+
+  # if the number of online fcp is less than the min FCP number, exit
+  if [[ $onlinefcpscount -lt $minfcp ]]; then
+      printError "Exit MSG: The number of online FCP devices: $onlinefcpscount is less than the required minimum FCP path count: $minfcp."
+      exit 1
+  else
+      inform "The number of online FCP devices: $onlinefcpscount satisfies the required minimum FCP path count: $minfcp."
+  fi
 
   # use the `lszfcp -P` cmd to get the valid combinations of (fcp,wwpn)
   # sample output:
@@ -1052,6 +1084,7 @@ function refreshFCPBootmap {
   # 0.0.1c04 0x500507680b22bac7
   # 0.0.1c04 0x500507680d760027
   lszfcp_output=`lszfcp -P | awk '{print $1}' | awk -F'/' '{print $1,$2}'`
+  inform "Output of 'lszfcp -P': $lszfcp_output."
   declare -A valid_paths_dict
   valid_paths_count=0
   rd_zfcp=""
@@ -1060,6 +1093,7 @@ function refreshFCPBootmap {
   # (["FCP1"]="W1 W2" ["FCP2"]="W3 W4")
   for fcp in "${INPUT_FCPS[@]}"
   do
+      # match accessable target wwpns of this fcp
       for wwpn in "${INPUT_WWPNS[@]}"
       do
           fcp_wwpn_str="0.0.${fcp} 0x${wwpn}"
@@ -1081,6 +1115,17 @@ function refreshFCPBootmap {
       done
   done
 
+  # Usable FCP: Only the FCPs that we can find a valid target WWPN via the `lszfcp -P` can be defined
+  # to VM.
+  # Check whether the count of usable FCPs are bigger than the minimum FCP count
+  #
+  usable_fcps=(${!valid_paths_dict[*]})
+  if [[ ${#usable_fcps[@]} -lt $minfcp ]]; then
+      printError "Exit MSG: Allocated FCPs include: ${INPUT_FCPS[@]}, but the number of usable FCPs(${usable_fcp[@]]}) is less than required minimum FCP count: $minfcp."
+      exit 9
+  fi
+
+  # 
   # check and record all the path that show up after unit_add (combinations of FCP and WWPN)
   # the available_paths_dict will be in the format: (["FCP1"]="W1 W2" ["FCP2"]="W3 W4")
   declare -A available_paths_dict
@@ -1127,7 +1172,7 @@ function refreshFCPBootmap {
 
   # check whether there is valid paths found
   if [[ -z $diskPath ]]; then
-    printError "No avaialble disk found between FCP devices: ${INPUT_FCPS[*]} and wwpns: ${INPUT_WWPNS[*]}"
+    printError "Exit MSG: No avaialble disk found between FCP devices: ${INPUT_FCPS[*]} and wwpns: ${INPUT_WWPNS[*]}"
     printLogs
     exit 10
   fi
@@ -1180,7 +1225,7 @@ function refreshBootMap {
   elif [[ $format = 'FBA' ]]; then
     :
   else
-    printError "Device type not recognised."
+    printError "Exit MSG: Device type not recognised."
     exit 11
   fi 
 } #refreshBootMap

--- a/zthin-parts/zthin/lib/zthinshellutils
+++ b/zthin-parts/zthin/lib/zthinshellutils
@@ -562,6 +562,8 @@ function dedicateOnlineFcp {
   if [[ $? -ne 0 ]]; then
       printError "An error was encountered while connecting to the dedicate device. Response:\n$out"
       return 1
+  else
+      inform "Dedicate FCP device: ${fcpChannel} successfully."
   fi
 
   # Online the FCP channel

--- a/zvmsdk/config.py
+++ b/zvmsdk/config.py
@@ -490,6 +490,19 @@ The default value is 1200 seconds, if the execution of refresh_bootmap
 reached the timeout, the process of refresh_bootmap will be stopped.
 '''
         ),
+    Opt('min_fcp_paths_count',
+        section='volume',
+        opt_type='int',
+        help='''
+The minimum number of FCP paths that should be defined to a vm when attaching
+ a data volume to a vm or BFV (deploying a vm from SCSI image).
+
+The default value would be the path count of the current fcp_list.
+
+If there is no this count of FCP paths available, the attach volume or BFV
+ would fail.
+'''
+        ),
     Opt('get_fcp_pair_with_same_index',
         section='volume',
         default='0',
@@ -625,6 +638,25 @@ class ConfigOpts(object):
                 for opt in opts:
                     val = cf.get(sec, opt)
                     configs[sec][opt] = val
+            # Set the min_fcp_paths_count value as the paths count of current
+            # fcp_list.
+            # if fcp_list is not set, we will use a large number as the value
+            # of min_fcp_paths_count
+            min_fcp_paths_count = 999
+            if "volume" in configs:
+                # if min_fcp_paths_count is not set by user, set the value as
+                # paths count of the current fcp_list
+                if "min_fcp_paths_count" not in configs["volume"] or \
+                not configs["volume"]["min_fcp_paths_count"]:
+                    fcp_list_value = configs['volume'].get('fcp_list', "")
+                    if fcp_list_value != "":
+                        min_fcp_paths_count = len(fcp_list_value.split(';'))
+                    configs["volume"]["min_fcp_paths_count"] = \
+                                                        min_fcp_paths_count
+            else:
+                configs["volume"] = {}
+                # make sure the min_fcp_paths_count is always set
+                configs["volume"]["min_fcp_paths_count"] = min_fcp_paths_count
             return configs
 
     def merge(self, defaults, override):
@@ -685,6 +717,10 @@ class ConfigOpts(object):
                 if (k2 == "user_default_max_cpu") and (
                     v2['default'] is not None):
                     self._check_user_default_max_cpu(v2['default'])
+                # check min_fcp_paths_count
+                if (k2 == "min_fcp_paths_count") and (
+                    v2['default'] is not None):
+                    self._check_min_fcp_paths_count(v2['default'])
 
     def _check_zvm_disk_pool(self, value):
         disks = value.split(':')
@@ -710,6 +746,10 @@ class ConfigOpts(object):
     def _check_user_default_max_cpu(self, value):
         if (value < 1) or (value > 64):
             raise OptFormatError("zvm", "user_default_max_cpu", value)
+
+    def _check_min_fcp_paths_count(self, value):
+        if value < 1:
+            raise OptFormatError("volume", "min_fcp_paths_count", value)
 
     def toDict(self, d):
         D = Dict()

--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -815,7 +815,9 @@ class SMTClient(object):
         wwpns = "--wwpn=%s" % ws
         lun = "--lun=%s" % lun
         wwid = "--wwid=%s" % wwid
-        cmd = ['sudo', '/opt/zthin/bin/refresh_bootmap', fcs, wwpns, lun, wwid]
+        paths = "--minfcp=%s" % CONF.volume.min_fcp_paths_count
+        cmd = ['sudo', '/opt/zthin/bin/refresh_bootmap', fcs, wwpns,
+               lun, wwid, paths]
 
         if guest_networks:
             # prepare additional parameters for RHCOS BFV
@@ -854,7 +856,7 @@ class SMTClient(object):
             err_output = ""
             output_lines = output.split('\n')
             for line in output_lines:
-                if line.__contains__("ERROR:"):
+                if line.__contains__("Exit MSG:"):
                     err_output += ("\\n" + line.strip())
             LOG.error(err_msg + err_output)
             raise exception.SDKVolumeOperationError(rs=5,

--- a/zvmsdk/tests/unit/test_smtclient.py
+++ b/zvmsdk/tests/unit/test_smtclient.py
@@ -1793,6 +1793,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
 
     @mock.patch.object(zvmutils, 'execute')
     def test_refresh_bootmap_return_value(self, execute):
+        base.set_conf('volume', 'min_fcp_paths_count', 2)
         fcpchannels = ['5d71']
         wwpns = ['5005076802100c1b', '5005076802200c1b']
         lun = '0000000000000000'
@@ -1804,11 +1805,13 @@ class SDKSMTClientTestCases(base.SDKTestCase):
                                '--fcpchannel=5d71',
                                '--wwpn=5005076802100c1b,5005076802200c1b',
                                '--lun=0000000000000000',
-                               '--wwid=600507640083826de00000000000605b']
+                               '--wwid=600507640083826de00000000000605b',
+                               '--minfcp=2']
         execute.assert_called_once_with(refresh_bootmap_cmd, timeout=1200)
 
     @mock.patch.object(zvmutils, 'execute')
     def test_refresh_bootmap_return_value_withskip(self, execute):
+        base.set_conf('volume', 'min_fcp_paths_count', 2)
         fcpchannels = ['5d71']
         wwpns = ['5005076802100c1b', '5005076802200c1b']
         lun = '0000000000000000'
@@ -1820,7 +1823,8 @@ class SDKSMTClientTestCases(base.SDKTestCase):
                                '--fcpchannel=5d71',
                                '--wwpn=5005076802100c1b,5005076802200c1b',
                                '--lun=0000000000000000',
-                               '--wwid=600507640083826de00000000000605b']
+                               '--wwid=600507640083826de00000000000605b',
+                               '--minfcp=2']
         execute.assert_called_once_with(refresh_bootmap_cmd, timeout=1200)
 
     @mock.patch.object(zvmutils, 'get_smt_userid')


### PR DESCRIPTION
1. add the option min_fcp_path_count. If available FCP >= min_fcp_path_count, do not report error
and make the BFV can continue, including the two stage would have this check:
     a. allocating FCP (some path may not have free FCPs any more, but other paths have)
     b. refreshbootmap stage (some FCPs may failed to be dedicated or online)

2. To make the FCP database consistent with the FCPs defined to vm, compare the valid_path_string
returned by refreshbootmap, if some fcps allocated but found not usable to be defined in vm, then
mark the fcp unreserved in database.

3. Make the refreshbootmap error msg clean. Previously all msgs printed with prefix "ERROR:" would be printed
in API response and UI msg, which may look like below:
```
Refresh bootmap fails, error code: 10 and reason: \\nERROR: An error was encountered while connecting to the dedicate device. Response:\\nDedicating device 1b11 to IAAS01E1's active configuration...\\nERROR: Failed to dedicate or online FCP: 1b11, rc is 1.\\nERROR: The lun 0x0000000000000000 does not show up on fcp:1a11 and wwpn: 0x500507680b21bac6.\\nERROR: Failed to add disk on fcp: 1a11 and wwpn: 500507680b21bac6, rc is 1.\\nERROR: The lun 0x0000000000000000 does not show up on fcp:1a11 and wwpn: 0x500507680b21bac7.\\nERROR: Failed to add disk on fcp: 1a11 and wwpn: 500507680b21bac7, rc is 1.\\nERROR: No avaialble disk found between FCP devices: 1a11 1b11 and wwpns: 500507680b21bac6 500507680b21bac7 500507680b22bac6 500507680b22bac7 500507680b23bac6 500507680b23bac7"
```
This commit change the exit msg to be marked as "EXIT msg:", only msg marked with this will be returned/displayed.

Signed-off-by: dyyang <dyyang@cn.ibm.com>