### PR TITLE
return the lparname_userid as the host value in get_volume_connector

### DIFF
--- a/zvmsdk/api.py
+++ b/zvmsdk/api.py
@@ -1573,14 +1573,15 @@ class SDKAPI(object):
         """Get connector information of the guest for attaching to volumes.
         This API is for Openstack Cinder driver only now.
 
-        Connector information is a dictionary representing the ip of the
-        machine that will be making the connection, the name of the iscsi
-        initiator and the hostname of the machine as follows::
+        Connector information is a dictionary representing the
+        machine that will be making the connection as follows::
 
             {
                 'zvm_fcp': fcp
                 'wwpns': [wwpn]
                 'host': host
+                'phy_to_virt_initiators': {},
+                'fcp_paths': 0
             }
         This information will be used by IBM storwize FC driver in Cinder.
 

--- a/zvmsdk/tests/unit/test_volumeop.py
+++ b/zvmsdk/tests/unit/test_volumeop.py
@@ -837,7 +837,7 @@ class TestFCPVolumeManager(base.SDKTestCase):
                         'wwpns': ['2007123400001234'],
                         'phy_to_virt_initiators': {'2007123400001234':
                             '20076d8500005181'},
-                        'host': 'fakehost',
+                        'host': 'fakehost_fakeuser',
                         'fcp_paths': 1}
             self.assertEqual(expected, connections)
 

--- a/zvmsdk/volumeop.py
+++ b/zvmsdk/volumeop.py
@@ -1052,7 +1052,7 @@ class FCPVolumeManager(object):
                 'zvm_fcp': [fcp]
                 'wwpns': [wwpn]
                 'phy_to_virt_initiators':{virt:physical}
-                'host': host
+                'host': LPARname_userid
                 'fcp_paths': fcp_list_paths_count
             }
         """
@@ -1130,10 +1130,12 @@ class FCPVolumeManager(object):
 
         # return the total path count
         fcp_paths = self.db.get_path_count()
+        # return the lparname+userid as host
+        ret_host = zvm_host + '_' + assigner_id
         connector = {'zvm_fcp': fcp_list,
                      'wwpns': wwpns,
                      'phy_to_virt_initiators': phy_virt_wwpn_map,
-                     'host': zvm_host,
+                     'host': ret_host,
                      'fcp_paths': fcp_paths}
         LOG.info('get_volume_connector returns %s for %s' %
                   (connector, assigner_id))


### PR DESCRIPTION
This can speed up the match of host when finding the host on the storage
backend with supplied wwpns.

Signed-off-by: dyyang <dyyang@cn.ibm.com>