### PR TITLE
[master] sync FCP DB when restart sdkserver

### DIFF
--- a/zvmsdk/tests/unit/test_api.py
+++ b/zvmsdk/tests/unit/test_api.py
@@ -32,6 +32,9 @@ class SDKAPITestCase(base.SDKTestCase):
     def setUp(self):
         super(SDKAPITestCase, self).setUp()
         vmops.VMOps.check_guests_exist_in_db = mock.MagicMock()
+        patcher = mock.patch('zvmsdk.volumeop.FCPManager.sync_db')
+        self.addCleanup(patcher.stop)
+        self.mock_sync_db = patcher.start()
         self.api = api.SDKAPI()
 
     def test_init_ComputeAPI(self):


### PR DESCRIPTION
- Before this PR, FCP DB will not by updated when restarting sdkserver

- With this PR, FCP DB will be synced in the following order
First, sync with the fcp_list of zvmsdk.conf
Second, sync with FCP status queried by smcli System_WWPN_Query to z/VM

Signed-off-by: Da Long Wang <shdlwang@cn.ibm.com>