### PR TITLE
[master] implement_TODO_for_PR_541

### DIFF
--- a/zvmsdk/tests/unit/test_volumeop.py
+++ b/zvmsdk/tests/unit/test_volumeop.py
@@ -1712,6 +1712,11 @@ class TestFCPVolumeManager(base.SDKTestCase):
             self.db_op.delete('783c')
             self.db_op.delete('883c')
 
+    @mock.patch("zvmsdk.volumeop.FCPManager._sync_db_with_zvm")
+    def test_get_all_fcp_usage_sync_with_zvm(self, mock_sync_db_with_zvm):
+        self.volumeops.get_all_fcp_usage(sync_with_zvm=True)
+        mock_sync_db_with_zvm.assert_called_once()
+
     def test_get_fcp_usage(self):
         self.db_op = database.FCPDbOperator()
         self.db_op.new('283c', 0)

--- a/zvmsdk/volumeop.py
+++ b/zvmsdk/volumeop.py
@@ -1469,10 +1469,7 @@ class FCPVolumeManager(object):
         ret = {}
         # sync the state of FCP devices by calling smcli
         if sync_with_zvm:
-            # TODO
-            LOG.info("Begin to sync state of FCP devices with zvm ...")
-            LOG.info("Sync FCP state done.")
-
+            self.fcp_mgr._sync_db_with_zvm()
         # get raw query results from database
         try:
             raw_usage = self.db.get_all_fcps_of_assigner(assigner_id)


### PR DESCRIPTION
implement_TODO_for_PR_541,
which enables ZCC API get_all_fcp_usage() to sync db with zvm before reading fcp info from db

Signed-off-by: Da Long Wang <shdlwang@cn.ibm.com>