### PR TITLE
Update the api get_volume_connector

### DIFF
--- a/zvmconnector/restclient.py
+++ b/zvmconnector/restclient.py
@@ -436,9 +436,11 @@ def req_volume_refresh_bootmap(start_index, *args, **kwargs):
 def req_get_volume_connector(start_index, *args, **kwargs):
     url = '/volumes/conn/%s'
     reserve = kwargs.get('reserve', False)
+    fcp_template_id = kwargs.get('fcp_template_id', None)
     body = {'info':
         {
-            "reserve": reserve
+            "reserve": reserve,
+            "fcp_template_id": fcp_template_id
         }
     }
     fill_kwargs_in_body(body['info'], **kwargs)

--- a/zvmsdk/api.py
+++ b/zvmsdk/api.py
@@ -1582,7 +1582,7 @@ class SDKAPI(object):
         """
         self._networkops.delete_vswitch(vswitch_name, persist)
 
-    def get_volume_connector(self, userid, reserve=False):
+    def get_volume_connector(self, userid, reserve=False, fcp_template_id=None):
         """Get connector information of the guest for attaching to volumes.
         This API is for Openstack Cinder driver only now.
 
@@ -1594,14 +1594,16 @@ class SDKAPI(object):
                 'wwpns': [wwpn]
                 'host': host
                 'phy_to_virt_initiators': {},
-                'fcp_paths': 0
+                'fcp_paths': 0,
+                'fcp_template_id': fcp_template_id
             }
         This information will be used by IBM storwize FC driver in Cinder.
 
         :param str userid: the user id of the guest
         :param boolean reserve: the flag to reserve FCP device
+        :param str fcp_template_id: the fcp template id which FCP devices are allocated bys
         """
-        return self._volumeop.get_volume_connector(userid, reserve)
+        return self._volumeop.get_volume_connector(userid, reserve, fcp_template_id)
 
     def get_all_fcp_usage(self, userid=None, raw=False, statistics=True,
                           sync_with_zvm=False):

--- a/zvmsdk/sdkwsgi/handlers/volume.py
+++ b/zvmsdk/sdkwsgi/handlers/volume.py
@@ -56,9 +56,9 @@ class VolumeAction(object):
         return info
 
     @validation.query_schema(volume.get_volume_connector)
-    def get_volume_connector(self, req, userid, reserve):
+    def get_volume_connector(self, req, userid, reserve, fcp_template_id):
         conn = self.client.send_request('get_volume_connector',
-                                        userid, reserve)
+                                        userid, reserve, fcp_template_id)
         return conn
 
     @validation.query_schema(volume.get_all_fcp_usage)
@@ -158,15 +158,15 @@ def volume_refresh_bootmap(req):
 @util.SdkWsgify
 @tokens.validate
 def get_volume_connector(req):
-    def _get_volume_conn(req, userid, reserve):
+    def _get_volume_conn(req, userid, reserve, fcp_template_id):
         action = get_action()
-        return action.get_volume_connector(req, userid, reserve)
+        return action.get_volume_connector(req, userid, reserve, fcp_template_id)
 
     userid = util.wsgi_path_item(req.environ, 'userid')
     body = util.extract_json(req.body)
     reserve = body['info']['reserve']
-
-    conn = _get_volume_conn(req, userid, reserve)
+    fcp_template_id = body['info']['fcp_template_id'] if 'fcp_template_id' in body['info'] else None
+    conn = _get_volume_conn(req, userid, reserve, fcp_template_id)
     conn_json = json.dumps(conn)
 
     req.response.content_type = 'application/json'


### PR DESCRIPTION
According the new design, user can specify a fcp template while choosing fcp devices, so need to update thee related APIs.

In this PR, updated the api `get_volume_connector`.

This is an example to run the api:
1. with `fcp_template_id` specified while attaching volume:
```
>>> conn.send_request('get_volume_connector', 'WXY00007', reserve=True, fcp_template_id='0002')
{'overallRC': 0, 'modID': None, 'rc': 0, 'rs': 0, 'errmsg': '', 'output': {'zvm_fcp': ['1c13', '1d1e'], 'wwpns': ['c05076de33000355', 'c05076de330003c2'], 'phy_to_virt_initiators': {'c05076de33000355': 'c05076de33002641', 'c05076de330003c2': 'c05076de33002e41'}, 'host': 'BOEM5401_WXY00007', 'fcp_paths': 2, 'fcp_template_id': '0002'}}
```
2. without `fcp_template_id` specified, then the default fcp template will be obtained and used to choose FCP devices:
```
>>> conn.send_request('get_volume_connector', 'WXY00007')
{'overallRC': 0, 'modID': None, 'rc': 0, 'rs': 0, 'errmsg': '', 'output': {'zvm_fcp': ['1c13', '1d1e'], 'wwpns': ['c05076de33000355', 'c05076de330003c2'], 'phy_to_virt_initiators': {'c05076de33000355': 'c05076de33002641', 'c05076de330003c2': 'c05076de33002e41'}, 'host': 'BOEM5401_WXY00007', 'fcp_paths': 2, 'fcp_template_id': '0001'}}
```
3. If user doesn't specify any fcp template, and there is no default fcp template predefined in the DB, then error will be rainsed:
```
>>> conn.send_request('get_volume_connector', 'WXY00007', reserve=True)
{'overallRC': 300, 'modID': 30, 'rc': 300, 'rs': 11, 'errmsg': 'Failed to get volume connector of WXY00007 because No FCP template is specified and no default FCP template is found.', 'output': ''}
```