### PR TITLE
Remove the FCP database rollback logic commited in PR: https://github.com/openmainframeproject/feilong/pull/538

### DIFF
--- a/zvmsdk/volumeop.py
+++ b/zvmsdk/volumeop.py
@@ -867,16 +867,6 @@ class FCPVolumeManager(object):
                                         transportfiles=transportfiles,
                                         guest_networks=guest_networks)
         LOG.debug('Exit lock of volume_refresh_bootmap with ret %s.' % ret)
-        # if some fcps passed to refreshbootmap but not in the returned valid
-        # path string, then it will not be defined in the vm definition.
-        # We should mark these unusable FCPs as free in ZCC database.
-        for fcp in fcpchannels:
-            if fcp not in ret:
-                LOG.warning("FCP: %s is not in the valid path list returned "
-                            "by refreshbootmap, marking it as free in DB."
-                            % fcp)
-                # mark FCP as free
-                self.db.unreserve(fcp)
         return ret
 
     def attach(self, connection_info):


### PR DESCRIPTION
In previous PR: https://github.com/openmainframeproject/feilong/pull/538
we have this:

> To make the FCP database consistent with the FCPs defined to vm, compare the valid_path_string
>returned by refreshbootmap, if some fcps allocated but found not usable to be defined in vm, then
>mark the fcp unreserved in database.

But this would cause the FCP marked as reserved=0 and connections=1, and also since these FCPs are
already defined in the storage host, we cann't mark them as free.

So this patch would remove the check and keep the unusable FCPs marked as in-use.