### PR TITLE
Support set MTU when setup RHCOS network interface

### DIFF
--- a/zthin-parts/zthin/bin/refresh_bootmap
+++ b/zthin-parts/zthin/bin/refresh_bootmap
@@ -415,7 +415,7 @@ function parseArgs {
   isOption -m --minfcp "      The minimum acceptable FCP count should be defined to the target vm."
   isOption -i --ignitionurl "  (RHCOS only) The URL or local path that points to RHCOS ignition file"
   isOption -n --nicid "        (RHCOS only) The nic ID. Example: 0.0.1000,0.0.1001,0.0.1002"
-  isOption -p --ipconfig "     (RHCOS only) The network configuration info. In format of <client-IP>:[<peer>]:<gateway-IP>:<netmask>:<client_hostname>:<interface>:none[:[<dns1>][:<dns2>]]"
+  isOption -p --ipconfig "     (RHCOS only) The network configuration info. In format of <client-IP>:[<peer>]:<gateway-IP>:<netmask>:<client_hostname>:<interface>:none[:[<dns1>][:<dns2>]];<mtu>"
 
   if [[ $printHelp ]]; then
     printHelp
@@ -721,9 +721,17 @@ function update_zipl_bootloader_rhcos {
 
     blsfile=$(ls $deviceMountPoint/loader/entries/*.conf)
     #Get zipl config file for parameters
-   
-    nameserver1=$(echo $ipconfig| awk -F: '{print $8}')    
-    nameserver2=$(echo $ipconfig| awk -F: '{print $9}')
+
+    # ipconfig format: <client-IP>:[<peer>]:<gateway-IP>:<netmask>:<client_hostname>:<interface>:none[:[<dns1>][:<dns2>]];<mtu>
+    # ipsetting format here: <client-IP>:[<peer>]:<gateway-IP>:<netmask>:<client_hostname>:<interface>:none[:[<dns1>][:<dns2>]]
+    ipsetting=$(echo ${ipconfig%;*})
+    # mtu format: <mtu> , example, "1500"
+    mtu=$(echo ${ipconfig#*;})
+    # nameserver format: nameserver=<nameserver>
+    nameserver1=$(echo $ipsetting| awk -F: '{print $8}')
+    nameserver2=$(echo $ipsetting| awk -F: '{print $9}')
+    # ipsetting format here: <client-IP>:[<peer>]:<gateway-IP>:<netmask>:<client_hostname>:<interface>:none:<mtu>
+    ipsetting=$(echo ${ipsetting/%none:*/none:}${mtu})
     if [ $nameserver1  ]; then 
         nameserver1='nameserver='${nameserver1}
     fi
@@ -731,7 +739,7 @@ function update_zipl_bootloader_rhcos {
         nameserver2='nameserver='${nameserver2}
     fi
 
-    echo "$(grep options $blsfile | cut -d' ' -f2-) zfcp.allow_lun_scan=0 rw $rd_zfcp rd.znet=qeth,$nicid,layer2=1,portno=0 ignition.firstboot=1 rd.neednet=1 ip=$ipconfig $nameserver1 $nameserver2" > $rhcosTempDir/zipl_prm
+    echo "$(grep options $blsfile | cut -d' ' -f2-) zfcp.allow_lun_scan=0 rw $rd_zfcp rd.znet=qeth,$nicid,layer2=1,portno=0 ignition.firstboot=1 rd.neednet=1 ip=$ipsetting $nameserver1 $nameserver2" > $rhcosTempDir/zipl_prm
     ziplstr=`cat $rhcosTempDir/zipl_prm`
     inform "zipl param string: $ziplstr"
 

--- a/zthin-parts/zthin/bin/unpackdiskimage
+++ b/zthin-parts/zthin/bin/unpackdiskimage
@@ -863,9 +863,18 @@ function deployDiskImage {
 
     blsfile=$(ls /tmp/$fcpChannel/boot_partition/loader/entries/*.conf)
     #Get zipl config file for parameters
-   
-    nameserver1=$(echo $ipConfig| awk -F: '{print $8}')    
-    nameserver2=$(echo $ipConfig| awk -F: '{print $9}')
+
+    # ipConfig format: <client-IP>:[<peer>]:<gateway-IP>:<netmask>:<client_hostname>:<interface>:none[:[<dns1>][:<dns2>]];<mtu>
+    # ipsetting format here: <client-IP>:[<peer>]:<gateway-IP>:<netmask>:<client_hostname>:<interface>:none[:[<dns1>][:<dns2>]]
+    ipsetting=$(echo ${ipConfig%;*})
+    # mtu format: <mtu> , example, "1500"
+    mtu=$(echo ${ipConfig#*;})
+    # nameserver format: nameserver=<nameserver>
+    nameserver1=$(echo $ipsetting| awk -F: '{print $8}')
+    nameserver2=$(echo $ipsetting| awk -F: '{print $9}')
+    # ipsetting format here: <client-IP>:[<peer>]:<gateway-IP>:<netmask>:<client_hostname>:<interface>:none:<mtu>
+    ipsetting=$(echo ${ipsetting/%none:*/none:}${mtu})
+
     if [ $nameserver1  ]; then 
         nameserver1='nameserver='${nameserver1}
     fi
@@ -873,7 +882,7 @@ function deployDiskImage {
         nameserver2='nameserver='${nameserver2}
     fi
 
-    echo "$(grep options $blsfile | cut -d' ' -f2-) zfcp.allow_lun_scan=0 rw $rd_zfcp rd.znet=qeth,$nicID,layer2=1,portno=0 ignition.firstboot=1 rd.neednet=1 ip=$ipConfig $nameserver1 $nameserver2" > /tmp/$fcpChannel/zipl_prm
+    echo "$(grep options $blsfile | cut -d' ' -f2-) zfcp.allow_lun_scan=0 rw $rd_zfcp rd.znet=qeth,$nicID,layer2=1,portno=0 ignition.firstboot=1 rd.neednet=1 ip=$ipsetting $nameserver1 $nameserver2" > /tmp/$fcpChannel/zipl_prm
     #Run zipl to update bootloader
     zipl --verbose -p /tmp/$fcpChannel/zipl_prm -i $(ls /tmp/$fcpChannel/boot_partition/ostree/*/*vmlinuz*) -r $(ls /tmp/$fcpChannel/boot_partition/ostree/*/*initramfs*) --target /tmp/$fcpChannel/boot_partition
     if [[ $? -ne 0 ]]; then
@@ -928,8 +937,18 @@ function deployDiskImage {
 
     blsfile=$(ls /tmp/$userID/boot_partition/loader/entries/*.conf)
     #Get zipl config file for parameters
-    nameserver1=$(echo $ipConfig| awk -F: '{print $8}')    
-    nameserver2=$(echo $ipConfig| awk -F: '{print $9}')
+
+    # ipConfig format: <client-IP>:[<peer>]:<gateway-IP>:<netmask>:<client_hostname>:<interface>:none[:[<dns1>][:<dns2>]];<mtu>
+    # ipsetting format here: <client-IP>:[<peer>]:<gateway-IP>:<netmask>:<client_hostname>:<interface>:none[:[<dns1>][:<dns2>]]
+    ipsetting=$(echo ${ipConfig%;*})
+    # mtu format: <mtu> , example, "1500"
+    mtu=$(echo ${ipConfig#*;})
+    # nameserver format: nameserver=<nameserver>
+    nameserver1=$(echo $ipsetting| awk -F: '{print $8}')
+    nameserver2=$(echo $ipsetting| awk -F: '{print $9}')
+    # ipsetting format here: <client-IP>:[<peer>]:<gateway-IP>:<netmask>:<client_hostname>:<interface>:none:<mtu>
+    ipsetting=$(echo ${ipsetting/%none:*/none:}${mtu})
+
     if [ $nameserver1  ]; then 
         nameserver1='nameserver='${nameserver1}
     fi
@@ -937,7 +956,7 @@ function deployDiskImage {
         nameserver2='nameserver='${nameserver2}
     fi
     
-    echo "$(grep options $blsfile | cut -d' ' -f2-) rd.dasd=0.0.$channelID rd.znet=qeth,$nicID,layer2=1,portno=0 ignition.firstboot=1 rd.neednet=1 ip=$ipConfig $nameserver1 $nameserver2" > /tmp/$userID/zipl_prm
+    echo "$(grep options $blsfile | cut -d' ' -f2-) rd.dasd=0.0.$channelID rd.znet=qeth,$nicID,layer2=1,portno=0 ignition.firstboot=1 rd.neednet=1 ip=$ipsetting $nameserver1 $nameserver2" > /tmp/$userID/zipl_prm
     #Run zipl to update bootloader
     zipl --verbose -p /tmp/$userID/zipl_prm -i $(ls /tmp/$userID/boot_partition/ostree/*/*vmlinuz*) -r $(ls /tmp/$userID/boot_partition/ostree/*/*initramfs*) --target /tmp/$userID/boot_partition
     if [[ $? -ne 0 ]]; then

--- a/zvmsdk/dist.py
+++ b/zvmsdk/dist.py
@@ -623,11 +623,12 @@ class rhcos(LinuxDist):
                     for dns in vif['dns_addr']:
                         _dns[_index] = dns
                         _index += 1
+            mtu = vif['mtu']
             # transfor network info and hostname into form of
             # ip=<client-IP>:[<peer>]:<gateway-IP>:<netmask>:<client_hostname>
-            # :<interface>:none[:[<dns1>][:<dns2>]]
-            result = "%s::%s:%s:%s:%s:none:%s:%s" % (ip_addr, gateway_addr,
-                        netmask, hostname, nic_name, _dns[0], _dns[1])
+            # :<interface>:none[:[<dns1>][:<dns2>]];<mtu>
+            result = "%s::%s:%s:%s:%s:none:%s:%s;%s" % (ip_addr, gateway_addr,
+                        netmask, hostname, nic_name, _dns[0], _dns[1], mtu)
             return result
         except Exception as err:
             LOG.error("Failed to create coreos parameter for userid '%s',"

--- a/zvmsdk/tests/unit/test_dist.py
+++ b/zvmsdk/tests/unit/test_dist.py
@@ -262,21 +262,31 @@ class RHCOS4TestCase(base.SDKTestCase):
                         'dns_addr': ['10.10.0.250', '10.10.0.51'],
                         'mac_addr': 'fa:16:3e:7a:1b:87',
                         'cidr': '10.10.0.0/24',
-                        'nic_id': 'adca70f3-8509-44d4-92d4-2c1c14b3f25e'}]
+                        'nic_id': 'adca70f3-8509-44d4-92d4-2c1c14b3f25e',
+                        'mtu': '1000'}]
         userid = "FakeID"
         guest_path.return_value = "/tmp/FakeID"
-        res = self.linux_dist.create_coreos_parameter_temp_file(network_info,
-                                                                userid)
-        self.assertEqual(res, True)
+        res = self.linux_dist.create_coreos_parameter(network_info, userid)
+        self.assertEqual(res, "10.10.0.217::10.10.0.1:24:FakeID:enc1000:none:"
+                              "10.10.0.250:10.10.0.51;1000")
 
     @mock.patch.object(smtclient.SMTClient, 'get_guest_path')
     def test_read_coreos_parameter(self, guest_path):
         guest_path.return_value = "/tmp/FakeID"
         userid = "FakeID"
+        network_info = [{'nic_vdev': '1000',
+                        'ip_addr': '10.10.0.217',
+                        'gateway_addr': '10.10.0.1',
+                        'dns_addr': ['10.10.0.250', '10.10.0.51'],
+                        'mac_addr': 'fa:16:3e:7a:1b:87',
+                        'cidr': '10.10.0.0/24',
+                        'nic_id': 'adca70f3-8509-44d4-92d4-2c1c14b3f25e',
+                        'mtu': '1000'}]
+        self.linux_dist.create_coreos_parameter_temp_file(network_info, userid)
         param = self.linux_dist.read_coreos_parameter(userid)
         self.assertEqual(param,
                          '10.10.0.217::10.10.0.1:24:FakeID:'
-                         'enc1000:none:10.10.0.250:10.10.0.51')
+                         'enc1000:none:10.10.0.250:10.10.0.51;1000')
 
 
 class SLESTestCase(base.SDKTestCase):


### PR DESCRIPTION
Leverage dracut cmdline 'ip=' to set MTU when deploy RHCOS with
scsi image.

Add new parameter - dns, to support customize nameservers.

Signed-off-by: bjhuangr <bjhuangr@cn.ibm.com>