### PR TITLE
set the maximum log msg size depending on the msg length

### DIFF
--- a/zthin-parts/zthin/lib/zthinshellutils
+++ b/zthin-parts/zthin/lib/zthinshellutils
@@ -325,8 +325,9 @@ function inform {
   local message=$1
   # @Code:
   message=$(echo "$message" | sed 's/\(\S\)\s\s*/\1 /g')
-  logger -p 'local5.info' \
-            "$$.0 $CMDNAME: ${BASH_SOURCE[1]/*\/}: ${FUNCNAME[1]}: ${message}"
+  fullmsg="$$.0 $CMDNAME: ${BASH_SOURCE[1]/*\/}: ${FUNCNAME[1]}: ${message}"
+  size=${#fullmsg}
+  logger -p 'local5.info' --size $size "$fullmsg"
   echo "${message}"
 } #inform{}
 
@@ -342,8 +343,9 @@ function warn {
   local message=$1
   # @Code:
   message=$(echo "$message" | sed 's/\s\s*/ /g')
-  logger -p 'local5.warning' \
-            "$$.0 $CMDNAME: ${BASH_SOURCE[1]/*\/}: ${FUNCNAME[1]}: ${message}"
+  fullmsg="$$.0 $CMDNAME: ${BASH_SOURCE[1]/*\/}: ${FUNCNAME[1]}: ${message}"
+  size=${#fullmsg}
+  logger -p 'local5.warning' --size $size "$fullmsg"
   echo "WARNING: ${message}"
 } #warn{}
 
@@ -359,8 +361,9 @@ function printError {
   local message=$1
   # @Code:
   message=$(echo "$message" | sed 's/\s\s*/ /g')
-  logger -p 'local5.err' \
-            "$$.0 $CMDNAME: ${BASH_SOURCE[1]/*\/}: ${FUNCNAME[1]}: ${message}"
+  fullmsg="$$.0 $CMDNAME: ${BASH_SOURCE[1]/*\/}: ${FUNCNAME[1]}: ${message}"
+  size=${#fullmsg}
+  logger -p 'local5.err' --size $size "$fullmsg"
   echo "ERROR: ${message}"
 } #printError{}
 


### PR DESCRIPTION
Before the change, the default size 1KB is used as the maximum length
of each single msg. So when the msg length exceeds that length, the msg
will be truncated.

With this fix, the msg size is dynamically set according to the msg length.

Signed-off-by: dyyang <dyyang@cn.ibm.com>