### PR TITLE
avoid lower case assigner_id in database

### DIFF
--- a/zvmsdk/tests/unit/test_volumeop.py
+++ b/zvmsdk/tests/unit/test_volumeop.py
@@ -804,9 +804,9 @@ class TestFCPManager(base.SDKTestCase):
         get_fcp_pair.return_value = ['1234', '5678']
         expected = ['1234', '5678']
         result = self.fcpops.get_available_fcp('user1', True)
-        assign.assert_has_calls([mock.call('1234', 'user1',
+        assign.assert_has_calls([mock.call('1234', 'USER1',
                                            update_connections=False),
-                                 mock.call('5678', 'user1',
+                                 mock.call('5678', 'USER1',
                                            update_connections=False)])
         self.assertEqual(expected, result)
         # case2: get_allocated return ['c83c', 'c83d']

--- a/zvmsdk/volumeop.py
+++ b/zvmsdk/volumeop.py
@@ -715,6 +715,7 @@ class FCPManager(object):
                 # when the vm provision with both root and data volumes
                 # the root and data volume would get the same FCP devices
                 # with the get_volume_connector call.
+                assigner_id = assigner_id.upper()
                 self.db.assign(item, assigner_id, update_connections=False)
 
             LOG.info("Newly allocated %s fcp for %s assigner" %


### PR DESCRIPTION
if the instance template specified in config.properties is lower case
assign() operation may cause assigner_id in db become lower case
so transfer to upper case every time before calling assign

Signed-off-by: cao biao <bjcb@cn.ibm.com>