### PR TITLE
[master] Add 3 new returned values in guest_get_info

### DIFF
--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -1,4 +1,4 @@
-# Copyright 2017,2021 IBM Corp.
+# Copyright 2017,2022 IBM Corp.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -1162,7 +1162,7 @@ class SMTClient(object):
                                                        msg=msg)
             # Get the os version of the vm
             try:
-                os_version = self._guest_get_os_version(userid)
+                os_version = self.guest_get_os_version(userid)
             except exception.SDKSMTRequestFailed as err:
                 msg = ('Failed to execute command on capture source vm %(vm)s'
                        'to get os version with error %(err)s'
@@ -1308,7 +1308,7 @@ class SMTClient(object):
         LOG.info('Image %s is captured and imported to image repository '
                  'successfully' % image_name)
 
-    def _guest_get_os_version(self, userid):
+    def guest_get_os_version(self, userid):
         os_version = ''
         release_file = self.execute_cmd(userid, 'ls /etc/*-release')
         if '/etc/os-release' in release_file:
@@ -3566,7 +3566,7 @@ class SMTClient(object):
         available_addrs.difference_update(used_set)
         return list(available_addrs)
 
-    def _get_active_cpu_addrs(self, userid):
+    def get_active_cpu_addrs(self, userid):
         # Get the active cpu addrs in two-digit hex string in upper case
         # Sample output for 'lscpu --parse=ADDRESS':
         # # The following is the parsable format, which can be fed to other
@@ -3668,7 +3668,7 @@ class SMTClient(object):
         # Get active cpu count and compare with requested count
         # If request count is smaller than the current count, then report
         # error and exit immediately.
-        active_addrs = self._get_active_cpu_addrs(userid)
+        active_addrs = self.get_active_cpu_addrs(userid)
         active_count = len(active_addrs)
         if active_count > count:
             LOG.error("Failed to live resize cpus of guest: %(uid)s, "
@@ -4123,6 +4123,17 @@ class SMTClient(object):
             and results.get('response'):
             return results.get('response')
         return []
+
+    def guest_get_kernel_info(self, userid):
+        # Get the kernel info of 'uname -srm'
+        try:
+            kernel_info = self.execute_cmd(userid, "uname -srm")
+            return kernel_info[0]
+        except exception.SDKSMTRequestFailed as err:
+            msg = err.format_message()
+            LOG.error("Get kernel info from the guest %s failed: %s"
+                      % (userid, msg))
+        return ''
 
 
 class FilesystemBackend(object):

--- a/zvmsdk/tests/unit/test_smtclient.py
+++ b/zvmsdk/tests/unit/test_smtclient.py
@@ -1,4 +1,4 @@
-# Copyright 2017,2021 IBM Corp.
+# Copyright 2017,2022 IBM Corp.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -2863,7 +2863,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
                                 'CPE_NAME="cpe:/o:redhat:enterprise_linux:'
                                 '7.0:GA:server"',
                                 'HOME_URL="https://www.redhat.com/"']]
-        result = self._smtclient._guest_get_os_version(userid)
+        result = self._smtclient.guest_get_os_version(userid)
         self.assertEqual(result, 'rhel7.0')
 
     @mock.patch.object(smtclient.SMTClient, 'execute_cmd')
@@ -2873,7 +2873,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
                                 '/etc/system-release'],
                                ['Red Hat Enterprise Linux Server release 6.7'
                                 ' (Santiago)']]
-        result = self._smtclient._guest_get_os_version(userid)
+        result = self._smtclient.guest_get_os_version(userid)
         self.assertEqual(result, 'rhel6.7')
 
     @mock.patch.object(smtclient.SMTClient, 'execute_cmd')
@@ -2892,7 +2892,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
                                 'BUG_REPORT_URL="http://bugs.launchpad.net'
                                 '/ubuntu/"',
                                 'UBUNTU_CODENAME=xenial']]
-        result = self._smtclient._guest_get_os_version(userid)
+        result = self._smtclient.guest_get_os_version(userid)
         self.assertEqual(result, 'ubuntu16.04')
 
     @mock.patch.object(database.GuestDbOperator,
@@ -2936,7 +2936,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
     @mock.patch.object(zvmutils.PathUtils, 'mkdir_if_not_exist')
     @mock.patch.object(smtclient.SMTClient, 'guest_stop')
     @mock.patch.object(smtclient.SMTClient, '_get_capture_devices')
-    @mock.patch.object(smtclient.SMTClient, '_guest_get_os_version')
+    @mock.patch.object(smtclient.SMTClient, 'guest_get_os_version')
     @mock.patch.object(smtclient.SMTClient, 'execute_cmd')
     @mock.patch.object(smtclient.SMTClient, 'get_guest_connection_status')
     def test_guest_capture_good_path_unreachable_poweron(
@@ -3013,7 +3013,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
     @mock.patch.object(zvmutils.PathUtils, 'mkdir_if_not_exist')
     @mock.patch.object(smtclient.SMTClient, 'guest_stop')
     @mock.patch.object(smtclient.SMTClient, '_get_capture_devices')
-    @mock.patch.object(smtclient.SMTClient, '_guest_get_os_version')
+    @mock.patch.object(smtclient.SMTClient, 'guest_get_os_version')
     @mock.patch.object(smtclient.SMTClient, 'execute_cmd')
     @mock.patch.object(smtclient.SMTClient, 'get_guest_connection_status')
     def test_guest_capture_good_path_poweroff(self, guest_connection_status,
@@ -3089,7 +3089,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
     @mock.patch.object(zvmutils.PathUtils, 'mkdir_if_not_exist')
     @mock.patch.object(smtclient.SMTClient, 'guest_stop')
     @mock.patch.object(smtclient.SMTClient, '_get_capture_devices')
-    @mock.patch.object(smtclient.SMTClient, '_guest_get_os_version')
+    @mock.patch.object(smtclient.SMTClient, 'guest_get_os_version')
     @mock.patch.object(smtclient.SMTClient, 'execute_cmd')
     @mock.patch.object(smtclient.SMTClient, 'get_guest_connection_status')
     def test_guest_capture_good_path_poweroff_os(self,
@@ -3173,7 +3173,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
     @mock.patch.object(zvmutils.PathUtils, 'mkdir_if_not_exist')
     @mock.patch.object(smtclient.SMTClient, 'guest_stop')
     @mock.patch.object(smtclient.SMTClient, '_get_capture_devices')
-    @mock.patch.object(smtclient.SMTClient, '_guest_get_os_version')
+    @mock.patch.object(smtclient.SMTClient, 'guest_get_os_version')
     @mock.patch.object(smtclient.SMTClient, 'execute_cmd')
     @mock.patch.object(smtclient.SMTClient, 'get_guest_connection_status')
     def test_guest_capture_poweroff_with_force_disk(self,
@@ -3258,7 +3258,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
     @mock.patch.object(zvmutils.PathUtils, 'mkdir_if_not_exist')
     @mock.patch.object(smtclient.SMTClient, 'guest_stop')
     @mock.patch.object(smtclient.SMTClient, '_get_capture_devices')
-    @mock.patch.object(smtclient.SMTClient, '_guest_get_os_version')
+    @mock.patch.object(smtclient.SMTClient, 'guest_get_os_version')
     @mock.patch.object(smtclient.SMTClient, 'execute_cmd')
     @mock.patch.object(smtclient.SMTClient, 'get_guest_connection_status')
     def test_guest_capture_poweroff_with_device_ass(self,
@@ -3345,7 +3345,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
     @mock.patch.object(zvmutils.PathUtils, 'mkdir_if_not_exist')
     @mock.patch.object(smtclient.SMTClient, 'guest_softstop')
     @mock.patch.object(smtclient.SMTClient, '_get_capture_devices')
-    @mock.patch.object(smtclient.SMTClient, '_guest_get_os_version')
+    @mock.patch.object(smtclient.SMTClient, 'guest_get_os_version')
     @mock.patch.object(smtclient.SMTClient, 'execute_cmd')
     @mock.patch.object(smtclient.SMTClient, 'get_guest_connection_status')
     def test_guest_capture_good_path_poweron(self, guest_connection_status,
@@ -3402,7 +3402,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         get_os_mock.assert_not_called()
 
     @mock.patch.object(smtclient.SMTClient, 'get_os_version_from_userid')
-    @mock.patch.object(smtclient.SMTClient, '_guest_get_os_version')
+    @mock.patch.object(smtclient.SMTClient, 'guest_get_os_version')
     @mock.patch.object(smtclient.SMTClient, 'execute_cmd')
     @mock.patch.object(smtclient.SMTClient, 'get_guest_connection_status')
     def test_guest_capture_error_path(self, guest_connection_status,
@@ -3850,7 +3850,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
                        '# Address',
                        '0', '3', '10', '19']
         exec_cmd.return_value = active_cpus
-        addrs = self._smtclient._get_active_cpu_addrs('TESTUID')
+        addrs = self._smtclient.get_active_cpu_addrs('TESTUID')
         exec_cmd.assert_called_once_with('TESTUID', "lscpu --parse=ADDRESS")
         addrs.sort()
         self.assertListEqual(addrs, ['00', '03', '0A', '13'])
@@ -3859,7 +3859,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
     @mock.patch.object(smtclient.SMTClient, 'execute_cmd')
     @mock.patch.object(smtclient.SMTClient, '_get_available_cpu_addrs')
     @mock.patch.object(smtclient.SMTClient, 'resize_cpus')
-    @mock.patch.object(smtclient.SMTClient, '_get_active_cpu_addrs')
+    @mock.patch.object(smtclient.SMTClient, 'get_active_cpu_addrs')
     def test_live_resize_cpus(self, get_active, resize, get_avail,
                               exec_cmd, request):
         userid = 'testuid'
@@ -3885,7 +3885,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
     @mock.patch.object(smtclient.SMTClient, 'execute_cmd')
     @mock.patch.object(smtclient.SMTClient, '_get_available_cpu_addrs')
     @mock.patch.object(smtclient.SMTClient, 'resize_cpus')
-    @mock.patch.object(smtclient.SMTClient, '_get_active_cpu_addrs')
+    @mock.patch.object(smtclient.SMTClient, 'get_active_cpu_addrs')
     def test_live_resize_cpus_equal_active(self, get_active, resize, get_avail,
                                            exec_cmd, request):
         userid = 'testuid'
@@ -3903,7 +3903,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
     @mock.patch.object(smtclient.SMTClient, 'execute_cmd')
     @mock.patch.object(smtclient.SMTClient, '_get_available_cpu_addrs')
     @mock.patch.object(smtclient.SMTClient, 'resize_cpus')
-    @mock.patch.object(smtclient.SMTClient, '_get_active_cpu_addrs')
+    @mock.patch.object(smtclient.SMTClient, 'get_active_cpu_addrs')
     def test_live_resize_cpus_less_active(self, get_active, resize, get_avail,
                                            exec_cmd, request):
         userid = 'testuid'
@@ -3921,7 +3921,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
     @mock.patch.object(smtclient.SMTClient, 'execute_cmd')
     @mock.patch.object(smtclient.SMTClient, '_get_available_cpu_addrs')
     @mock.patch.object(smtclient.SMTClient, 'resize_cpus')
-    @mock.patch.object(smtclient.SMTClient, '_get_active_cpu_addrs')
+    @mock.patch.object(smtclient.SMTClient, 'get_active_cpu_addrs')
     def test_live_resize_cpus_revert_definition_equal(self, get_active,
                                                         resize, get_avail,
                                                         exec_cmd, request):
@@ -3948,7 +3948,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
     @mock.patch.object(smtclient.SMTClient, 'execute_cmd')
     @mock.patch.object(smtclient.SMTClient, '_get_available_cpu_addrs')
     @mock.patch.object(smtclient.SMTClient, 'resize_cpus')
-    @mock.patch.object(smtclient.SMTClient, '_get_active_cpu_addrs')
+    @mock.patch.object(smtclient.SMTClient, 'get_active_cpu_addrs')
     def test_live_resize_cpus_revert_added_cpus(self, get_active,
                                                 resize, get_avail,
                                                 exec_cmd, request):
@@ -3976,7 +3976,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
     @mock.patch.object(smtclient.SMTClient, 'execute_cmd')
     @mock.patch.object(smtclient.SMTClient, '_get_available_cpu_addrs')
     @mock.patch.object(smtclient.SMTClient, 'resize_cpus')
-    @mock.patch.object(smtclient.SMTClient, '_get_active_cpu_addrs')
+    @mock.patch.object(smtclient.SMTClient, 'get_active_cpu_addrs')
     def test_live_resize_cpus_revert_deleted_cpus(self, get_active,
                                                   resize, get_avail,
                                                   exec_cmd, request):
@@ -4004,7 +4004,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
     @mock.patch.object(smtclient.SMTClient, 'execute_cmd')
     @mock.patch.object(smtclient.SMTClient, '_get_available_cpu_addrs')
     @mock.patch.object(smtclient.SMTClient, 'resize_cpus')
-    @mock.patch.object(smtclient.SMTClient, '_get_active_cpu_addrs')
+    @mock.patch.object(smtclient.SMTClient, 'get_active_cpu_addrs')
     def test_live_resize_cpus_revert_failed(self, get_active,
                                             resize, get_avail,
                                             exec_cmd, request):
@@ -4033,7 +4033,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
     @mock.patch.object(smtclient.SMTClient, 'execute_cmd')
     @mock.patch.object(smtclient.SMTClient, '_get_available_cpu_addrs')
     @mock.patch.object(smtclient.SMTClient, 'resize_cpus')
-    @mock.patch.object(smtclient.SMTClient, '_get_active_cpu_addrs')
+    @mock.patch.object(smtclient.SMTClient, 'get_active_cpu_addrs')
     def test_live_resize_cpus_rescan_failed(self, get_active,
                                             resize, get_avail,
                                             exec_cmd, request):
@@ -4062,7 +4062,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
     @mock.patch.object(smtclient.SMTClient, 'execute_cmd')
     @mock.patch.object(smtclient.SMTClient, '_get_available_cpu_addrs')
     @mock.patch.object(smtclient.SMTClient, 'resize_cpus')
-    @mock.patch.object(smtclient.SMTClient, '_get_active_cpu_addrs')
+    @mock.patch.object(smtclient.SMTClient, 'get_active_cpu_addrs')
     def test_live_resize_cpus_redhat(self, get_active, resize, get_avail,
                               exec_cmd, request):
         userid = 'testuid'
@@ -4095,7 +4095,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
     @mock.patch.object(smtclient.SMTClient, 'execute_cmd')
     @mock.patch.object(smtclient.SMTClient, '_get_available_cpu_addrs')
     @mock.patch.object(smtclient.SMTClient, 'resize_cpus')
-    @mock.patch.object(smtclient.SMTClient, '_get_active_cpu_addrs')
+    @mock.patch.object(smtclient.SMTClient, 'get_active_cpu_addrs')
     def test_live_resize_cpus_ubuntu(self, get_active, resize, get_avail,
                               exec_cmd, request):
         userid = 'testuid'


### PR DESCRIPTION
The 3 new values are: online cpu number, OS distro and kernel version.

Signed-off-by: QingFeng Hao <haoqf@linux.vnet.ibm.com>