### PR TITLE
[fcp-template] rename the variable names on ZCC

### DIFF
--- a/zvmsdk/api.py
+++ b/zvmsdk/api.py
@@ -1813,23 +1813,23 @@ class SDKAPI(object):
                                             connections)
 
     def create_fcp_template(self, name, description, fcp_devices,
-                            default_of_host: bool = False,
-                            default_of_sps: list = None):
+                            host_default: bool = False,
+                            default_sp_list: list = None):
         """API for creating a FCP template in database.
 
         :param str name: the name of the template
         :param str description: the description for the template
         :param str fcp_devices: a fcp list is composed of fcp device IDs,
             range indicator '-', and split indicator ';'.
-        :param bool default_to_host: this template is default to this
+        :param bool host_default: this template is default to this
             host or not
-        :param list default_of_sps: the list of storage providers that will
+        :param list default_sp_list: the list of storage providers that will
             use this FCP template as default FCP template. If None, it means
             no storage provider would use this FCP template as default.
         """
         return self._volumeop.create_fcp_template(
             name, description, fcp_devices,
-            default_of_host=default_of_host, default_of_sps=default_of_sps)
+            host_default=host_default, default_sp_list=default_sp_list)
 
     def volume_attach(self, connection_info):
         """ Attach a volume to a guest. It's prerequisite to active multipath

--- a/zvmsdk/sdkwsgi/handlers/volume.py
+++ b/zvmsdk/sdkwsgi/handlers/volume.py
@@ -110,13 +110,13 @@ class VolumeAction(object):
         name = body.get('name')
         description = body.get('description')
         fcp_devices = body.get('fcp_devices', None)
-        default_of_host = body.get('default_of_host', False)
-        default_of_sps = body.get('default_of_sps', None)
+        host_default = body.get('host_default', False)
+        default_sp_list = body.get('default_sp_list', None)
 
         ret = self.client.send_request('create_fcp_template', name,
                                        description, fcp_devices,
-                                       default_of_host=default_of_host,
-                                       default_of_sps=default_of_sps)
+                                       host_default=host_default,
+                                       default_sp_list=default_sp_list)
         return ret
 
 

--- a/zvmsdk/sdkwsgi/schemas/volume.py
+++ b/zvmsdk/sdkwsgi/schemas/volume.py
@@ -152,8 +152,8 @@ create_fcp_template = {
         'fcp_devices': {
             'type': 'string'
         },
-        'default_of_host': parameter_types.boolean,
-        'default_of_sps': {
+        'host_default': parameter_types.boolean,
+        'default_sp_list': {
             'type': 'array'
         }
     },


### PR DESCRIPTION
1. rename the following var names on ZCC
```
default_of_sps  -> default_sp_list
default_of_host -> host_default
```
2. change
```
if (wwpn_npiv_zvm != wwpn_npiv_db and
        0 != connections and 0 != reserved)
```
to
```
if (wwpn_npiv_zvm != wwpn_npiv_db and
        (0 != connections or 0 != reserved))
```

Signed-off-by: Da Long Wang <shdlwang@cn.ibm.com>