### PR TITLE
Skip replace direct and nic couple when vswitch exists in NICDEF

### DIFF
--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -2199,6 +2199,14 @@ class SMTClient(object):
             if len(ent) > 0:
                 new_user_direct.append(ent)
                 if ent.upper().startswith(nicdef):
+                    # If NIC already coupled with this vswitch,
+                    # return and skip following actions,
+                    # such as migrating VM
+                    if ("LAN SYSTEM %s" % vswitch_name) in ent:
+                        LOG.info("NIC %s already coupled to vswitch %s, "
+                                 "skip couple action."
+                                 % (nic_vdev, vswitch_name))
+                        return
                     # vlan_id < 0 means no VLAN ID given
                     v = nicdef
                     if vlan_id < 0:


### PR DESCRIPTION
In couple_nic_to_vswitch, Image Directory is replaced by adding
vswitch to NICDEF statement. If the user directory NICDEF
statment already included the specified switch, means the NIC has
already coupled to the vswitch, error happens when running above
actions.

This commit is to skip replace direct and nic couple when
 vswitch exists in NICDEF. A user scenario is when a VM is migrating
to a target host. The target host detected the device add and call
into couple nic to vswitch.