### PR TITLE
[WIP]Add new param to specify migration operation to  guest_register

### DIFF
--- a/zvmconnector/restclient.py
+++ b/zvmconnector/restclient.py
@@ -245,6 +245,9 @@ def req_guest_register(start_index, *args, **kwargs):
             'net_set': args[start_index + 1]}
     if len(args) - start_index == 3:
         body['port_macs'] = args[start_index + 2]
+    if len(args) - start_index == 4:
+        body['port_macs'] = args[start_index + 2]
+        body['migration'] = args[start_index + 3]
     return url, body
 
 
@@ -718,7 +721,7 @@ DATABASE = {
     'guest_register': {
         'method': 'POST',
         'args_required': 3,
-        'args_optional': 1,
+        'args_optional': 2,
         'params_path': 1,
         'request': req_guest_register},
     'guest_deregister': {

--- a/zvmsdk/database.py
+++ b/zvmsdk/database.py
@@ -272,6 +272,26 @@ class NetworkDbOperator(object):
 
         return self._parse_switch_record(switch_list)
 
+    def update_comment_of_switch(self, userid, interface, comment_dict):
+        """Update the content of comment.
+        :param userid: (str) the userid
+        :param interface: (str) the interface number
+        :param comment_dict: (dict) the dict to describe the interface status
+            this api will transfer this into string and store into db
+        The comment in database should be a string like:
+            '{"migrated": 0}'
+        """
+        # the input parameter comment_dict must be a dict
+        if not isinstance(comment_dict, dict):
+            msg = ("Failed to update comments of interface %s because input "
+                   "comment %s is not a dict type." % (interface, comment_dict))
+            raise exception.SDKInternalError(msg=msg, modID=self._module_id)
+        new_comment = json.dumps(comment_dict)
+        # storage the new comment into database
+        with get_network_conn() as conn:
+            conn.execute("UPDATE switch SET comments=? "
+                         "WHERE userid=? and interface=?", (new_comment, userid, interface))
+
 
 class FCPDbOperator(object):
 

--- a/zvmsdk/sdkwsgi/handlers/guest.py
+++ b/zvmsdk/sdkwsgi/handlers/guest.py
@@ -315,8 +315,11 @@ class VMAction(object):
         port_macs = None
         if 'port_macs' in body.keys():
             port_macs = body['port_macs']
+        migration = None
+        if 'migration' in body.keys():
+            migration = body['migration']
         info = self.client.send_request('guest_register',
-                                userid, meta, net_set, port_macs)
+                                userid, meta, net_set, port_macs, migration)
         return info
 
     @validation.schema(guest.deregister_vm)

--- a/zvmsdk/sdkwsgi/schemas/guest.py
+++ b/zvmsdk/sdkwsgi/schemas/guest.py
@@ -266,6 +266,7 @@ register_vm = {
         'meta': {'type': ['string']},
         'net_set': {'type': ['string']},
         'port': {'type': ['string']},
+        'migration': parameter_types.boolean,
     },
     'required': ['meta', 'net_set'],
     'additionalProperties': True


### PR DESCRIPTION
Changes:
- For live migrtion operation, specify migration as True when calling
guest_register
- During live migration, mark guests and switch records in source host
  database with comment as {"migrated": 1}
- During live migration, mark guests and switch record in target host
  database with comment as {"migrated": 0}