### PR TITLE
Add wsgi handler for status report

### DIFF
--- a/doc/source/parameters.yaml
+++ b/doc/source/parameters.yaml
@@ -1321,3 +1321,45 @@ fcp_connections:
   in: body
   required: true
   type: integer
+smapi_healthy:
+  description: |
+    Status of SMAPI healthy
+  in: body
+  required: true
+  type: dict
+totalSuccess:
+  description: |
+    The total success calls for SMAPI.
+  in: body
+  required: true
+  type: integer
+totalFail:
+  description: |
+    The total fail calls for SMAPI.
+  in: body
+  required: true
+  type: integer
+lastSuccess:
+  description: |
+    The last success call for SMAPI.
+  in: body
+  required: true
+  type: string
+lastFail:
+  description: |
+    The last fail call for SMAPI.
+  in: body
+  required: true
+  type: string
+continueousFail:
+  description: |
+    The count of continueous fail.
+  in: body
+  required: true
+  type: integer
+healthy:
+  description: |
+    Whether SMAPI is healthy.
+  in: body
+  required: true
+  type: integer

--- a/doc/source/restapi.rst
+++ b/doc/source/restapi.rst
@@ -88,6 +88,38 @@ you can think as a combination of username and password.
 
   Please refer to :ref:`TokenUsage` to get more details.
 
+SMAPI Healthy
+=============
+
+Report healthy of SMAPI
+-----------------------
+
+**GET /smapi-healthy**
+
+Get healthy of the SMAPI status.
+
+* Request:
+
+.. restapi_parameters:: parameters.yaml
+
+  - X-Admin-Token: token_admin
+
+* Response code:
+
+  HTTP status code 200 on success.
+
+* Response contents:
+
+.. restapi_parameters:: parameters.yaml
+
+  - smapi_healthy: smapi_healthy
+  - totalSuccess: totalSuccess
+  - totalFail: totalFail
+  - lastSuccess: lastSuccess
+  - lastFail: lastFail
+  - continueousFail: continueousFail
+  - healthy: healthy
+
 Guest(s)
 ========
 

--- a/smtLayer/tests/unit/test_vmStatus.py
+++ b/smtLayer/tests/unit/test_vmStatus.py
@@ -26,7 +26,7 @@ class SMTvmStatusTestCase(base.SMTTestCase):
         s.recordSuccess()
         s.recordSuccess()
 
-        ret = s.Get()
+        ret = s.Get()['SMAPI']
         d = ret.pop('lastSuccess', None)
         self.assertIsNotNone(d)
         exp = {'continueousFail': 0,
@@ -41,7 +41,7 @@ class SMTvmStatusTestCase(base.SMTTestCase):
         s.recordFail()
         s.recordFail()
 
-        ret = s.Get()
+        ret = s.Get()['SMAPI']
         d = ret.pop('lastFail', None)
         self.assertIsNotNone(d)
         exp = {'continueousFail': 2,
@@ -57,7 +57,7 @@ class SMTvmStatusTestCase(base.SMTTestCase):
         for i in range(40):
             s.recordFail()
 
-        ret = s.Get()
+        ret = s.Get()['SMAPI']
         d = ret.pop('lastFail', None)
         self.assertIsNotNone(d)
         m = ret.pop('lastSuccess', None)

--- a/smtLayer/vmStatus.py
+++ b/smtLayer/vmStatus.py
@@ -50,16 +50,21 @@ class SMAPIStatus():
         self.continueFail += 1
 
     def Get(self):
-        status = {'totalSuccess': self.totalSuccess,
+        status = {'SMAPI':
+                  {'totalSuccess': self.totalSuccess,
                   'totalFail': self.totalFail,
                   'lastSuccess': self.lastSuccess,
                   'lastFail': self.lastFail,
                   'continueousFail': self.continueFail,
                   'healthy': self.IsHealthy()}
+                 }
         return status
 
     def IsHealthy(self):
         return self.continueFail < CONTINUE_FAIL_THRESHOLD
+
+
+_SMAPIStatus = None
 
 
 def GetSMAPIStatus():

--- a/zvmsdk/sdkwsgi/handler.py
+++ b/zvmsdk/sdkwsgi/handler.py
@@ -20,6 +20,7 @@ from zvmsdk import log
 from zvmsdk.sdkwsgi import util
 from zvmsdk.sdkwsgi.handlers import file
 from zvmsdk.sdkwsgi.handlers import guest
+from zvmsdk.sdkwsgi.handlers import healthy
 from zvmsdk.sdkwsgi.handlers import host
 from zvmsdk.sdkwsgi.handlers import image
 from zvmsdk.sdkwsgi.handlers import tokens
@@ -112,6 +113,9 @@ ROUTE_LIST = (
         'POST': guest.guest_create_disks,
         'DELETE': guest.guest_delete_disks,
         'PUT': guest.guest_config_disks,
+    }),
+    ('/smapi-healthy', {
+        'GET': healthy.healthy,
     }),
     ('/host', {
         'GET': host.host_get_info,

--- a/zvmsdk/sdkwsgi/handlers/healthy.py
+++ b/zvmsdk/sdkwsgi/handlers/healthy.py
@@ -1,0 +1,36 @@
+# Copyright 2022 IBM Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""Handler for the root of the sdk API."""
+
+import json
+
+from smtLayer import vmStatus
+from zvmsdk.sdkwsgi.handlers import tokens
+from zvmsdk.sdkwsgi import util
+from zvmsdk import utils
+
+
+@util.SdkWsgify
+@tokens.validate
+def healthy(req):
+
+    s = vmStatus.GetSMAPIStatus()
+    output = s.Get()
+    info_json = json.dumps(output)
+    req.response.body = utils.to_utf8(info_json)
+    req.response.content_type = 'application/json'
+    req.response.status = 200
+
+    return req.response


### PR DESCRIPTION
Add status healthy wsgi 

GET /healthy 
is supported so that we can report such
```
# curl localhost:8080/healthy
{"totalSuccess": 0, "totalFail": 0, "lastSuccess": "", "lastFail": "", "continueousFail": 0, "healthy": true}
```

Signed-off-by: jichenjc <jichenjc@cn.ibm.com>