### PR TITLE
return the total fcp paths count in get_volume_connector

### DIFF
--- a/zthin-parts/zthin/bin/refresh_bootmap
+++ b/zthin-parts/zthin/bin/refresh_bootmap
@@ -1033,7 +1033,8 @@ function refreshFCPBootmap {
 
   # Dedicate and online each FCP device. Record the number of available FCP devices
   onlinefcpscount=0
-  onlinefcps=""
+  onlinefailed=""
+  onlinesuccess=""
   for fcp in "${INPUT_FCPS[@]}"
   do
     # dedicate and online FCP device
@@ -1041,9 +1042,10 @@ function refreshFCPBootmap {
     rc=$?
     if [[ $rc -ne 0 ]]; then
         printError "Failed to dedicate or online FCP: $fcp, rc is $rc."
+        onlinefailed+="$fcp "
     else
         ((onlinefcpscount=$onlinefcpscount+1))
-        onlinefcps+="$fcp "
+        onlinesuccess+="$fcp "
     fi
   done
 
@@ -1064,7 +1066,7 @@ function refreshFCPBootmap {
 
   # if the number of online fcp is less than the min FCP number, exit
   if [[ $onlinefcpscount -lt $minfcp ]]; then
-      printError "Exit MSG: The number of online FCP devices: $onlinefcpscount is less than the required minimum FCP path count: $minfcp."
+      printError "Exit MSG: Failed to online FCP devices( $onlinefailed) and the number of online FCP devices( $onlinesuccess) is less than the required minimum FCP path count: $minfcp."
       exit 1
   else
       inform "The number of online FCP devices: $onlinefcpscount satisfies the required minimum FCP path count: $minfcp."

--- a/zvmsdk/tests/unit/test_volumeop.py
+++ b/zvmsdk/tests/unit/test_volumeop.py
@@ -837,7 +837,8 @@ class TestFCPVolumeManager(base.SDKTestCase):
                         'wwpns': ['2007123400001234'],
                         'phy_to_virt_initiators': {'2007123400001234':
                             '20076d8500005181'},
-                        'host': 'fakehost'}
+                        'host': 'fakehost',
+                        'fcp_paths': 1}
             self.assertEqual(expected, connections)
 
             fcp_list = self.db_op.get_from_fcp('b83c')

--- a/zvmsdk/volumeop.py
+++ b/zvmsdk/volumeop.py
@@ -1053,11 +1053,12 @@ class FCPVolumeManager(object):
                 'wwpns': [wwpn]
                 'phy_to_virt_initiators':{virt:physical}
                 'host': host
+                'fcp_paths': fcp_list_paths_count
             }
         """
 
         empty_connector = {'zvm_fcp': [], 'wwpns': [], 'host': '',
-                           'phy_to_virt_initiators': {}}
+                           'phy_to_virt_initiators': {}, 'fcp_paths': 0}
         # get lpar name of the userid, if no host name got, raise exception
         zvm_host = zvmutils.get_lpar_name()
         if zvm_host == '':
@@ -1127,10 +1128,13 @@ class FCPVolumeManager(object):
                          "is (assigner_id: %s, reserved:%s, connections: %s)."
                          % (fcp_no, _userid, _reserved, _conns))
 
+        # return the total path count
+        fcp_paths = self.db.get_path_count()
         connector = {'zvm_fcp': fcp_list,
                      'wwpns': wwpns,
                      'phy_to_virt_initiators': phy_virt_wwpn_map,
-                     'host': zvm_host}
+                     'host': zvm_host,
+                     'fcp_paths': fcp_paths}
         LOG.info('get_volume_connector returns %s for %s' %
                   (connector, assigner_id))
         return connector


### PR DESCRIPTION
so that in the upper layer we can check whether the allocated FCP
count equals to the configured total path count. If not equal,
we then can log and send warning msg to end user.

Signed-off-by: dyyang <dyyang@cn.ibm.com>