### PR TITLE
[DO NOT MERGE][POC]refine ZCC token mechanism

### DIFF
--- a/zvmconnector/connector.py
+++ b/zvmconnector/connector.py
@@ -21,37 +21,50 @@ CONN_TYPE_SOCKET = 'socket'
 CONN_TYPE_REST = 'rest'
 
 
-class baseConnection(object):
-    def request(self, api_name, *api_args, **api_kwargs):
-        pass
-
-
-class socketConnection(baseConnection):
-
+class socketConnection(object):
+    """Client based on socket."""
     def __init__(self, ip_addr='127.0.0.1', port=2000, timeout=3600):
         self.client = socketclient.SDKSocketClient(ip_addr, port, timeout)
 
-    def request(self, api_name, *api_args, **api_kwargs):
-        return self.client.call(api_name, *api_args, **api_kwargs)
+    def send_request(self, api_name, *api_args, **api_kwargs):
+        """Refer to SDK API documentation.
 
-
-class restConnection(baseConnection):
-
-    def __init__(self, ip_addr='127.0.0.1', port=8080, ssl_enabled=False,
-                 verify=False, token_path=None):
-        self.client = restclient.RESTClient(ip_addr, port, ssl_enabled, verify,
-                                            token_path)
-
-    def request(self, api_name, *api_args, **api_kwargs):
-        return self.client.call(api_name, *api_args, **api_kwargs)
-
-
-class ZVMConnector(object):
-
-    def __init__(self, ip_addr=None, port=None, timeout=3600,
-                 connection_type=None, ssl_enabled=False, verify=False,
-                 token_path=None):
+        :param api_name:       SDK API name
+        :param *api_args:      SDK API sequence parameters
+        :param **api_kwargs:   SDK API keyword parameters
         """
+        return self.client.call(api_name, *api_args, **api_kwargs)
+
+
+class restConnection(object):
+    """Client based on REST API."""
+    def __init__(self, ip_addr='127.0.0.1', port=8080, ssl_enabled=False,
+                 verify=False):
+        self.client = restclient.RESTClient(ip_addr, port, ssl_enabled, verify)
+
+    def request_token(self, authentication_path):
+        if not authentication_path:
+            # TODO(bjcb): implement this exception
+            raise Exception("Authentication file is necessary!")
+        return self.client.get_token(authentication_path)
+
+    def send_request(self, token, api_name, *api_args, **api_kwargs):
+        """Refer to SDK API documentation.
+
+        :param token:          Token data for authentication
+        :param api_name:       SDK API name
+        :param *api_args:      SDK API sequence parameters
+        :param **api_kwargs:   SDK API keyword parameters
+        """
+        if not token:
+            # TODO(bjcb): implement this exception
+            raise Exception("token is necessary for rest connection!")
+        return self.client.call(token, api_name, *api_args, **api_kwargs)
+
+
+def get_connector(ip_addr=None, port=None, timeout=3600,
+                  connection_type='rest', ssl_enabled=False, verify=False):
+    """
         :param str ip_addr:         IP address of SDK server
         :param int port:            Port of SDK server daemon
         :param int timeout:         Wait timeout if request no response
@@ -64,33 +77,14 @@ class ZVMConnector(object):
                                     TLS certificate, or a string, in which
                                     case it must be a path to a CA bundle
                                     to use. Default to False.
-        :param str token_path:      The path of token file.
-        """
-        if (connection_type is not None and
-                connection_type.lower() == CONN_TYPE_SOCKET):
-            connection_type = CONN_TYPE_SOCKET
-        else:
-            connection_type = CONN_TYPE_REST
-        self.conn = self._get_connection(ip_addr, port, timeout,
-                                         connection_type, ssl_enabled, verify,
-                                         token_path)
+    """
+    if connection_type not in [CONN_TYPE_REST, CONN_TYPE_SOCKET]:
+        raise Exception("The value of connection_type is invalid, it should "
+                        "be rest or socket.")
 
-    def _get_connection(self, ip_addr, port, timeout,
-                        connection_type, ssl_enabled, verify,
-                        token_path):
-        if connection_type == CONN_TYPE_SOCKET:
-            return socketConnection(ip_addr or '127.0.0.1', port or 2000,
-                                    timeout)
-        else:
-            return restConnection(ip_addr or '127.0.0.1', port or 8080,
-                                  ssl_enabled=ssl_enabled, verify=verify,
-                                  token_path=token_path)
-
-    def send_request(self, api_name, *api_args, **api_kwargs):
-        """Refer to SDK API documentation.
-
-        :param api_name:       SDK API name
-        :param *api_args:      SDK API sequence parameters
-        :param **api_kwargs:   SDK API keyword parameters
-        """
-        return self.conn.request(api_name, *api_args, **api_kwargs)
+    if connection_type == CONN_TYPE_SOCKET:
+        return socketConnection(ip_addr or '127.0.0.1', port or 2000,
+                                timeout)
+    else:
+        return restConnection(ip_addr or '127.0.0.1', port or 8080,
+                              ssl_enabled=ssl_enabled, verify=verify)

--- a/zvmsdk/sdkwsgi/handlers/guest.py
+++ b/zvmsdk/sdkwsgi/handlers/guest.py
@@ -39,9 +39,9 @@ CONF = config.CONF
 
 class VMHandler(object):
     def __init__(self):
-        self.client = connector.ZVMConnector(connection_type='socket',
-                                             ip_addr=CONF.sdkserver.bind_addr,
-                                             port=CONF.sdkserver.bind_port)
+        self.client = connector.get_connector(
+            connection_type='socket', ip_addr=CONF.sdkserver.bind_addr,
+            port=CONF.sdkserver.bind_port)
 
     @validation.schema(guest.create)
     def create(self, body):
@@ -247,9 +247,9 @@ class VMHandler(object):
 class VMAction(object):
 
     def __init__(self):
-        self.client = connector.ZVMConnector(connection_type='socket',
-                                             ip_addr=CONF.sdkserver.bind_addr,
-                                             port=CONF.sdkserver.bind_port)
+        self.client = connector.get_connector(
+            connection_type='socket', ip_addr=CONF.sdkserver.bind_addr,
+            port=CONF.sdkserver.bind_port)
         self.dd_semaphore = threading.BoundedSemaphore(
             value=CONF.wsgi.max_concurrent_deploy_capture)
 

--- a/zvmsdk/sdkwsgi/handlers/host.py
+++ b/zvmsdk/sdkwsgi/handlers/host.py
@@ -35,9 +35,9 @@ LOG = log.LOG
 class HostAction(object):
 
     def __init__(self):
-        self.client = connector.ZVMConnector(connection_type='socket',
-                                             ip_addr=CONF.sdkserver.bind_addr,
-                                             port=CONF.sdkserver.bind_port)
+        self.client = connector.get_connector(
+            connection_type='socket', ip_addr=CONF.sdkserver.bind_addr,
+            port=CONF.sdkserver.bind_port)
 
     def get_info(self):
         info = self.client.send_request('host_get_info')

--- a/zvmsdk/sdkwsgi/handlers/image.py
+++ b/zvmsdk/sdkwsgi/handlers/image.py
@@ -33,7 +33,7 @@ LOG = log.LOG
 class ImageAction(object):
 
     def __init__(self):
-        self.client = connector.ZVMConnector(connection_type='socket',
+        self.client = connector.get_connector(connection_type='socket',
                                              ip_addr=CONF.sdkserver.bind_addr,
                                              port=CONF.sdkserver.bind_port)
 

--- a/zvmsdk/sdkwsgi/handlers/volume.py
+++ b/zvmsdk/sdkwsgi/handlers/volume.py
@@ -33,7 +33,7 @@ LOG = log.LOG
 
 class VolumeAction(object):
     def __init__(self):
-        self.client = connector.ZVMConnector(connection_type='socket',
+        self.client = connector.get_connector(connection_type='socket',
                                              ip_addr=CONF.sdkserver.bind_addr,
                                              port=CONF.sdkserver.bind_port)
 

--- a/zvmsdk/sdkwsgi/handlers/vswitch.py
+++ b/zvmsdk/sdkwsgi/handlers/vswitch.py
@@ -33,7 +33,7 @@ LOG = log.LOG
 
 class VswitchAction(object):
     def __init__(self):
-        self.client = connector.ZVMConnector(connection_type='socket',
+        self.client = connector.get_connector(connection_type='socket',
                                              ip_addr=CONF.sdkserver.bind_addr,
                                              port=CONF.sdkserver.bind_port)
 


### PR DESCRIPTION
**Note:** just a draft and POC, no UT added.

there are a lot of token requests in zvmsdk.log, it is confusing and annoying.
So I refine the token mechanism, my though is, we will use restclient like follwing in the future:
```
# step1: get connector object
from zvmconnector import connector
conn = connector.get_connector(ip_addr='127.0.0.1', port='8080', timeout=3600, connection_type='rest')

# step2: if we specify type as REST, we can request a token
token = conn.request_token(authentication_path='/etc/zvmsdk/token.dat')

# step3: put token as parameter to send_request
conn.send_request(token, 'guest_list')
```

in nova-zvm-driver, we will use restclient like:
```
# step1: in utils.ConnectorClient:
self._conn = connector.get_connector()

# step2: request a token and store as a variable
self._token = self._conn.request_token()

# step3: send_request
try:
    conn.send_request(self._token, 'guest_list')
except ServiceUnauthorized:
    # which means the token is expired
    # request token again
    self._token =  conn.request_token(authentication_path='/etc/zvmsdk/token.dat')
    # send request again
    try:
        conn.send_request(token, 'guest_list')
    except:
          xxxx

```

@jichenjc @bjhuangr @dongyanyang this is just a POC, you can review this and give some advice.
I am just not comfortable with so many token requests now, I think no need to add this in CIC 116, but this is an enhancement in the future.

Signed-off-by: cao biao <bjcb@cn.ibm.com>