### PR TITLE
[master]Support resize memory when USER Directory Statement has more than 6 fields

### DIFF
--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -3741,7 +3741,7 @@ class SMTClient(object):
             # u'USER userid password storage max privclass'
             if ent.startswith("USER "):
                 fields = ent.split(' ')
-                if len(fields) != 6:
+                if len(fields) < 6:
                     # This case should not exist if the target user
                     # is created by zcc and not updated manually by user
                     break

--- a/zvmsdk/tests/unit/test_smtclient.py
+++ b/zvmsdk/tests/unit/test_smtclient.py
@@ -4425,6 +4425,42 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         self.assertEqual(reserved_mem, -1)
         self.assertListEqual(user_direct, sample_definition)
 
+    @mock.patch.object(smtclient.SMTClient, 'get_user_direct')
+    def test_get_defined_memory_user_more_than_6_fields(self, get_user_direct):
+        userid = 'testuid'
+        sample_definition = [u'USER TESTUID LBYONLY 4096M 64G G 64',
+                             u'INCLUDE OSDFLT',
+                             u'COMMAND DEF STOR RESERVED 61440M',
+                             u'CPU 00 BASE',
+                             u'IPL 0100',
+                             u'MDISK 0100 3390 5501 5500 OMB1BA MR',
+                             u'']
+        get_user_direct.return_value = sample_definition
+        (defined_mem, max_mem, reserved_mem, user_direct) = \
+            self._smtclient._get_defined_memory(userid)
+        self.assertEqual(defined_mem, 4096)
+        self.assertEqual(max_mem, 65536)
+        self.assertEqual(reserved_mem, 61440)
+        self.assertListEqual(user_direct, sample_definition)
+
+    @mock.patch.object(smtclient.SMTClient, 'get_user_direct')
+    def test_get_defined_memory_user_less_than_6_fields(self, get_user_direct):
+        userid = 'testuid'
+        sample_definition = [u'USER TESTUID LBYONLY 4096M 64G',
+                             u'INCLUDE OSDFLT',
+                             u'COMMAND DEF STOR RESERVED 61440M',
+                             u'CPU 00 BASE',
+                             u'IPL 0100',
+                             u'MDISK 0100 3390 5501 5500 OMB1BA MR',
+                             u'']
+        get_user_direct.return_value = sample_definition
+        (defined_mem, max_mem, reserved_mem, user_direct) = \
+            self._smtclient._get_defined_memory(userid)
+        self.assertEqual(defined_mem, -1)
+        self.assertEqual(max_mem, -1)
+        self.assertEqual(reserved_mem, -1)
+        self.assertListEqual(user_direct, sample_definition)
+
     @mock.patch.object(smtclient.SMTClient, '_request')
     def test_replace_user_direct_err(self, req):
         userid = 'testuid'


### PR DESCRIPTION

Current implementation in smtclient.py, if USER Directory Statement has
fields number not equal to 6, then defined memory and reserved memory value
of the userid are fetched as -1, which leads to memory resize failure.

With this commit, it is not strictly requires the USER Directory Statement
have 6 fields, because there are real cases that has 7 fields.
Now it is to check the fields number is not fewer than 6.

Signed-off-by: Shu Juan Zhang <zshujuan@cn.ibm.com>