### PR TITLE
make error msg more clear when no valid path found between FCP and WWPN

### DIFF
--- a/zthin-parts/zthin/bin/refresh_bootmap
+++ b/zthin-parts/zthin/bin/refresh_bootmap
@@ -1117,6 +1117,11 @@ function refreshFCPBootmap {
       done
   done
 
+  # check whether there is valid combination of FCP and target wwpns found from the `lszfcp -P`
+  if [[ $valid_paths_count -eq 0 ]]; then
+      printError "Exit MSG:  No valid path found between FCP devices: ${INPUT_FCPS[*]} and wwpns: ${INPUT_WWPNS[*]}."
+      exit 18
+  fi
   # Usable FCP: Only the FCPs that we can find a valid target WWPN via the `lszfcp -P` can be defined
   # to VM.
   # Check whether the count of usable FCPs are bigger than the minimum FCP count


### PR DESCRIPTION
Signed-off-by: dyyang <dyyang@cn.ibm.com>