### PR TITLE
[master]Support MTU configuration for VM's NIC in RHEL

### DIFF
--- a/zvmsdk/dist.py
+++ b/zvmsdk/dist.py
@@ -121,8 +121,9 @@ class LinuxDist(object):
     def _generate_network_configuration(self, network, vdev, active=False):
         ip_v4 = dns_str = gateway_v4 = ''
         ip_cidr = netmask_v4 = broadcast_v4 = ''
-        net_cmd = ''
+        net_cmd = mtu = ''
         dns_v4 = []
+
         if (('ip_addr' in network.keys()) and
             (network['ip_addr'] is not None)):
             ip_v4 = network['ip_addr']
@@ -146,6 +147,10 @@ class LinuxDist(object):
             if broadcast_v4 == 'None':
                 broadcast_v4 = ''
 
+        if (('mtu' in network.keys()) and
+            (network['mtu'] is not None)):
+            mtu = str(network['mtu'])
+
         device = self._get_device_name(vdev)
         address_read = str(vdev).zfill(4)
         address_write = str(hex(int(vdev, 16) + 1))[2:].zfill(4)
@@ -156,7 +161,7 @@ class LinuxDist(object):
 
         cfg_str = self._get_cfg_str(device, broadcast_v4, gateway_v4,
                                     ip_v4, netmask_v4, address_read,
-                                    subchannels, dns_v4)
+                                    subchannels, dns_v4, mtu)
         cmd_str = self._get_cmd_str(address_read, address_write,
                                     address_data)
         route_str = self._get_route_str(gateway_v4)
@@ -331,7 +336,7 @@ class rhel(LinuxDist):
         return '/etc/sysconfig/network-scripts/'
 
     def _get_cfg_str(self, device, broadcast_v4, gateway_v4, ip_v4,
-                     netmask_v4, address_read, subchannels, dns_v4):
+                     netmask_v4, address_read, subchannels, dns_v4, mtu):
         cfg_str = 'DEVICE=\"' + device + '\"\n'
         cfg_str += 'BOOTPROTO=\"static\"\n'
         cfg_str += 'BROADCAST=\"' + broadcast_v4 + '\"\n'
@@ -343,6 +348,7 @@ class rhel(LinuxDist):
         cfg_str += 'PORTNAME=\"PORT' + address_read + '\"\n'
         cfg_str += 'OPTIONS=\"layer2=1\"\n'
         cfg_str += 'SUBCHANNELS=\"' + subchannels + '\"\n'
+        cfg_str += 'MTU=\"' + mtu + '\"\n'
         if (dns_v4 is not None) and (len(dns_v4) > 0):
             i = 1
             for dns in dns_v4:

--- a/zvmsdk/tests/unit/test_dist.py
+++ b/zvmsdk/tests/unit/test_dist.py
@@ -37,7 +37,8 @@ class RHEL7TestCase(base.SDKTestCase):
                'dns_addr': ['9.0.2.1', '9.0.3.1'],
                'gateway_addr': '192.168.95.1',
                'cidr': "192.168.95.0/24",
-               'nic_vdev': '1000'}]
+               'nic_vdev': '1000',
+               'mtu': 1600}]
         file_path = '/etc/sysconfig/network-scripts/'
         first = False
         files_and_cmds = self.linux_dist.create_network_configuration_files(
@@ -49,8 +50,9 @@ class RHEL7TestCase(base.SDKTestCase):
         self.assertEqual('BROADCAST="192.168.95.255"', cfg_str[2])
         self.assertEqual('GATEWAY="192.168.95.1"', cfg_str[3])
         self.assertEqual('IPADDR="192.168.95.10"', cfg_str[4])
-        self.assertEqual('DNS1="9.0.2.1"', cfg_str[11])
-        self.assertEqual('DNS2="9.0.3.1"', cfg_str[12])
+        self.assertEqual('MTU="1600"', cfg_str[11])
+        self.assertEqual('DNS1="9.0.2.1"', cfg_str[12])
+        self.assertEqual('DNS2="9.0.3.1"', cfg_str[13])
 
     @mock.patch('jinja2.Template.render')
     @mock.patch('zvmsdk.dist.LinuxDist.get_template')
@@ -147,7 +149,8 @@ class RHEL8TestCase(base.SDKTestCase):
                            'dns_addr': ['9.0.2.1', '9.0.3.1'],
                            'gateway_addr': '192.168.95.1',
                            'cidr': "192.168.95.0/24",
-                           'nic_vdev': '1000'}]
+                           'nic_vdev': '1000',
+                           'mtu': 8000}]
         file_path = '/etc/sysconfig/network-scripts/'
         first = False
         files_and_cmds = self.linux_dist.create_network_configuration_files(
@@ -159,8 +162,9 @@ class RHEL8TestCase(base.SDKTestCase):
         self.assertEqual('BROADCAST="192.168.95.255"', cfg_str[2])
         self.assertEqual('GATEWAY="192.168.95.1"', cfg_str[3])
         self.assertEqual('IPADDR="192.168.95.10"', cfg_str[4])
-        self.assertEqual('DNS1="9.0.2.1"', cfg_str[11])
-        self.assertEqual('DNS2="9.0.3.1"', cfg_str[12])
+        self.assertEqual('MTU="8000"', cfg_str[11])
+        self.assertEqual('DNS1="9.0.2.1"', cfg_str[12])
+        self.assertEqual('DNS2="9.0.3.1"', cfg_str[13])
 
     @mock.patch('jinja2.Template.render')
     @mock.patch('zvmsdk.dist.LinuxDist.get_template')


### PR DESCRIPTION
Add code logic to parse MTU value from network info
and set to network configuration scripts for RHEL.

Signed-off-by: Shu Juan Zhang <zshujuan@cn.ibm.com>