### PR TITLE
Remove maxLength for fcp_templ_id_list and fix bug for creating fcp tmpl

### DIFF
--- a/zvmsdk/database.py
+++ b/zvmsdk/database.py
@@ -1145,6 +1145,8 @@ class FCPDbOperator(object):
         # if not exist, will insert new records
         sp_mapping_to_add = list()
         sp_mapping_to_update = list()
+        if not default_sp_list:
+            default_sp_list = []
         for sp_name in default_sp_list:
             record = (fcp_template_id, sp_name)
             if self.sp_name_exist_in_db(sp_name):

--- a/zvmsdk/sdkwsgi/validation/parameter_types.py
+++ b/zvmsdk/sdkwsgi/validation/parameter_types.py
@@ -352,8 +352,7 @@ fcp_template_id = {
 
 fcp_template_id_list = {
     'items': {
-        'type': 'string',
-        'maxLength': 36,
+        'type': 'string'
     },
     'type': 'array'
 }

--- a/zvmsdk/tests/unit/test_database.py
+++ b/zvmsdk/tests/unit/test_database.py
@@ -1280,8 +1280,20 @@ class FCPDbOperatorTestCase(base.SDKTestCase):
             self.db_op.bulk_delete_from_fcp_table(fcp_id_list)
             self.db_op.bulk_delete_fcp_from_template(fcp_id_list, template_id)
 
-    def test_create_fcp_template(self):
-        pass
+    def test_create_fcp_template_with_name_and_desc(self):
+        """Create fcp template only with name and description, other parameters are all default values"""
+        fcp_template_id = 'fake_tmpl_id'
+        name = 'tmpl_1'
+        description = 'this is the description.'
+        fcp_devices_by_path = []
+        host_default = False
+        default_sp_list = None
+        self.db_op.create_fcp_template(fcp_template_id, name, description,
+                                       fcp_devices_by_path, host_default,
+                                       default_sp_list)
+        actual_tmpl = self.db_op.get_fcp_templates([fcp_template_id])
+        self.assertEqual(actual_tmpl[0]['id'], fcp_template_id)
+        self.db_op.delete_fcp_template(fcp_template_id)
 
     def test_edit_fcp_template(self):
         """ Test edit_fcp_template()

--- a/zvmsdk/volumeop.py
+++ b/zvmsdk/volumeop.py
@@ -943,7 +943,7 @@ class FCPManager(object):
                 'id': tmpl_id,
                 'description': description,
                 'host_default': host_default,
-                'storage_providers': default_sp_list}}
+                'storage_providers': default_sp_list if default_sp_list else []}}
 
     def edit_fcp_template(self, fcp_template_id, name=None,
                           description=None, fcp_devices=None,


### PR DESCRIPTION
In this PR:
1. Remove maxLength for fcp_template_id_list since we have the fcp tmpl id check.
2. When creating fcp template, if not set storage_providers, its default value is None. Then error will be raised.


Signed-off-by: xingjing <xingjing@cn.ibm.com>