### PR TITLE
Add more info for unpackdiskimage under zthin-parts/zthin/bin/

### DIFF
--- a/zthin-parts/zthin/bin/unpackdiskimage
+++ b/zthin-parts/zthin/bin/unpackdiskimage
@@ -619,11 +619,12 @@ function deployDiskImage {
     if [[ $(vmcp q v $alias | grep 'BLK ON DASD') ]]; then
       local diskSize="$(dd if=$imageFile bs=1 count=16 skip=20 2>/dev/null |
                         awk '{print $1}')"
+      local targetDiskSize=`vmcp q v $alias | awk '{print $6}'`
       if [[ $diskSize -eq 0 ]]; then
           printError "$imageFile does not contain block information.  This appears to be a dummy image file."
           exit 3
       fi
-      if [[ ${diskSize} -le $(vmcp q v $alias | awk '{print $6}') ]]; then
+      if [[ ${diskSize} -le ${targetDiskSize} ]]; then
         errorFile=`mktemp -p /var/log/zthin -t unpackStderr.XXXXXXXXXX`
         if (( $? )); then
           printError "Failed to create a temporary file in the /var/log/zthin directory"
@@ -658,7 +659,7 @@ function deployDiskImage {
           exit 3
         fi
       else
-        printError "Target disk is too small for specified image."
+        printError "Target disk is too small for specified image. The image has $diskSize blocks in the header, deploy to a disk with $targetDiskSize blocks, either deploy to a bigger size target disk or create a smaller image."
         exit 3
       fi
     else


### PR DESCRIPTION
Signed-off-by: “haoxy” <haoxy@cn.ibm.com>
in zcc, unpackdiskimage has error,  printError "Target disk is too small for specified image."

There is already a PR https://github.com/openmainframeproject/feilong/pull/576 days ago which updated unpackdiskimage under scripts/.  BOE1 fba disk pool has not worked till Jan 13 tonight, so just find the problems: 
1.  There are two files named unpackdiskimage in feilong.  It seems it is the copy under bin takes effect.  So need to change again.
2. These 2 PRs are hard to be verified because the changed code are in **deployFBAImage** function.  In unpackdiskimage , there are deployFBAptImage and deployFBAImage functions handling fba image.  I have tested all 5 existed fba images (rhel82_ext4_fba.img, rhel78_ext4_fba.img, sles15fba_new.img, sles15sp2_ext4_fba.img and ubuntu20_ext4_fba.img), but none of them calls deployFBAImage. 

@jichenjc @bjhuangr @SeanHQF @zhshuj Could you please review? Thanks.
