### PR TITLE
Update unpackdiskimage under bin directory

### DIFF
--- a/zthin-parts/zthin/bin/unpackdiskimage
+++ b/zthin-parts/zthin/bin/unpackdiskimage
@@ -619,11 +619,12 @@ function deployDiskImage {
     if [[ $(vmcp q v $alias | grep 'BLK ON DASD') ]]; then
       local diskSize="$(dd if=$imageFile bs=1 count=16 skip=20 2>/dev/null |
                         awk '{print $1}')"
+      local targetDiskSize=`vmcp q v $alias | awk '{print $6}'`
       if [[ $diskSize -eq 0 ]]; then
           printError "$imageFile does not contain block information.  This appears to be a dummy image file."
           exit 3
       fi
-      if [[ ${diskSize} -le $(vmcp q v $alias | awk '{print $6}') ]]; then
+      if [[ ${diskSize} -le ${targetDiskSize} ]]; then
         errorFile=`mktemp -p /var/log/zthin -t unpackStderr.XXXXXXXXXX`
         if (( $? )); then
           printError "Failed to create a temporary file in the /var/log/zthin directory"
@@ -658,7 +659,7 @@ function deployDiskImage {
           exit 3
         fi
       else
-        printError "Target disk is too small for specified image."
+        printError "Target disk is too small for specified image. The image has $diskSize blocks in the header, deploy to a disk with $targetDiskSize blocks, either deploy to a bigger size target disk or create a smaller image."
         exit 3
       fi
     else


### PR DESCRIPTION
in zcc, unpackdiskimage has error,  printError "Target disk is too small for specified image."

This is for https://github.ibm.com/zvc/planning/issues/4098 again.  There is already a PR https://github.com/openmainframeproject/feilong/pull/576 days ago which updated unpackdiskimage under scripts/.  BOE1 fba disk pool did not work till tonight, so just find that it is the copy under bin takes effect.   

These 2 PRs are hard to be verified because the changed code are in **deployFBAImage** function.  In unpackdiskimage , there are deployFBAptImage and deployFBAImage functions handling fba image.  I have tested all 5 fba images under https://ibm.ent.box.com/folder/118943194912, but none of them calls deployFBAImage. The fix are using similar methods existed in other functions already. 