### PR TITLE
[master] Support dest_zcc_userid to be None

### DIFF
--- a/zvmsdk/sdkwsgi/schemas/guest.py
+++ b/zvmsdk/sdkwsgi/schemas/guest.py
@@ -53,7 +53,7 @@ create = {
 live_migrate_vm = {
     'type': 'object',
     'properties': {
-        'dest_zcc_userid': parameter_types.userid,
+        'dest_zcc_userid': parameter_types.userid_or_None,
         'destination': parameter_types.userid,
         'parms': parameter_types.live_migrate_parms,
         'operation': parameter_types.name,


### PR DESCRIPTION
So that no need to set the userid for the onboarded guest
which has no permission. Without this, LGR can still work.

Signed-off-by: QingFeng Hao <haoqf@linux.vnet.ibm.com>