### PR TITLE
fix rhcos network connection issue after LGR

### DIFF
--- a/zthin-parts/zthin/bin/refresh_bootmap
+++ b/zthin-parts/zthin/bin/refresh_bootmap
@@ -715,7 +715,7 @@ function update_zipl_bootloader_rhcos {
         exit 17
     fi
     #Update BLS config file for reboot
-    sed -i -e 's/ignition.firstboot=1//' $rhcosTempDir/zipl_prm
+    sed -i -e 's/ignition.firstboot=1.*//' $rhcosTempDir/zipl_prm
     sed -e '/options/d' $blsfile > $rhcosTempDir/blsfile
     echo "options $(cat $rhcosTempDir/zipl_prm) " >> $rhcosTempDir/blsfile
     cat $rhcosTempDir/blsfile > $blsfile

--- a/zthin-parts/zthin/bin/unpackdiskimage
+++ b/zthin-parts/zthin/bin/unpackdiskimage
@@ -880,7 +880,7 @@ function deployDiskImage {
         exit 1
     fi
     #Update BLS config file for reboot
-    sed -i -e 's/ignition.firstboot=1//' /tmp/$fcpChannel/zipl_prm
+    sed -i -e 's/ignition.firstboot=1.*//' /tmp/$fcpChannel/zipl_prm
     sed -e '/options/d' $blsfile > /tmp/$fcpChannel/blsfile
     echo "options $(cat /tmp/$fcpChannel/zipl_prm) " >>/tmp/$fcpChannel/blsfile
     cat /tmp/$fcpChannel/blsfile > $blsfile
@@ -944,7 +944,7 @@ function deployDiskImage {
         exit 1
     fi
     #Update BLS config file for reboot
-    sed -i -e 's/ignition.firstboot=1//' /tmp/$userID/zipl_prm
+    sed -i -e 's/ignition.firstboot=1.*//' /tmp/$userID/zipl_prm
     sed -e '/options/d' $blsfile > /tmp/$userID/blsfile
     echo "options $(cat /tmp/$userID/zipl_prm) " >>/tmp/$userID/blsfile
     cat /tmp/$userID/blsfile > $blsfile


### PR DESCRIPTION
After the hard reboot of rhcos, network connection will be broken
once LGR to another SSI member.

The root cause is, in current implementation, rhcos network will
be configured via "ip=" kernel parameter, not leveraging
NetworkManager network connection config file.

Fix this by remove "rd.neednet=1", "ip=" and "nameserver=" kernel
parameters from rhcos BLS config file after run zipl.

Signed-off-by: bjhuangr <bjhuangr@cn.ibm.com>