### PR TITLE
[master]Do not add PORTTYPE option to a VLAN UNAWARE vswitch

### DIFF
--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -2220,8 +2220,7 @@ class SMTClient(object):
                     # vlan_id < 0 means no VLAN ID given
                     v = nicdef
                     if vlan_id < 0:
-                        v += " LAN SYSTEM %s PORTTYPE %s" \
-                             % (vswitch_name, port_type)
+                        v += " LAN SYSTEM %s" % vswitch_name
                     else:
                         v += " LAN SYSTEM %s VLAN %s PORTTYPE %s" \
                              % (vswitch_name, vlan_id, port_type)

--- a/zvmsdk/tests/unit/test_smtclient.py
+++ b/zvmsdk/tests/unit/test_smtclient.py
@@ -2093,7 +2093,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
     def test_couple_nic_to_vswitch_no_vlan(self, couple_nic, replace,
                                    lock, get_user):
         replace_data = ["USER ABC", "NICDEF 1000 DEVICE 3",
-                        "NICDEF 1000 LAN SYSTEM VS1 PORTTYPE ACCESS"]
+                        "NICDEF 1000 LAN SYSTEM VS1"]
         get_user.return_value = ["USER ABC", "NICDEF 1000 DEVICE 3"]
         self._smtclient.couple_nic_to_vswitch("fake_userid",
                                                "1000",
@@ -2176,12 +2176,13 @@ class SDKSMTClientTestCases(base.SDKTestCase):
     def test_couple_nic_to_vswitch_port_type(self, couple_nic, replace,
                                    lock, get_user):
         replace_data = ["USER ABC", "NICDEF 1000 DEVICE 3",
-                        "NICDEF 1000 LAN SYSTEM VS1 PORTTYPE TRUNK"]
+                        "NICDEF 1000 LAN SYSTEM VS1 VLAN 8 PORTTYPE TRUNK"]
         get_user.return_value = ["USER ABC", "NICDEF 1000 DEVICE 3"]
         self._smtclient.couple_nic_to_vswitch("fake_userid",
                                                "1000",
                                                "VS1",
                                                active=True,
+                                               vlan_id=8,
                                                port_type='TRUNK')
         lock.assert_called_with("fake_userid")
         replace.assert_called_with("fake_userid", replace_data)


### PR DESCRIPTION
A new parameter was added to specify port_type in
couple_nic_to_vswitch. But it should only be specified
to VLAN AWARE vswitch.

The code is updated to use vlan_id > 0 to decide the vswitch
is VLAN AWARE, then add PORTTYPE option.