### PR TITLE
Update API get_volume_connection with fcp template

### DIFF
--- a/zvmconnector/restclient.py
+++ b/zvmconnector/restclient.py
@@ -436,9 +436,11 @@ def req_volume_refresh_bootmap(start_index, *args, **kwargs):
 def req_get_volume_connector(start_index, *args, **kwargs):
     url = '/volumes/conn/%s'
     reserve = kwargs.get('reserve', False)
+    fcp_template_id = kwargs.get('fcp_template_id', None)
     body = {'info':
         {
-            "reserve": reserve
+            "reserve": reserve,
+            "fcp_template_id": fcp_template_id
         }
     }
     fill_kwargs_in_body(body['info'], **kwargs)

--- a/zvmsdk/api.py
+++ b/zvmsdk/api.py
@@ -1582,7 +1582,7 @@ class SDKAPI(object):
         """
         self._networkops.delete_vswitch(vswitch_name, persist)
 
-    def get_volume_connector(self, userid, reserve=False):
+    def get_volume_connector(self, userid, reserve=False, fcp_template_id=None):
         """Get connector information of the guest for attaching to volumes.
         This API is for Openstack Cinder driver only now.
 
@@ -1594,14 +1594,16 @@ class SDKAPI(object):
                 'wwpns': [wwpn]
                 'host': host
                 'phy_to_virt_initiators': {},
-                'fcp_paths': 0
+                'fcp_paths': 0,
+                'fcp_template_id': fcp_template_id
             }
         This information will be used by IBM storwize FC driver in Cinder.
 
         :param str userid: the user id of the guest
         :param boolean reserve: the flag to reserve FCP device
+        :param str fcp_template_id: the fcp template id which FCP devices are allocated by
         """
-        return self._volumeop.get_volume_connector(userid, reserve)
+        return self._volumeop.get_volume_connector(userid, reserve, fcp_template_id)
 
     def get_all_fcp_usage(self, userid=None, raw=False, statistics=True,
                           sync_with_zvm=False):

--- a/zvmsdk/database.py
+++ b/zvmsdk/database.py
@@ -623,21 +623,27 @@ class FCPDbOperator(object):
 
         return connections
 
-    def get_allocated_fcps_from_assigner(self, assigner_id):
+    def get_allocated_fcps_from_assigner(self, assigner_id, fcp_template_id):
         with get_fcp_conn() as conn:
-
-            result = conn.execute("SELECT * FROM fcp WHERE assigner_id=? "
-                                  "AND (connections<>0 OR reserved<>0) "
-                                  "ORDER BY fcp_id ASC", (assigner_id,))
+            result = conn.execute("SELECT * FROM template_fcp_mapping "
+                                  "INNER JOIN fcp "
+                                  "ON template_fcp_mapping.fcp_id=fcp.fcp_id "
+                                  "WHERE template_fcp_mapping.tmpl_id=? "
+                                  "AND fcp.assigner_id=? "
+                                  "AND (fcp.connections<>0 OR fcp.reserved<>0) "
+                                  "ORDER BY template_fcp_mapping.fcp_id ASC", (fcp_template_id, assigner_id))
             fcp_list = result.fetchall()
         return fcp_list
 
-    def get_reserved_fcps_from_assigner(self, assigner_id):
+    def get_reserved_fcps_from_assigner(self, assigner_id, fcp_template_id):
         with get_fcp_conn() as conn:
-
-            result = conn.execute("SELECT * FROM fcp WHERE assigner_id=? "
-                                  "AND reserved <> 0 "
-                                  "ORDER BY fcp_id ASC", (assigner_id,))
+            result = conn.execute("SELECT * FROM template_fcp_mapping "
+                                  "INNER JOIN fcp "
+                                  "ON template_fcp_mapping.fcp_id=fcp.fcp_id "
+                                  "WHERE template_fcp_mapping.tmpl_id=? "
+                                  "AND fcp.assigner_id=? "
+                                  "AND (fcp.connections<>0 OR fcp.reserved<>0) "
+                                  "ORDER BY template_fcp_mapping.fcp_id ASC", (fcp_template_id, assigner_id))
             fcp_list = result.fetchall()
 
         return fcp_list
@@ -661,17 +667,17 @@ class FCPDbOperator(object):
     def get_path_count(self):
         with get_fcp_conn() as conn:
             # Get distinct path list in DB
-            result = conn.execute("SELECT DISTINCT path FROM fcp")
+            result = conn.execute("SELECT DISTINCT path FROM template_fcp_mapping")
             path_list = result.fetchall()
 
         return len(path_list)
 
-    def get_fcp_pair_with_same_index(self):
+    def get_fcp_pair_with_same_index(self, fcp_template_id):
         """ Get a group of available FCPs with the same index,
             which also need satisfy the following conditions:
             a. connections = 0
             b. reserved = 0
-            c. comment includes 'state': 'free'
+            c. state = 'free'
 
         :return fcp_list: (list)
         case 1
@@ -700,20 +706,25 @@ class FCPDbOperator(object):
             4 paths: [7, 4, 5, 6]
             2 paths: [7, 6]
             '''
-            result = conn.execute("SELECT COUNT(path) FROM fcp "
+            result = conn.execute("SELECT COUNT(path) FROM template_fcp_mapping "
+                                  "WHERE tmpl_id=?"
                                   "GROUP BY path "
-                                  "ORDER BY path ASC")
+                                  "ORDER BY path ASC", (fcp_template_id,))
             count_per_path = [a[0] for a in result.fetchall()]
             # case1: return [] if no fcp found in FCP DB
             if not count_per_path:
                 LOG.error("Not enough FCPs available, return empty list.")
                 return fcp_list
-            result = conn.execute("SELECT COUNT(path) FROM fcp "
-                                  "WHERE reserved = 0 "
-                                  "AND connections = 0 "
-                                  "AND comment LIKE \"%state': 'free%\" "
-                                  "GROUP BY path")
-            free_count_per_path = result.fetchall()
+            result = conn.execute("SELECT COUNT(template_fcp_mapping.path) FROM template_fcp_mapping "
+                                  "INNER JOIN fcp "
+                                  "ON template_fcp_mapping.fcp_id=fcp.fcp_id "
+                                  "WHERE template_fcp_mapping.tmpl_id=? "
+                                  "AND fcp.connections=0 "
+                                  "AND fcp.reserved=0 "
+                                  "AND fcp.state='free' "
+                                  "GROUP BY template_fcp_mapping.path "
+                                  "ORDER BY template_fcp_mapping.path", (fcp_template_id,))
+            free_count_per_path = [a[0] for a in result.fetchall()]
             # case2: return [] if no free fcp found from at least one path
             if len(free_count_per_path) < len(count_per_path):
                 # For get_fcp_pair_with_same_index, we will not check the
@@ -727,23 +738,26 @@ class FCPDbOperator(object):
             fcps 2 paths example:
                fcp  conn reserved
               ------------------
-            [('1a00', 1, 1, "{'state': 'active', 'owner': 'user1'}"),
-             ('1a01', 0, 0, "{'state': 'free', 'owner': 'NONE'}"),
-             ('1a02', 0, 0, "{'state': 'free', 'owner': 'NONE'}"),
-             ('1a03', 0, 0, "{'state': 'free', 'owner': 'NONE'}"),
-             ('1a04', 0, 0, "{'state': 'offline', 'owner': 'user3'}"),
+            [('1a00', 1, 1, 'active'),
+             ('1a01', 0, 0, 'free'),
+             ('1a02', 0, 0, 'free'),
+             ('1a03', 0, 0, 'free'),
+             ('1a04', 0, 0, 'offline'"),
              ...
-             ('1b00', 1, 0, "{'state': 'active', 'owner': 'user1'}"),
-             ('1b01', 2, 1, "{'state': 'active', 'owner': 'user2'}"),
-             ('1b02', 0, 0, "{'state': 'free', 'owner': 'NONE'}"),
-             ('1b03', 0, 0, "{'state': 'free', 'owner': 'NONE'}"),
-             ('1b04', 0, 0, "{'state': 'free', 'owner': 'NONE'}"),
+             ('1b00', 1, 0, 'active'),
+             ('1b01', 2, 1, 'active'),
+             ('1b02', 0, 0, 'free'),
+             ('1b03', 0, 0, 'free'),
+             ('1b04', 0, 0, 'free'),
              ...           ]
             '''
-            result = conn.execute("SELECT fcp_id, connections, "
-                                  "reserved, comment "
+            result = conn.execute("SELECT fcp.fcp_id, fcp.connections, "
+                                  "fcp.reserved, fcp.state "
                                   "FROM fcp "
-                                  "ORDER BY path, fcp_id")
+                                  "INNER JOIN template_fcp_mapping "
+                                  "ON template_fcp_mapping.fcp_id=fcp.fcp_id "
+                                  "WHERE template_fcp_mapping.tmpl_id=? "
+                                  "ORDER BY template_fcp_mapping.path, template_fcp_mapping.fcp_id", (fcp_template_id,))
             fcps = result.fetchall()
         '''
         get all free fcps from 1st path
@@ -759,13 +773,7 @@ class FCPDbOperator(object):
             fcp_no = fcps[i][0]
             connections = fcps[i][1]
             reserved = fcps[i][2]
-            comment = fcps[i][3]
-            # Expectedly, comment is a string, such as,
-            # "{'state': 'xxx', 'owner': 'yyy'}"
-            if comment.startswith('{') and comment.endswith('}'):
-                state = eval(comment).get('state', '')
-            else:
-                state = ''
+            state = fcps[i][3]
             if connections == reserved == 0 and state == 'free':
                 fcp_pair_map[i] = [fcp_no]
         '''
@@ -784,11 +792,7 @@ class FCPDbOperator(object):
                 fcp_no = fcps[s + idx][0]
                 connections = fcps[s + idx][1]
                 reserved = fcps[s + idx][2]
-                comment = fcps[s + idx][3]
-                if comment.startswith('{') and comment.endswith('}'):
-                    state = eval(comment).get('state', '')
-                else:
-                    state = ''
+                state = fcps[s + idx][3]
                 if (idx < count_per_path[i + 1] and
                         connections == reserved == 0 and
                         state == 'free'):
@@ -809,26 +813,29 @@ class FCPDbOperator(object):
             LOG.error("Not eligible FCP group found in FCP DB.")
         return fcp_list
 
-    def get_fcp_pair(self):
+    def get_fcp_pair(self, fcp_template_id):
         """ Get a group of available FCPs,
             which satisfy the following conditions:
             a. connections = 0
             b. reserved = 0
-            c. comment includes 'state': 'free'
+            c. state = free
         """
         fcp_list = []
         with get_fcp_conn() as conn:
             # Get distinct path list in DB
-            result = conn.execute("SELECT DISTINCT path FROM fcp")
+            result = conn.execute("SELECT DISTINCT path FROM template_fcp_mapping")
             path_list = result.fetchall()
             # Get fcp_list of every path
             for no in path_list:
-                result = conn.execute("SELECT * FROM fcp "
-                                      "WHERE connections=0 "
-                                      "AND reserved=0 "
-                                      "AND comment LIKE \"%state': 'free%\" "
-                                      "AND path=? ORDER BY "
-                                      "fcp_id", no)
+                result = conn.execute("SELECT * FROM template_fcp_mapping "
+                                      "INNER JOIN fcp "
+                                      "ON template_fcp_mapping.fcp_id=fcp.fcp_id "
+                                      "WHERE template_fcp_mapping.tmpl_id=? "
+                                      "AND fcp.connections=0 "
+                                      "AND fcp.reserved=0 "
+                                      "AND fcp.state='free' "
+                                      "AND template_fcp_mapping.path=? "
+                                      "ORDER BY template_fcp_mapping.fcp_id", (fcp_template_id, no[0]))
                 fcps = result.fetchall()
                 if not fcps:
                     # continue to find whether other paths has available FCP
@@ -854,6 +861,17 @@ class FCPDbOperator(object):
                 return []
         else:
             return fcp_list
+
+    def get_default_fcp_template(self):
+        """Get the default FCP template for this Host."""
+        with get_fcp_conn() as conn:
+            result = conn.execute("select id from template where is_default=1")
+            fcp_tmpl_id = result.fetchall()
+            if fcp_tmpl_id:
+                return fcp_tmpl_id[0][0]
+            else:
+                LOG.warning("Can not find the default FCP template for this host.")
+                return []
 
     def get_all_free_unreserved(self):
         with get_fcp_conn() as conn:

--- a/zvmsdk/database.py
+++ b/zvmsdk/database.py
@@ -683,7 +683,7 @@ class FCPDbOperator(object):
     def get_from_fcp(self, fcp):
         with get_fcp_conn() as conn:
 
-            result = conn.execute("SELECT * FROM fcp where fcp_id=? ", (fcp,))
+            result = conn.execute("SELECT * FROM fcp WHERE fcp_id=?", (fcp,))
             fcp_list = result.fetchall()
 
         return fcp_list

--- a/zvmsdk/database.py
+++ b/zvmsdk/database.py
@@ -778,7 +778,7 @@ class FCPDbOperator(object):
              ...           ]
             '''
             result = conn.execute("SELECT fcp.fcp_id, fcp.connections, "
-                                  "fcp.reserved, fcp.state, fcp.wwpn_npiv, fcp.wwpn_phy, template_fcp_mapping.path"
+                                  "fcp.reserved, fcp.state, fcp.wwpn_npiv, fcp.wwpn_phy, template_fcp_mapping.path "
                                   "FROM fcp "
                                   "INNER JOIN template_fcp_mapping "
                                   "ON template_fcp_mapping.fcp_id=fcp.fcp_id "
@@ -796,13 +796,7 @@ class FCPDbOperator(object):
         '''
         # The FCP count of 1st path
         for i in range(count_per_path[0]):
-            fcp_no = fcps[i][0]
-            connections = fcps[i][1]
-            reserved = fcps[i][2]
-            state = fcps[i][3]
-            wwpn_npiv = fcps[i][4]
-            wwpn_phy = fcps[i][5]
-            fcp_path = fcps[i][6]
+            (fcp_no, connections, reserved, state, wwpn_npiv, wwpn_phy, fcp_path) = fcps[i]
             if connections == reserved == 0 and state == 'free':
                 fcp_pair_map[i] = [(fcp_no, wwpn_npiv, wwpn_phy, fcp_path)]
         '''
@@ -818,13 +812,7 @@ class FCPDbOperator(object):
             for i, c in enumerate(count_per_path[:-1]):
                 s += c
                 # avoid index out of range for per path in fcps[]
-                fcp_no = fcps[s + idx][0]
-                connections = fcps[s + idx][1]
-                reserved = fcps[s + idx][2]
-                state = fcps[s + idx][3]
-                wwpn_npiv = fcps[s + idx][4]
-                wwpn_phy = fcps[s + idx][5]
-                fcp_path = fcps[s + idx][6]
+                (fcp_no, connections, reserved, state, wwpn_npiv, wwpn_phy, fcp_path) = fcps[s + idx]
                 if (idx < count_per_path[i + 1] and
                         connections == reserved == 0 and
                         state == 'free'):
@@ -868,7 +856,7 @@ class FCPDbOperator(object):
                                       "AND fcp.reserved=0 "
                                       "AND fcp.state='free' "
                                       "AND template_fcp_mapping.path=? "
-                                      "ORDER BY template_fcp_mapping.fcp_id", (fcp_template_id, no[0]))
+                                      "ORDER BY template_fcp_mapping.path", (fcp_template_id, no[0]))
                 fcps = result.fetchall()
                 if not fcps:
                     # continue to find whether other paths has available FCP

--- a/zvmsdk/sdkwsgi/handlers/volume.py
+++ b/zvmsdk/sdkwsgi/handlers/volume.py
@@ -56,9 +56,9 @@ class VolumeAction(object):
         return info
 
     @validation.query_schema(volume.get_volume_connector)
-    def get_volume_connector(self, req, userid, reserve):
+    def get_volume_connector(self, req, userid, reserve, fcp_template_id):
         conn = self.client.send_request('get_volume_connector',
-                                        userid, reserve)
+                                        userid, reserve, fcp_template_id)
         return conn
 
     @validation.query_schema(volume.get_all_fcp_usage)
@@ -158,15 +158,15 @@ def volume_refresh_bootmap(req):
 @util.SdkWsgify
 @tokens.validate
 def get_volume_connector(req):
-    def _get_volume_conn(req, userid, reserve):
+    def _get_volume_conn(req, userid, reserve, fcp_template_id):
         action = get_action()
-        return action.get_volume_connector(req, userid, reserve)
+        return action.get_volume_connector(req, userid, reserve, fcp_template_id)
 
     userid = util.wsgi_path_item(req.environ, 'userid')
     body = util.extract_json(req.body)
     reserve = body['info']['reserve']
-
-    conn = _get_volume_conn(req, userid, reserve)
+    fcp_template_id = body['info']['fcp_template_id'] if 'fcp_template_id' in body['info'] else None
+    conn = _get_volume_conn(req, userid, reserve, fcp_template_id)
     conn_json = json.dumps(conn)
 
     req.response.content_type = 'application/json'

--- a/zvmsdk/sdkwsgi/handlers/volume.py
+++ b/zvmsdk/sdkwsgi/handlers/volume.py
@@ -165,7 +165,7 @@ def get_volume_connector(req):
     userid = util.wsgi_path_item(req.environ, 'userid')
     body = util.extract_json(req.body)
     reserve = body['info']['reserve']
-    fcp_template_id = body['info']['fcp_template_id'] if 'fcp_template_id' in body['info'] else None
+    fcp_template_id = body['info'].get('fcp_template_id', None)
     conn = _get_volume_conn(req, userid, reserve, fcp_template_id)
     conn_json = json.dumps(conn)
 

--- a/zvmsdk/volumeop.py
+++ b/zvmsdk/volumeop.py
@@ -1384,6 +1384,13 @@ class FCPVolumeManager(object):
             raise exception.SDKVolumeOperationError(rs=11,
                                                     userid=assigner_id,
                                                     msg=errmsg)
+        """
+            Reserve or unreserve FCP device according to assigner id and FCP template id.
+            The data structure of fcp_list is:  [(fcp_id, wwpn_npiv, wwpn_phy, path)].
+            An example of fcp_list:
+                [('1c10', 'c12345abcdefg1', 'c1234abcd33002641', 0),
+                ('1d10', 'c12345abcdefg2', 'c1234abcd33002641', 1)]
+        """
         if reserve:
             fcp_list = self.fcp_mgr.reserve_fcp_by_assigner_and_fcp_template(assigner_id, fcp_tmpl_id)
         else:
@@ -1397,8 +1404,7 @@ class FCPVolumeManager(object):
         wwpns = []
         phy_virt_wwpn_map = {}
         for fcp in fcp_list:
-            wwpn_npiv = fcp[1]
-            wwpn_phy = fcp[2]
+            (fcp_id, wwpn_npiv, wwpn_phy, path) = fcp
             if not wwpn_npiv:
                 # wwpn_npiv not found in FCP DB
                 errmsg = ("NPIV WWPN of FCP device %s not found in "

--- a/zvmsdk/volumeop.py
+++ b/zvmsdk/volumeop.py
@@ -685,12 +685,10 @@ class FCPManager(object):
 
         return connections
 
-    def _valid_fcp_devcies(self, fcp_list, assigner_id):
+    def _valid_fcp_devcie_wwpn(self, fcp_list, assigner_id):
         """This method is to check if the FCP wwpn_npiv or wwpn_phy is NULL, if yes, raise error"""
         for fcp in fcp_list:
-            fcp_id = fcp[0]
-            wwpn_npiv = fcp[1]
-            wwpn_phy = fcp[2]
+            fcp_id, wwpn_npiv, wwpn_phy, *_ = fcp
             if not wwpn_npiv:
                 # wwpn_npiv not found in FCP DB
                 errmsg = ("NPIV WWPN of FCP device %s not found in "
@@ -784,7 +782,7 @@ class FCPManager(object):
                     LOG.warning("FCPs previously assigned to %s includes %s, "
                                 "it is not equal to the path count: %s." %
                                 (assigner_id, fcp_list, path_count))
-                self._valid_fcp_devcies(fcp_list, assigner_id)
+                self._valid_fcp_devcie_wwpn(fcp_list, assigner_id)
                 # we got it from db, let's reuse it
                 available_list = fcp_list
             return available_list
@@ -819,7 +817,7 @@ class FCPManager(object):
                                                         msg=errmsg)
             fcp_list = self.db.get_reserved_fcps_from_assigner(assigner_id, fcp_template_id)
             if fcp_list:
-                self._valid_fcp_devcies(fcp_list, assigner_id)
+                self._valid_fcp_devcie_wwpn(fcp_list, assigner_id)
                 # the data structure of fcp_list is (fcp_id, wwpn_npiv, wwpn_phy, connections), only unreserve the fcps
                 # with connections=0
                 fcp_ids = [fcp[0] for fcp in fcp_list if fcp[3] == 0]

--- a/zvmsdk/volumeop.py
+++ b/zvmsdk/volumeop.py
@@ -96,8 +96,8 @@ class VolumeOperatorAPI(object):
                                             transportfiles=transportfiles,
                                             guest_networks=guest_networks)
 
-    def get_volume_connector(self, assigner_id, reserve):
-        return self._volume_manager.get_volume_connector(assigner_id, reserve)
+    def get_volume_connector(self, assigner_id, reserve, fcp_template_id=None):
+        return self._volume_manager.get_volume_connector(assigner_id, reserve, fcp_template_id=fcp_template_id)
 
     def check_fcp_exist_in_db(self, fcp, raise_exec=True):
         return self._volume_manager.check_fcp_exist_in_db(fcp, raise_exec)
@@ -690,7 +690,7 @@ class FCPManager(object):
     def is_reserved(self, fcp):
         self.db.is_reserved(fcp)
 
-    def get_available_fcp(self, assigner_id, reserve):
+    def get_available_fcp(self, assigner_id, reserve, fcp_template_id):
         """ Return a group of available FCPs, one FCP per path
             For example,
             if there are 2 FCP paths,
@@ -702,9 +702,9 @@ class FCPManager(object):
         if not reserve:
             # go here, means try to detach volumes, cinder still need the info
             # of the FCPs belongs to assigner to do some cleanup jobs
-            fcp_list = self.db.get_reserved_fcps_from_assigner(assigner_id)
-            LOG.info("Got fcp records %s belonging to instance %s in "
-                     "Unreserve mode." % (fcp_list, assigner_id))
+            fcp_list = self.db.get_reserved_fcps_from_assigner(assigner_id, fcp_template_id)
+            LOG.info("Got fcp records %s belonging to instance %s in fcp template %s in "
+                     "Unreserve mode." % (fcp_list, fcp_template_id, assigner_id))
             # in this case, we just return the fcp_list
             # no need to allocated new ones if fcp_list is empty
             for old_fcp in fcp_list:
@@ -714,9 +714,9 @@ class FCPManager(object):
         # go here, means try to attach volumes
         # first check whether this userid already has a FCP device
         # get the FCP devices belongs to assigner_id
-        fcp_list = self.db.get_allocated_fcps_from_assigner(assigner_id)
-        LOG.info("Previously allocated records %s for instance %s." %
-                 (fcp_list, assigner_id))
+        fcp_list = self.db.get_allocated_fcps_from_assigner(assigner_id, fcp_template_id)
+        LOG.info("Previously allocated records %s for instance %s in fcp template %s." %
+                 (fcp_list, assigner_id, fcp_template_id))
         if not fcp_list:
             # Sync DB to update FCP state,
             # so that allocating new FCPs is based on the latest FCP state
@@ -730,7 +730,7 @@ class FCPManager(object):
                 then fcp pair is randomly selected from below combinations.
                 [fa00,fb00],[fa01,fb01],[fa02,fb02]
                 '''
-                free_unreserved = self.db.get_fcp_pair_with_same_index()
+                free_unreserved = self.db.get_fcp_pair_with_same_index(fcp_template_id)
             else:
                 '''
                 If use get_fcp_pair,
@@ -739,7 +739,7 @@ class FCPManager(object):
                 [fa00,fb01],[fa01,fb01],[fa02,fb01]
                 [fa00,fb02],[fa01,fb02],[fa02,fb02]
                 '''
-                free_unreserved = self.db.get_fcp_pair()
+                free_unreserved = self.db.get_fcp_pair(fcp_template_id)
             for item in free_unreserved:
                 available_list.append(item)
                 # record the assigner id in the fcp DB so that
@@ -753,8 +753,8 @@ class FCPManager(object):
                       (available_list, assigner_id))
         else:
             # reuse the old ones if fcp_list is not empty
-            LOG.info("Found allocated fcps %s for %s, will reuse them."
-                     % (fcp_list, assigner_id))
+            LOG.info("Found allocated fcps %s for %s in fcp template, will reuse them."
+                     % (fcp_list, assigner_id, fcp_template_id))
             path_count = self.db.get_path_count()
             if len(fcp_list) != path_count:
                 # TODO: handle the case when len(fcp_list) < multipath_count
@@ -1231,7 +1231,7 @@ class FCPVolumeManager(object):
                      multipath, os_version, mount_point,
                      is_root_volume, update_connections_only)
 
-    def get_volume_connector(self, assigner_id, reserve):
+    def get_volume_connector(self, assigner_id, reserve, fcp_template_id=None):
         """Get connector information of the instance for attaching to volumes.
 
         Connector information is a dictionary representing the Fibre
@@ -1245,12 +1245,27 @@ class FCPVolumeManager(object):
                 npiv_wwpn2: phy_wwpn2,
             }
             'host': LPARname_VMuserid,
-            'fcp_paths': 2            # the count of fcp paths
+            'fcp_paths': 2,            # the count of fcp paths
+            'fcp_template_id': fcp_template_id # if user doesn't specify it, it is the host default fcp template id
         }
         """
-
+        fcp_tmpl_id = fcp_template_id if fcp_template_id else self.db.get_default_fcp_template()
         empty_connector = {'zvm_fcp': [], 'wwpns': [], 'host': '',
-                           'phy_to_virt_initiators': {}, 'fcp_paths': 0}
+                           'phy_to_virt_initiators': {}, 'fcp_paths': 0, 'fcp_template_id': fcp_tmpl_id}
+        if fcp_tmpl_id is None or len(fcp_tmpl_id) == 0:
+            errmsg = "No FCP template is specified and no default FCP template is found."
+            LOG.error(errmsg)
+            raise exception.SDKVolumeOperationError(rs=11,
+                                                    userid=assigner_id,
+                                                    msg=errmsg)
+        # if reserve is False which means to release FCP devices, fcp_template_id must be specified. Or else, raise err.
+        if fcp_template_id is None and reserve is False:
+            errmsg = "fcp_template_id is not specified while releasing FCP devices."
+            LOG.error(errmsg)
+            raise exception.SDKVolumeOperationError(rs=11,
+                                                    userid=assigner_id,
+                                                    msg=errmsg)
+
         # get lpar name of the userid, if no host name got, raise exception
         zvm_host = zvmutils.get_lpar_name()
         if zvm_host == '':
@@ -1263,7 +1278,7 @@ class FCPVolumeManager(object):
         # let get_available_fcp return all the FCP info include wwpns,
         # then no need to query database again when get wwpns
         # we even can do reserve or unreserve operations together
-        fcp_list = self.fcp_mgr.get_available_fcp(assigner_id, reserve)
+        fcp_list = self.fcp_mgr.get_available_fcp(assigner_id, reserve, fcp_tmpl_id)
         if not fcp_list:
             errmsg = "No available FCP device found."
             LOG.error(errmsg)
@@ -1330,9 +1345,10 @@ class FCPVolumeManager(object):
                      'wwpns': wwpns,
                      'phy_to_virt_initiators': phy_virt_wwpn_map,
                      'host': ret_host,
-                     'fcp_paths': fcp_paths}
-        LOG.info('get_volume_connector returns %s for %s' %
-                  (connector, assigner_id))
+                     'fcp_paths': fcp_paths,
+                     'fcp_template_id': fcp_tmpl_id}
+        LOG.info('get_volume_connector returns %s for assigner %s and fcp template %s' %
+                 (connector, assigner_id, fcp_tmpl_id))
         return connector
 
     def check_fcp_exist_in_db(self, fcp, raise_exec=True):


### PR DESCRIPTION
Signed-off-by: xingjing <xingjing@cn.ibm.com>

According the new design, user can specify a fcp template while choosing fcp devices, so need to update thee related APIs.

In this PR, updated the api `get_volume_connector`.

Here are some examples to run the api:
1. with `fcp_template_id` specified while attaching volume:
```
>>> conn.send_request('get_volume_connector', 'WXY00007', reserve=True, fcp_template_id='0002')
{'overallRC': 0, 'modID': None, 'rc': 0, 'rs': 0, 'errmsg': '', 'output': {'zvm_fcp': ['1c13', '1d1e'], 'wwpns': ['c05076de33000355', 'c05076de330003c2'], 'phy_to_virt_initiators': {'c05076de33000355': 'c05076de33002641', 'c05076de330003c2': 'c05076de33002e41'}, 'host': 'BOEM5401_WXY00007', 'fcp_paths': 2, 'fcp_template_id': '0002'}}
```
2. without `fcp_template_id` specified, then the default fcp template will be obtained and used to choose FCP devices:
```
>>> conn.send_request('get_volume_connector', 'WXY00007', reserve=True)
{'overallRC': 0, 'modID': None, 'rc': 0, 'rs': 0, 'errmsg': '', 'output': {'zvm_fcp': ['1c13', '1d1e'], 'wwpns': ['c05076de33000355', 'c05076de330003c2'], 'phy_to_virt_initiators': {'c05076de33000355': 'c05076de33002641', 'c05076de330003c2': 'c05076de33002e41'}, 'host': 'BOEM5401_WXY00007', 'fcp_paths': 2, 'fcp_template_id': '0001'}}
```
3. If user doesn't specify any fcp template, and there is no default fcp template predefined in the DB, then error will be raised:
```
>>> conn.send_request('get_volume_connector', 'WXY00007', reserve=True)
{'overallRC': 300, 'modID': 30, 'rc': 300, 'rs': 11, 'errmsg': 'Failed to get volume connector of WXY00007 because No FCP template is specified and no default FCP template is found.', 'output': ''}
```
4. if user doesn't specify fcp template while detach a volume, an error will be raised, which means user must specify the fcp template when to release a volume.
```
>>> conn.send_request('get_volume_connector', 'WXY00007', reserve=False)
{'overallRC': 300, 'modID': 30, 'rc': 300, 'rs': 11, 'errmsg': 'Failed to get volume connector of WXY00007 because fcp_template_id must be specified while releasing FCP devices.', 'output': ''}
```

In the table `fcp` in DB, `reserved=1` and `tmpl_id=0001` after reserving FCPs:
```
sqlite> select * from fcp where tmpl_id='0001';
fcp_id      assigner_id  connections  reserved    wwpn_npiv         wwpn_phy          chpid       state       owner       tmpl_id   
----------  -----------  -----------  ----------  ----------------  ----------------  ----------  ----------  ----------  ----------
1d1b        WXY00007     0            1           c05076de3300033a  c05076de33002e41  27          free        none        0001      
1c13        WXY00007     0            1           c05076de33000355  c05076de33002641  32          free        none        0001 
```