### PR TITLE
[master]Add a new parameter to specify port_type in couple_nic_to_vswitch

### DIFF
--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -2181,7 +2181,8 @@ class SMTClient(object):
         LOG.info(msg)
 
     def couple_nic_to_vswitch(self, userid, nic_vdev,
-                              vswitch_name, active=False, vlan_id=-1):
+                              vswitch_name, active=False,
+                              vlan_id=-1, port_type='ACCESS'):
         """Couple nic to vswitch."""
         if active:
             msg = ("both in the user direct of guest %s and on "
@@ -2219,9 +2220,11 @@ class SMTClient(object):
                     # vlan_id < 0 means no VLAN ID given
                     v = nicdef
                     if vlan_id < 0:
-                        v += " LAN SYSTEM %s" % vswitch_name
+                        v += " LAN SYSTEM %s PORTTYPE %s" \
+                             % (vswitch_name, port_type)
                     else:
-                        v += " LAN SYSTEM %s VLAN %s" % (vswitch_name, vlan_id)
+                        v += " LAN SYSTEM %s VLAN %s PORTTYPE %s" \
+                             % (vswitch_name, vlan_id, port_type)
 
                     new_user_direct.append(v)
         try:

--- a/zvmsdk/tests/unit/test_smtclient.py
+++ b/zvmsdk/tests/unit/test_smtclient.py
@@ -2093,7 +2093,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
     def test_couple_nic_to_vswitch_no_vlan(self, couple_nic, replace,
                                    lock, get_user):
         replace_data = ["USER ABC", "NICDEF 1000 DEVICE 3",
-                        "NICDEF 1000 LAN SYSTEM VS1"]
+                        "NICDEF 1000 LAN SYSTEM VS1 PORTTYPE ACCESS"]
         get_user.return_value = ["USER ABC", "NICDEF 1000 DEVICE 3"]
         self._smtclient.couple_nic_to_vswitch("fake_userid",
                                                "1000",
@@ -2113,7 +2113,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
     def test_couple_nic_to_vswitch_vlan(self, couple_nic, replace,
                                    lock, get_user):
         replace_data = ["USER ABC", "NICDEF 1000 DEVICE 3",
-                        "NICDEF 1000 LAN SYSTEM VS1 VLAN 55"]
+                        "NICDEF 1000 LAN SYSTEM VS1 VLAN 55 PORTTYPE ACCESS"]
         get_user.return_value = ["USER ABC", "NICDEF 1000 DEVICE 3"]
         self._smtclient.couple_nic_to_vswitch("fake_userid",
                                                "1000",
@@ -2135,7 +2135,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
     def test_couple_nic_to_vswitch_vlan_fail(self, couple_nic, replace,
                                    lock, get_user, request):
         replace_data = ["USER ABC", "NICDEF 1000 DEVICE 3",
-                        "NICDEF 1000 LAN SYSTEM VS1 VLAN 55"]
+                        "NICDEF 1000 LAN SYSTEM VS1 VLAN 55 PORTTYPE ACCESS"]
         results = {'rs': 0, 'errno': 0, 'strError': '',
                    'overallRC': 1, 'logEntries': [], 'rc': 0,
                    'response': ['fake response']}
@@ -2168,6 +2168,27 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         lock.assert_not_called()
         replace.assert_not_called()
         couple_nic.assert_not_called()
+
+    @mock.patch.object(smtclient.SMTClient, 'get_user_direct')
+    @mock.patch.object(smtclient.SMTClient, '_lock_user_direct')
+    @mock.patch.object(smtclient.SMTClient, '_replace_user_direct')
+    @mock.patch.object(smtclient.SMTClient, '_couple_nic')
+    def test_couple_nic_to_vswitch_port_type(self, couple_nic, replace,
+                                   lock, get_user):
+        replace_data = ["USER ABC", "NICDEF 1000 DEVICE 3",
+                        "NICDEF 1000 LAN SYSTEM VS1 PORTTYPE TRUNK"]
+        get_user.return_value = ["USER ABC", "NICDEF 1000 DEVICE 3"]
+        self._smtclient.couple_nic_to_vswitch("fake_userid",
+                                               "1000",
+                                               "VS1",
+                                               active=True,
+                                               port_type='TRUNK')
+        lock.assert_called_with("fake_userid")
+        replace.assert_called_with("fake_userid", replace_data)
+        couple_nic.assert_called_with("fake_userid",
+                                      "1000",
+                                      "VS1",
+                                      active=True)
 
     @mock.patch.object(smtclient.SMTClient, '_uncouple_nic')
     def test_uncouple_nic_from_vswitch(self, uncouple_nic):


### PR DESCRIPTION
The new parameter port_type could be ACCESS or TRUNK, when
not specified, it is ACCESS. Then the NICDEF statment is added
'PORTTYPE ACCESS' or 'PORTTYPE TRUNK'.

Signed-off-by: Shu Juan Zhang <zshujuan@cn.ibm.com>