### PR TITLE
Add support for min_fcp_paths_count.

### DIFF
--- a/doc/source/errcode.csv
+++ b/doc/source/errcode.csv
@@ -87,6 +87,7 @@
 409;None;409;20;Failed to resize memory of guest: '%(userid)s', error: the requested memory size: '%(req)im' exceeds the maximum memory size defined: '%(max)im'.
 409;None;409;21;Failed to live resize memory of guest: %(userid)s, error: the memory size to be increased: '%(inc)im' is greater than the maximum reserved memory size: '%(max)im'.
 409;None;409;22;Failed to delete FCP device template, error: %(msg)s
+409;None;409;23;Failed to create or update FCP device template, error: %(msg)s
 **The operated object is deleted**
 410;None;410;;The operated object is deleted
 **ZVM SDK Internal Error**

--- a/doc/source/zvmsdk.conf.sample
+++ b/doc/source/zvmsdk.conf.sample
@@ -244,19 +244,6 @@
 
 
 # 
-# The minimum number of FCP paths that should be defined to a vm when attaching
-#  a data volume to a vm or BFV (deploying a vm from SCSI image).
-# 
-# The default value would be the path count of the current fcp_list.
-# 
-# If there is no this count of FCP paths available, the attach volume or BFV
-#  would fail.
-# 
-# This param is optional
-#min_fcp_paths_count=2
-
-
-# 
 # The timeout value for waiting attach/detach punch scripts
 # execution, in seconds.
 # 

--- a/zvmconnector/restclient.py
+++ b/zvmconnector/restclient.py
@@ -419,6 +419,7 @@ def req_volume_refresh_bootmap(start_index, *args, **kwargs):
     wwid = kwargs.get('wwid', '')
     transportfiles = kwargs.get('transportfiles', '')
     guest_networks = kwargs.get('guest_networks', [])
+    min_fcp_paths_count = kwargs.get('min_fcp_paths_count', None)
     body = {'info':
         {
             "fcpchannel": fcpchannel,
@@ -427,6 +428,7 @@ def req_volume_refresh_bootmap(start_index, *args, **kwargs):
             "wwid": wwid,
             "transportfiles": transportfiles,
             "guest_networks": guest_networks,
+            "min_fcp_paths_count": min_fcp_paths_count
         }
     }
     fill_kwargs_in_body(body['info'], **kwargs)

--- a/zvmconnector/restclient.py
+++ b/zvmconnector/restclient.py
@@ -419,7 +419,7 @@ def req_volume_refresh_bootmap(start_index, *args, **kwargs):
     wwid = kwargs.get('wwid', '')
     transportfiles = kwargs.get('transportfiles', '')
     guest_networks = kwargs.get('guest_networks', [])
-    min_fcp_paths_count = kwargs.get('min_fcp_paths_count', None)
+    fcp_template_id = kwargs.get('fcp_template_id', None)
     body = {'info':
         {
             "fcpchannel": fcpchannel,
@@ -428,7 +428,7 @@ def req_volume_refresh_bootmap(start_index, *args, **kwargs):
             "wwid": wwid,
             "transportfiles": transportfiles,
             "guest_networks": guest_networks,
-            "min_fcp_paths_count": min_fcp_paths_count
+            "fcp_template_id": fcp_template_id
         }
     }
     fill_kwargs_in_body(body['info'], **kwargs)

--- a/zvmsdk/api.py
+++ b/zvmsdk/api.py
@@ -1807,7 +1807,7 @@ class SDKAPI(object):
     def create_fcp_template(self, name, description: str = '',
                             fcp_devices: str = '',
                             host_default: bool = False,
-                            default_sp_list: list = None,
+                            default_sp_list: list = [],
                             min_fcp_paths_count: int = None):
         """API for creating a FCP template in database.
 
@@ -1899,7 +1899,7 @@ class SDKAPI(object):
 
     def volume_refresh_bootmap(self, fcpchannels, wwpns, lun,
                                wwid='',
-                               transportfiles=None, guest_networks=None, min_fcp_paths_count=None):
+                               transportfiles=None, guest_networks=None, fcp_template_id=None):
         """ Refresh a volume's bootmap info.
 
         :param list of fcpchannels
@@ -1935,13 +1935,13 @@ class SDKAPI(object):
                'gateway_addr': '192.168.96.1',
                'cidr': "192.168.96.0/24",
                'nic_vdev': '1003}],
-        :param min_fcp_paths_count
+        :param fcp_template_id
         """
         return self._volumeop.volume_refresh_bootmap(fcpchannels, wwpns, lun,
                                                 wwid=wwid,
                                                 transportfiles=transportfiles,
                                                 guest_networks=guest_networks,
-                                                min_fcp_paths_count=min_fcp_paths_count)
+                                                fcp_template_id=fcp_template_id)
 
     def volume_detach(self, connection_info):
         """ Detach a volume from a guest. It's prerequisite to active multipath

--- a/zvmsdk/api.py
+++ b/zvmsdk/api.py
@@ -1807,7 +1807,8 @@ class SDKAPI(object):
     def create_fcp_template(self, name, description: str = '',
                             fcp_devices: str = '',
                             host_default: bool = False,
-                            default_sp_list: list = []):
+                            default_sp_list: list = None,
+                            min_fcp_paths_count: int = None):
         """API for creating a FCP template in database.
 
         :param str name: the name of the template
@@ -1819,14 +1820,17 @@ class SDKAPI(object):
         :param list default_sp_list: the list of storage providers that will
             use this FCP template as default FCP template. If None, it means
             no storage provider would use this FCP template as default.
+        :param min_fcp_paths_count: The minimum number of FCP paths that
+            should be defined to a vm when attachinga data volume to a vm or
+            BFV (deploying a vm from SCSI image).
         """
         return self._volumeop.create_fcp_template(
             name, description, fcp_devices,
-            host_default=host_default, default_sp_list=default_sp_list)
+            host_default=host_default, default_sp_list=default_sp_list, min_fcp_paths_count=min_fcp_paths_count)
 
     def edit_fcp_template(self, fcp_template_id, name=None,
                           description=None, fcp_devices=None,
-                          host_default=None, default_sp_list=None):
+                          host_default=None, default_sp_list=None, min_fcp_paths_count: int = None):
         """ Edit a FCP device template
 
         The kwargs values are pre-validated in two places:
@@ -1850,6 +1854,7 @@ class SDKAPI(object):
         :param default_sp_list: (list)
           Example:
             ["SP1", "SP2"]
+        :param min_fcp_paths_count: min fcp paths count
         :return:
           Example
             {
@@ -1865,7 +1870,7 @@ class SDKAPI(object):
         return self._volumeop.edit_fcp_template(
             fcp_template_id, name=name, description=description,
             fcp_devices=fcp_devices, host_default=host_default,
-            default_sp_list=default_sp_list)
+            default_sp_list=default_sp_list, min_fcp_paths_count=min_fcp_paths_count)
 
     def volume_attach(self, connection_info):
         """ Attach a volume to a guest. It's prerequisite to active multipath
@@ -1894,7 +1899,7 @@ class SDKAPI(object):
 
     def volume_refresh_bootmap(self, fcpchannels, wwpns, lun,
                                wwid='',
-                               transportfiles=None, guest_networks=None):
+                               transportfiles=None, guest_networks=None, min_fcp_paths_count=None):
         """ Refresh a volume's bootmap info.
 
         :param list of fcpchannels
@@ -1929,12 +1934,14 @@ class SDKAPI(object):
                'dns_addr': ['9.0.2.1', '9.0.3.1'],
                'gateway_addr': '192.168.96.1',
                'cidr': "192.168.96.0/24",
-               'nic_vdev': '1003}]
+               'nic_vdev': '1003}],
+        :param min_fcp_paths_count
         """
         return self._volumeop.volume_refresh_bootmap(fcpchannels, wwpns, lun,
                                                 wwid=wwid,
                                                 transportfiles=transportfiles,
-                                                guest_networks=guest_networks)
+                                                guest_networks=guest_networks,
+                                                min_fcp_paths_count=min_fcp_paths_count)
 
     def volume_detach(self, connection_info):
         """ Detach a volume from a guest. It's prerequisite to active multipath

--- a/zvmsdk/config.py
+++ b/zvmsdk/config.py
@@ -524,20 +524,6 @@ The default value is 1800 seconds, if the execution of punch scripts
 reached the timeout, the attach/detach will fail.
 '''
         ),
-    Opt('min_fcp_paths_count',
-        section='volume',
-        default=2,
-        opt_type='int',
-        help='''
-The minimum number of FCP paths that should be defined to a vm when attaching
- a data volume to a vm or BFV (deploying a vm from SCSI image).
-
-The default value would be the path count of the current fcp_list.
-
-If there is no this count of FCP paths available, the attach volume or BFV
- would fail.
-'''
-        ),
     Opt('get_fcp_pair_with_same_index',
         section='volume',
         default='0',
@@ -673,25 +659,6 @@ class ConfigOpts(object):
                 for opt in opts:
                     val = cf.get(sec, opt)
                     configs[sec][opt] = val
-            # Set the min_fcp_paths_count value as the paths count of current
-            # fcp_list.
-            # if fcp_list is not set, we will use a large number as the value
-            # of min_fcp_paths_count
-            min_fcp_paths_count = 999
-            if "volume" in configs:
-                # if min_fcp_paths_count is not set by user, set the value as
-                # paths count of the current fcp_list
-                if "min_fcp_paths_count" not in configs["volume"] or \
-                not configs["volume"]["min_fcp_paths_count"]:
-                    fcp_list_value = configs['volume'].get('fcp_list', "")
-                    if fcp_list_value != "":
-                        min_fcp_paths_count = len(fcp_list_value.split(';'))
-                    configs["volume"]["min_fcp_paths_count"] = \
-                                                        min_fcp_paths_count
-            else:
-                configs["volume"] = {}
-                # make sure the min_fcp_paths_count is always set
-                configs["volume"]["min_fcp_paths_count"] = min_fcp_paths_count
             return configs
 
     def merge(self, defaults, override):
@@ -752,10 +719,6 @@ class ConfigOpts(object):
                 if (k2 == "user_default_max_cpu") and (
                     v2['default'] is not None):
                     self._check_user_default_max_cpu(v2['default'])
-                # check min_fcp_paths_count
-                if (k2 == "min_fcp_paths_count") and (
-                    v2['default'] is not None):
-                    self._check_min_fcp_paths_count(v2['default'])
 
     def _check_zvm_disk_pool(self, value):
         disks = value.split(':')
@@ -781,10 +744,6 @@ class ConfigOpts(object):
     def _check_user_default_max_cpu(self, value):
         if (value < 1) or (value > 64):
             raise OptFormatError("zvm", "user_default_max_cpu", value)
-
-    def _check_min_fcp_paths_count(self, value):
-        if value < 1:
-            raise OptFormatError("volume", "min_fcp_paths_count", value)
 
     def toDict(self, d):
         D = Dict()

--- a/zvmsdk/database.py
+++ b/zvmsdk/database.py
@@ -349,10 +349,11 @@ class FCPDbOperator(object):
         #       as integer 1 and 0 respectively
         fcp_info_tables['template'] = (
             "CREATE TABLE IF NOT EXISTS template("
-            "id             varchar(32)  NOT NULL COLLATE NOCASE,"
-            "name           varchar(128) NOT NULL COLLATE NOCASE,"
-            "description    varchar(255) NOT NULL DEFAULT '' COLLATE NOCASE,"
-            "is_default     integer      NOT NULL DEFAULT 0,"
+            "id                   varchar(32)  NOT NULL COLLATE NOCASE,"
+            "name                 varchar(128) NOT NULL COLLATE NOCASE,"
+            "description          varchar(255) NOT NULL DEFAULT '' COLLATE NOCASE,"
+            "is_default           integer      NOT NULL DEFAULT 0,"
+            "min_fcp_paths_count  integer      NOT NULL DEFAULT -1,"
             "PRIMARY KEY (id))")
 
         # table for relationships between templates and storage providers:
@@ -794,6 +795,16 @@ class FCPDbOperator(object):
         else:
             return False
 
+    def get_min_fcp_paths_count(self, fcp_template_id):
+        with get_fcp_conn() as conn:
+            query_sql = conn.execute("SELECT min_fcp_paths_count FROM template "
+                                     "WHERE id=?", (fcp_template_id,))
+            min_fcp_paths_count = query_sql.fetchall()
+            if min_fcp_paths_count:
+                return min_fcp_paths_count[0][0]
+            else:
+                return None
+
     @staticmethod
     def update_basic_info_of_fcp_template(record):
         """ update basic info of a fcp template
@@ -805,7 +816,7 @@ class FCPDbOperator(object):
 
             :return NULL
         """
-        name, description, host_default, fcp_template_id = record
+        name, description, host_default, min_fcp_paths_count, fcp_template_id = record
         with get_fcp_conn() as conn:
             # 1. change the is_default of existing templates to False,
             #    if the is_default of the being-created template is True,
@@ -814,8 +825,8 @@ class FCPDbOperator(object):
                 conn.execute("UPDATE template SET is_default=?", (False,))
             # 2. update current template
             conn.execute("UPDATE template "
-                         "SET name=?, description=?, is_default=? "
-                         "WHERE id=?",
+                         "SET name=?, description=?, is_default=?, "
+                         "min_fcp_paths_count=? WHERE id=?",
                          record)
 
     #########################################################
@@ -1095,14 +1106,15 @@ class FCPDbOperator(object):
         # Start to check whether the available count >= min_fcp_paths_count
         allocated_paths = len(fcp_list)
         total_paths = len(path_list)
+        min_fcp_paths_count = self.get_min_fcp_paths_count(fcp_template_id)
         if allocated_paths < total_paths:
             LOG.info("Not all paths have available FCP devices. "
                      "The count of paths having available FCP: %d is less "
                      "than total paths: %d. "
                      "The configured minimum FCP paths count is: %d." %
                      (allocated_paths, total_paths,
-                      CONF.volume.min_fcp_paths_count))
-            if allocated_paths >= CONF.volume.min_fcp_paths_count:
+                      min_fcp_paths_count))
+            if allocated_paths >= min_fcp_paths_count:
                 LOG.warning("Return the FCPs from the available paths to "
                             "continue.")
                 return fcp_list
@@ -1114,7 +1126,7 @@ class FCPDbOperator(object):
 
     def create_fcp_template(self, fcp_template_id, name, description,
                             fcp_devices_by_path, host_default,
-                            default_sp_list):
+                            default_sp_list, min_fcp_paths_count):
         """ Insert records of new fcp template in fcp DB
 
         :param fcp_template_id: fcp template id
@@ -1131,6 +1143,7 @@ class FCPDbOperator(object):
             }
         :param host_default: (bool)
         :param default_sp_list: (list)
+        :param min_fcp_paths_count: (int)
         :return: NULL
         """
         # first check the template exist or not
@@ -1167,9 +1180,16 @@ class FCPDbOperator(object):
             if host_default is True:
                 conn.execute("UPDATE template SET is_default=?", (False,))
             # 2. insert a new record in template table
-            tmpl_basics = (fcp_template_id, name, description, host_default)
-            conn.execute("INSERT INTO template (id, name, description, "
-                         "is_default) VALUES (?, ?, ?, ?)", tmpl_basics)
+            #    if min_fccp_paths_count is None or less than 1, will not insert it to db
+            if not min_fcp_paths_count or min_fcp_paths_count < 1:
+                tmpl_basics = (fcp_template_id, name, description, host_default)
+                sql = "INSERT INTO template (id, name, description, " \
+                      "is_default) VALUES (?, ?, ?, ?)"
+            else:
+                tmpl_basics = (fcp_template_id, name, description, host_default, min_fcp_paths_count)
+                sql = "INSERT INTO template (id, name, description, " \
+                      "is_default, min_fcp_paths_count) VALUES (?, ?, ?, ?, ?)"
+            conn.execute(sql, tmpl_basics)
             # 3. insert new records in template_fcp_mapping
             conn.executemany("INSERT INTO template_fcp_mapping (fcp_id, "
                              "tmpl_id, path) VALUES (?, ?, ?)", fcp_mapping)
@@ -1184,9 +1204,33 @@ class FCPDbOperator(object):
                                      "tmpl_id=? WHERE sp_name=?",
                                      sp_mapping_to_update)
 
+    def _validate_min_fcp_paths_count(self, fcp_devices, min_fcp_paths_count, fcp_template_id=None):
+        """
+        When to edit FCP template, if min_fcp_paths_count is not None or
+        fcp_devices is not None, need to validate the values.
+        min_fcp_paths_count should not be larger than fcp_device_path_count.
+        If min_fcp_paths_count is None, get the value from template table.
+        If fcp_devices is None, get the fcp_device_path_count from template_fcp_mapping table.
+        """
+        if min_fcp_paths_count or fcp_devices:
+            if not fcp_devices:
+                fcp_devices_path_count = self.get_path_count(fcp_template_id)
+            else:
+                fcp_devices_by_path = utils.expand_fcp_list(fcp_devices)
+                fcp_devices_path_count = len(fcp_devices_by_path)
+            if not min_fcp_paths_count:
+                min_fcp_paths_count = self.get_min_fcp_paths_count(fcp_template_id)
+
+            if min_fcp_paths_count > fcp_devices_path_count:
+                msg = "min_fcp_paths_count %s is larger than fcp device path count %s " \
+                      "which is not allowed. Please change the fcp_devices setting or " \
+                      "min_fcp_paths_count." % (min_fcp_paths_count, fcp_devices_path_count)
+                LOG.error(msg)
+                raise exception.ValidationError(msg)
+
     def edit_fcp_template(self, fcp_template_id, name=None, description=None,
                           fcp_devices=None, host_default=None,
-                          default_sp_list=None):
+                          default_sp_list=None, min_fcp_paths_count=None):
         """ Edit a FCP device template
 
         The kwargs values are pre-validated in two places:
@@ -1197,11 +1241,11 @@ class FCPDbOperator(object):
 
         If any kwarg is None, the kwarg will not be updated.
 
-        :param fcp_template_id: template id
-        :param name:            template name
-        :param description:     template desc
-        :param fcp_devices:     FCP devices divided into
-                                different paths by semicolon
+        :param fcp_template_id:     template id
+        :param name:                template name
+        :param description:         template desc
+        :param fcp_devices:         FCP devices divided into
+                                    different paths by semicolon
           Format:
             "fcp-devices-from-path0;fcp-devices-from-path1;..."
           Example:
@@ -1210,6 +1254,7 @@ class FCPDbOperator(object):
         :param default_sp_list: (list)
           Example:
             ["SP1", "SP2"]
+        :param min_fcp_paths_count: if it is -1 or None, then will not update this field in db.
         :return:
           Example
             {
@@ -1218,7 +1263,8 @@ class FCPDbOperator(object):
                 'id': '36439338-db14-11ec-bb41-0201018b1dd2',
                 'description': 'This is Default template',
                 'host_default': True,
-                'storage_providers': ['sp4', 'v7k60']
+                'storage_providers': ['sp4', 'v7k60'],
+                'min_fcp_paths_count': 2
               }
             }
         """
@@ -1257,6 +1303,9 @@ class FCPDbOperator(object):
                                   "({}) are allocated from template {}."
                                   .format(inuse_fcp, fcp_template_id))
                         raise exception.ValidationError(detail=detail)
+            # If min_fcp_paths_count is not None or fcp_devices is not None, need to validate the value.
+            # min_fcp_paths_count should not be larger than fcp device path count, or else, raise error.
+            self._validate_min_fcp_paths_count(fcp_devices, min_fcp_paths_count, fcp_template_id)
 
             tmpl_basic, fcp_detail = self.get_fcp_templates_details(
                 [fcp_template_id])
@@ -1359,7 +1408,7 @@ class FCPDbOperator(object):
                                          fcp_from_input[fcp]))
 
             # DML: table template
-            if (name, description, host_default) != (None, None, None):
+            if (name, description, host_default, min_fcp_paths_count) != (None, None, None, None):
                 LOG.info("DML: table template")
                 record_to_update = (
                     name if name is not None
@@ -1368,6 +1417,8 @@ class FCPDbOperator(object):
                     else tmpl_basic[0]['description'],
                     host_default if host_default is not None
                     else tmpl_basic[0]['is_default'],
+                    min_fcp_paths_count if min_fcp_paths_count is not None
+                    else tmpl_basic[0]['min_fcp_paths_count'],
                     fcp_template_id)
                 self.update_basic_info_of_fcp_template(record_to_update)
                 LOG.info("FCP template basic info updated.")
@@ -1397,7 +1448,9 @@ class FCPDbOperator(object):
                 'host_default': bool(tmpl_basic[0]['is_default']),
                 'storage_providers':
                     [] if tmpl_basic[0]['sp_name'] is None
-                    else [r['sp_name'] for r in tmpl_basic]}}
+                    else [r['sp_name'] for r in tmpl_basic],
+                'min_fcp_paths_count': tmpl_basic[0]['min_fcp_paths_count']
+            }}
 
     def get_fcp_templates(self, template_id_list=None):
         """Get fcp templates base info by template_id_list.
@@ -1505,7 +1558,7 @@ class FCPDbOperator(object):
         template_sp_mapping table.
 
         tmpl_cmd result format:
-        id|name|description|is_default|sp_name
+        id|name|description|is_default|min_fcp_paths_count|sp_name
 
         'devices_cmd' is used to get fcp device info. Device's template id is
         gotten from template_fcp_mapping table, device's usage info is gotten
@@ -1528,7 +1581,7 @@ class FCPDbOperator(object):
         """
         tmpl_cmd = (
             "SELECT t.id, t.name, t.description, "
-            "t.is_default, ts.sp_name "
+            "t.is_default, t.min_fcp_paths_count, ts.sp_name "
             "FROM template AS t "
             "LEFT OUTER JOIN template_sp_mapping AS ts "
             "ON t.id=ts.tmpl_id")

--- a/zvmsdk/returncode.py
+++ b/zvmsdk/returncode.py
@@ -336,6 +336,8 @@ errors = {
                       "'%(max)im'."),
                   22: ("Failed to delete FCP device template, "
                       "error: %(msg)s"),
+                  23: ("Failed to create or update FCP device template, "
+                       "error: %(msg)s")
                   },
                  "The operated object status conflict"
                  ],

--- a/zvmsdk/sdkwsgi/handlers/volume.py
+++ b/zvmsdk/sdkwsgi/handlers/volume.py
@@ -101,10 +101,10 @@ class VolumeAction(object):
                                         connections, fcp_template_id)
 
     def volume_refresh_bootmap(self, fcpchannel, wwpn, lun, wwid,
-                               transportfiles, guest_networks):
+                               transportfiles, guest_networks, min_fcp_paths_count):
         info = self.client.send_request('volume_refresh_bootmap',
                                         fcpchannel, wwpn, lun, wwid,
-                                        transportfiles, guest_networks)
+                                        transportfiles, guest_networks, min_fcp_paths_count)
         return info
 
     @validation.schema(volume.create_fcp_template)
@@ -113,6 +113,7 @@ class VolumeAction(object):
         description = body.get('description', '')
         fcp_devices = body.get('fcp_devices', '')
         host_default = body.get('host_default', False)
+        min_fcp_paths_count = body.get('min_fcp_paths_count', None)
         # ensure host_default parameter is boolean type
         # because of the database's requirements
         valid_true_values = [True, 'True', 'TRUE', 'true', '1',
@@ -121,13 +122,14 @@ class VolumeAction(object):
             host_default = True
         else:
             host_default = False
-        default_sp_list = body.get('storage_providers', None)
+        default_sp_list = body.get('storage_providers', [])
 
         ret = self.client.send_request('create_fcp_template', name,
                                        description=description,
                                        fcp_devices=fcp_devices,
                                        host_default=host_default,
-                                       default_sp_list=default_sp_list)
+                                       default_sp_list=default_sp_list,
+                                       min_fcp_paths_count=min_fcp_paths_count)
         return ret
 
     @validation.schema(volume.edit_fcp_template)
@@ -138,13 +140,15 @@ class VolumeAction(object):
         fcp_devices = body.get('fcp_devices', None)
         host_default = body.get('host_default', None)
         default_sp_list = body.get('storage_providers', None)
+        min_fcp_paths_count = body.get('min_fcp_paths_count', None)
 
         ret = self.client.send_request('edit_fcp_template',
                                        fcp_template_id,
                                        name=name, description=description,
                                        fcp_devices=fcp_devices,
                                        host_default=host_default,
-                                       default_sp_list=default_sp_list)
+                                       default_sp_list=default_sp_list,
+                                       min_fcp_paths_count=min_fcp_paths_count)
         return ret
 
 
@@ -196,17 +200,18 @@ def volume_detach(req):
 def volume_refresh_bootmap(req):
 
     def _volume_refresh_bootmap(req, fcpchannel, wwpn, lun, wwid,
-                                transportfiles, guest_networks):
+                                transportfiles, guest_networks, min_fcp_paths_count):
         action = get_action()
         return action.volume_refresh_bootmap(fcpchannel, wwpn, lun, wwid,
-                                             transportfiles, guest_networks)
+                                             transportfiles, guest_networks, min_fcp_paths_count)
 
     body = util.extract_json(req.body)
     info = _volume_refresh_bootmap(req, body['info']['fcpchannel'],
                                    body['info']['wwpn'], body['info']['lun'],
                                    body['info'].get('wwid', ""),
                                    body['info'].get('transportfiles', ""),
-                                   body['info'].get('guest_networks', []))
+                                   body['info'].get('guest_networks', []),
+                                   body['info'].get('min_fcp_paths_count', None))
     info_json = json.dumps(info)
     req.response.body = utils.to_utf8(info_json)
     req.response.content_type = 'application/json'

--- a/zvmsdk/sdkwsgi/handlers/volume.py
+++ b/zvmsdk/sdkwsgi/handlers/volume.py
@@ -101,10 +101,10 @@ class VolumeAction(object):
                                         connections, fcp_template_id)
 
     def volume_refresh_bootmap(self, fcpchannel, wwpn, lun, wwid,
-                               transportfiles, guest_networks, min_fcp_paths_count):
+                               transportfiles, guest_networks, fcp_template_id):
         info = self.client.send_request('volume_refresh_bootmap',
                                         fcpchannel, wwpn, lun, wwid,
-                                        transportfiles, guest_networks, min_fcp_paths_count)
+                                        transportfiles, guest_networks, fcp_template_id)
         return info
 
     @validation.schema(volume.create_fcp_template)
@@ -200,10 +200,10 @@ def volume_detach(req):
 def volume_refresh_bootmap(req):
 
     def _volume_refresh_bootmap(req, fcpchannel, wwpn, lun, wwid,
-                                transportfiles, guest_networks, min_fcp_paths_count):
+                                transportfiles, guest_networks, fcp_template_id):
         action = get_action()
         return action.volume_refresh_bootmap(fcpchannel, wwpn, lun, wwid,
-                                             transportfiles, guest_networks, min_fcp_paths_count)
+                                             transportfiles, guest_networks, fcp_template_id)
 
     body = util.extract_json(req.body)
     info = _volume_refresh_bootmap(req, body['info']['fcpchannel'],
@@ -211,7 +211,7 @@ def volume_refresh_bootmap(req):
                                    body['info'].get('wwid', ""),
                                    body['info'].get('transportfiles', ""),
                                    body['info'].get('guest_networks', []),
-                                   body['info'].get('min_fcp_paths_count', None))
+                                   body['info'].get('fcp_template_id', None))
     info_json = json.dumps(info)
     req.response.body = utils.to_utf8(info_json)
     req.response.content_type = 'application/json'

--- a/zvmsdk/sdkwsgi/schemas/volume.py
+++ b/zvmsdk/sdkwsgi/schemas/volume.py
@@ -146,7 +146,8 @@ create_fcp_template = {
         'host_default': parameter_types.boolean,
         'storage_providers': {
             'type': 'array'
-        }
+        },
+        'min_fcp_paths_count': parameter_types.positive_integer
     },
     'required': ['name'],
     'additionalProperties': False,
@@ -167,7 +168,8 @@ edit_fcp_template = {
         'host_default': parameter_types.boolean,
         'storage_providers': {
             'type': 'array'
-        }
+        },
+        'min_fcp_paths_count': parameter_types.positive_integer
     },
     'required': ['fcp_template_id'],
     'additionalProperties': False

--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -851,15 +851,20 @@ class SMTClient(object):
             self._pathutils.clean_temp_folder(iucv_path)
 
     def volume_refresh_bootmap(self, fcpchannels, wwpns, lun, wwid='',
-                               transportfiles=None, guest_networks=None):
+                               transportfiles=None, guest_networks=None, min_fcp_paths_count=None):
         guest_networks = guest_networks or []
+        # User can set min_fcp_paths_count when creating or editing fcp template. If user doesn't set it,
+        # it is the FCP devices path count of the current FCP template by default. But if no FCP devices
+        # are added to the template, it will be set to 999.
+        if not min_fcp_paths_count:
+            min_fcp_paths_count = 999
         fcps = ','.join(fcpchannels)
         ws = ','.join(wwpns)
         fcs = "--fcpchannel=%s" % fcps
         wwpns = "--wwpn=%s" % ws
         lun = "--lun=%s" % lun
         wwid = "--wwid=%s" % wwid
-        paths = "--minfcp=%s" % CONF.volume.min_fcp_paths_count
+        paths = "--minfcp=%s" % min_fcp_paths_count
         cmd = ['sudo', '/opt/zthin/bin/refresh_bootmap', fcs, wwpns,
                lun, wwid, paths]
 

--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -851,13 +851,8 @@ class SMTClient(object):
             self._pathutils.clean_temp_folder(iucv_path)
 
     def volume_refresh_bootmap(self, fcpchannels, wwpns, lun, wwid='',
-                               transportfiles=None, guest_networks=None, min_fcp_paths_count=None):
+                               transportfiles=None, guest_networks=None, min_fcp_paths_count=0):
         guest_networks = guest_networks or []
-        # User can set min_fcp_paths_count when creating or editing fcp template. If user doesn't set it,
-        # it is the FCP devices path count of the current FCP template by default. But if no FCP devices
-        # are added to the template, it will be set to 999.
-        if not min_fcp_paths_count:
-            min_fcp_paths_count = 999
         fcps = ','.join(fcpchannels)
         ws = ','.join(wwpns)
         fcs = "--fcpchannel=%s" % fcps

--- a/zvmsdk/tests/unit/sdkwsgi/handlers/test_volume.py
+++ b/zvmsdk/tests/unit/sdkwsgi/handlers/test_volume.py
@@ -98,17 +98,19 @@ class HandlersVolumeTest(unittest.TestCase):
         wwpns = ['5005076802100c1b', '5005076802200c1b']
         lun = '0000000000000000'
         wwid = '600507640083826de00000000000605b'
+        fcp_template_id = 'fake_fcp_tmpl_id'
         info = {"fcpchannel": fcpchannels,
                 "wwpn": wwpns,
                 "lun": lun,
-                "wwid": wwid}
+                "wwid": wwid,
+                "fcp_template_id": fcp_template_id}
         body_str = {"info": info}
         self.req.body = json.dumps(body_str)
 
         volume.volume_refresh_bootmap(self.req)
         mock_refresh_bootmap.assert_called_once_with(
             'volume_refresh_bootmap',
-            fcpchannels, wwpns, lun, wwid, '', [])
+            fcpchannels, wwpns, lun, wwid, '', [], fcp_template_id)
 
     @mock.patch.object(util, 'wsgi_path_item')
     @mock.patch('zvmconnector.connector.ZVMConnector.send_request')
@@ -157,14 +159,15 @@ class HandlersVolumeTest(unittest.TestCase):
                 'description': 'desc text',
                 'fcp_devices': '1a00-1a0f;1b00, 1b05-1b0f',
                 'host_default': 'yes',
-                'storage_providers': []}
+                'storage_providers': [],
+                'min_fcp_paths_count': 2}
         self.req.body = json.dumps(body)
         volume.create_fcp_template(self.req)
         mock_send_request.assert_called_once_with('create_fcp_template', 'tmpl name',
                                                   description='desc text',
                                                   fcp_devices='1a00-1a0f;1b00, 1b05-1b0f',
                                                   host_default=True,
-                                                  default_sp_list=[])
+                                                  default_sp_list=[], min_fcp_paths_count=2)
 
     @mock.patch('zvmconnector.connector.ZVMConnector.send_request')
     def test_create_fcp_template_default_values(self, mock_send_request):
@@ -196,7 +199,7 @@ class HandlersVolumeTest(unittest.TestCase):
         volume.edit_fcp_template(self.req)
         mock_send_request.assert_called_once_with(
             'edit_fcp_template', tmpl_id,
-            description=None, fcp_devices=None, **request_args)
+            description=None, fcp_devices=None, min_fcp_paths_count=None, **request_args)
 
     @mock.patch('zvmconnector.connector.ZVMConnector.send_request')
     def test_get_fcp_templates(self, mock_send_request):

--- a/zvmsdk/tests/unit/sdkwsgi/handlers/test_volume.py
+++ b/zvmsdk/tests/unit/sdkwsgi/handlers/test_volume.py
@@ -177,7 +177,8 @@ class HandlersVolumeTest(unittest.TestCase):
         self.req.body = json.dumps(body)
         volume.create_fcp_template(self.req)
         mock_send_request.assert_called_once_with('create_fcp_template', 'tmpl name', description='',
-                                                  fcp_devices='', host_default=False, default_sp_list=None)
+                                                  fcp_devices='', host_default=False, default_sp_list=[],
+                                                  min_fcp_paths_count=None)
 
     @mock.patch('zvmconnector.connector.ZVMConnector.send_request')
     def test_edit_fcp_template(self, mock_send_request):

--- a/zvmsdk/tests/unit/test_api.py
+++ b/zvmsdk/tests/unit/test_api.py
@@ -49,7 +49,8 @@ class SDKAPITestCase(base.SDKTestCase):
             'description': 'new_desc',
             'fcp_devices': '1A00-1A03;1B00-1B03',
             'host_default': False,
-            'default_sp_list': ['sp1']}
+            'default_sp_list': ['sp1'],
+            'min_fcp_paths_count': 2}
         self.api.edit_fcp_template(tmpl_id, **kwargs)
         mock_edit_tmpl.assert_called_once_with(tmpl_id, **kwargs)
 
@@ -566,9 +567,11 @@ class SDKAPITestCase(base.SDKTestCase):
         wwpn = ['5005076802100c1b', '5005076802200c1b']
         lun = '01000000000000'
         wwid = '600507640083826de00000000000605b'
-        self.api.volume_refresh_bootmap(fcpchannel, wwpn, lun, wwid)
+        fcp_template_id = 'fake_tmpl_id'
+        self.api.volume_refresh_bootmap(fcpchannel, wwpn, lun, wwid, fcp_template_id=fcp_template_id)
         mock_attach.assert_called_once_with(fcpchannel, wwpn, lun, wwid=wwid,
-                                    transportfiles=None, guest_networks=None)
+                                            transportfiles=None, guest_networks=None,
+                                            fcp_template_id=fcp_template_id)
 
     @mock.patch("zvmsdk.volumeop.VolumeOperatorAPI."
                 "detach_volume_from_instance")

--- a/zvmsdk/tests/unit/test_database.py
+++ b/zvmsdk/tests/unit/test_database.py
@@ -1247,6 +1247,9 @@ class FCPDbOperatorTestCase(base.SDKTestCase):
         self.db_op.bulk_delete_fcp_from_template(fcp_id_list, template_id)
         # insert new test data
         self._insert_data_into_template_fcp_mapping_table(template_fcp)
+        # insert date to template table
+        template_info = [(template_id, 'name', 'desc', False, -1)]
+        self._insert_data_into_template_table(template_info)
         try:
             # expected result
             all_possible_pairs = {
@@ -1271,8 +1274,7 @@ class FCPDbOperatorTestCase(base.SDKTestCase):
                 self.assertEqual(fcp_list, [])
             # test case3: min_fcp_paths_count was set to 1
             # set min_fcp_paths_count to 1
-            template_info = [(template_id, 'name-1', 'description-1', False, 1)]
-            self._insert_data_into_template_table(template_info)
+            self.db_op.edit_fcp_template(template_id, min_fcp_paths_count=1)
             all_possible_pairs = {('1b01',), ('1b03',)}
             result = set()
             for i in range(10):
@@ -1341,6 +1343,18 @@ class FCPDbOperatorTestCase(base.SDKTestCase):
         get_min_fcp_paths_count_from_db.return_value = 4
         ret = self.db_op.get_min_fcp_paths_count('template_id')
         self.assertEqual(4, ret)
+
+    def test_get_min_fcp_paths_count_with_non_template(self):
+        self.assertRaisesRegex(exception.SDKObjectNotExistError,
+                               'min_fcp_paths_count from fcp_template_id',
+                               self.db_op.get_min_fcp_paths_count, None)
+
+    @mock.patch("zvmsdk.database.FCPDbOperator.get_min_fcp_paths_count_from_db")
+    def test_get_min_fcp_paths_count_with_none_mincount(self, get_min_fcp_paths_count_from_db):
+        get_min_fcp_paths_count_from_db.return_value = None
+        self.assertRaisesRegex(exception.SDKObjectNotExistError,
+                               'min_fcp_paths_count from fcp_template_id',
+                               self.db_op.get_min_fcp_paths_count, 'fake_fcp_template_id')
 
     def test_edit_fcp_template(self):
         """ Test edit_fcp_template()

--- a/zvmsdk/tests/unit/test_smtclient.py
+++ b/zvmsdk/tests/unit/test_smtclient.py
@@ -1879,7 +1879,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         wwid = '600507640083826de00000000000605b'
         execute.side_effect = [(0, "")]
         self._smtclient.volume_refresh_bootmap(fcpchannels, wwpns, lun,
-                                               wwid=wwid)
+                                               wwid=wwid, min_fcp_paths_count=2)
         refresh_bootmap_cmd = ['sudo', '/opt/zthin/bin/refresh_bootmap',
                                '--fcpchannel=5d71',
                                '--wwpn=5005076802100c1b,5005076802200c1b',
@@ -1890,14 +1890,13 @@ class SDKSMTClientTestCases(base.SDKTestCase):
 
     @mock.patch.object(zvmutils, 'execute')
     def test_refresh_bootmap_return_value_withskip(self, execute):
-        base.set_conf('volume', 'min_fcp_paths_count', 2)
         fcpchannels = ['5d71']
         wwpns = ['5005076802100c1b', '5005076802200c1b']
         lun = '0000000000000000'
         wwid = '600507640083826de00000000000605b'
         execute.side_effect = [(0, "")]
         self._smtclient.volume_refresh_bootmap(fcpchannels, wwpns, lun,
-                                               wwid=wwid)
+                                               wwid=wwid, min_fcp_paths_count=2)
         refresh_bootmap_cmd = ['sudo', '/opt/zthin/bin/refresh_bootmap',
                                '--fcpchannel=5d71',
                                '--wwpn=5005076802100c1b,5005076802200c1b',

--- a/zvmsdk/tests/unit/test_volumeop.py
+++ b/zvmsdk/tests/unit/test_volumeop.py
@@ -40,7 +40,8 @@ class TestVolumeOperatorAPI(base.SDKTestCase):
             'description': 'new_desc',
             'fcp_devices': '1A00-1A03;1B00-1B03',
             'host_default': False,
-            'default_sp_list': ['sp1']}
+            'default_sp_list': ['sp1'],
+            'min_fcp_paths_count': 2}
         self.operator.edit_fcp_template(tmpl_id, **kwargs)
         mock_edit_tmpl.assert_called_once_with(tmpl_id, **kwargs)
 
@@ -865,21 +866,24 @@ class TestFCPManager(base.SDKTestCase):
                 "name": "name1",
                 "description": "desc1",
                 "host_default": False,
-                "storage_providers": []
+                "storage_providers": [],
+                'min_fcp_paths_count': 0
             },
             'fakehos2-1111-1111-1111-111111111111': {
                 "id": "fakehos2-1111-1111-1111-111111111111",
                 "name": "name2",
                 "description": "desc2",
                 "host_default": False,
-                "storage_providers": []
+                "storage_providers": [],
+                'min_fcp_paths_count': 0
             },
             'ad8f352e-4c9e-4335-aafa-4f4eb2fcc77c': {
                 "id": "ad8f352e-4c9e-4335-aafa-4f4eb2fcc77c",
                 "name": "test template",
                 "description": "test create_fcp_template",
                 "host_default": True,
-                "storage_providers": ['sp1', 'sp2']
+                "storage_providers": ['sp1', 'sp2'],
+                'min_fcp_paths_count': 2,
             },
         }
         try:
@@ -903,6 +907,17 @@ class TestFCPManager(base.SDKTestCase):
                                                      new_template_id)
             self.db_op.bulk_delete_from_fcp_table(fcp_id_list)
 
+    def test_create_fcp_template_with_error(self):
+        name = 'test_fcp_tmpl'
+        description = 'test-desc'
+        fcp_devices = '1a10;1b10'
+        min_fcp_paths_count = 4
+        self.assertRaisesRegex(exception.SDKConflictError,
+                               'min_fcp_paths_count 4 is larger than fcp device path count 2',
+                               self.fcpops.create_fcp_template,
+                               name, description, fcp_devices,
+                               min_fcp_paths_count=min_fcp_paths_count)
+
     @mock.patch("zvmsdk.database.FCPDbOperator.edit_fcp_template")
     def test_edit_fcp_template(self, mock_db_edit_tmpl):
         """ Test edit_fcp_template """
@@ -912,7 +927,8 @@ class TestFCPManager(base.SDKTestCase):
             'description': 'new_desc',
             'fcp_devices': '1A00-1A03;1B00-1B03',
             'host_default': False,
-            'default_sp_list': ['sp1']}
+            'default_sp_list': ['sp1'],
+            'min_fcp_paths_count': 2}
         self.fcpops.edit_fcp_template(tmpl_id, **kwargs)
         mock_db_edit_tmpl.assert_called_once_with(tmpl_id, **kwargs)
 
@@ -933,7 +949,7 @@ class TestFCPManager(base.SDKTestCase):
             template_id_1 = 'template_id_1'
             template_id_2 = 'template_id_2'
             templates = [(template_id_1, 'name1', 'desc1', 1),
-                        (template_id_2, 'name2', 'desc2', 0)]
+                         (template_id_2, 'name2', 'desc2', 0)]
             self._delete_from_template_table([template_id_1, template_id_2])
             self._insert_data_into_template_table(templates)
             template_sp_mapping = [('sp1', template_id_1), ('sp2', template_id_2)]
@@ -960,7 +976,8 @@ class TestFCPManager(base.SDKTestCase):
                     "name": "name1",
                     "description": "desc1",
                     "host_default": True,
-                    "storage_providers": ["sp1"]
+                    "storage_providers": ["sp1"],
+                    'min_fcp_paths_count': 0
                     }]}
             self.assertDictEqual(result_1, expected_1)
 
@@ -972,7 +989,8 @@ class TestFCPManager(base.SDKTestCase):
                     "name": "name2",
                     "description": "desc2",
                     "host_default": False,
-                    "storage_providers": ["sp2"]
+                    "storage_providers": ["sp2"],
+                    'min_fcp_paths_count': 0
                     }]}
             result_2 = self.fcpops.get_fcp_templates(assigner_id='user2')
             self.assertDictEqual(result_2, expected_2)
@@ -997,14 +1015,16 @@ class TestFCPManager(base.SDKTestCase):
                         "name": "name1",
                         "description": "desc1",
                         "host_default": True,
-                        "storage_providers": ["sp1"]
+                        "storage_providers": ["sp1"],
+                        'min_fcp_paths_count': 0
                     },
                     {
                         "id": template_id_2,
                         "name": "name2",
                         "description": "desc2",
                         "host_default": False,
-                        "storage_providers": ["sp2"]
+                        "storage_providers": ["sp2"],
+                        'min_fcp_paths_count': 0
                     }]}
             result_6 = self.fcpops.get_fcp_templates(default_sp_list=['all'])
             self.assertDictEqual(result_6, expected_all)
@@ -1028,7 +1048,7 @@ class TestFCPManager(base.SDKTestCase):
             template_id_1 = 'template_id_1'
             template_id_2 = 'template_id_2'
             templates = [(template_id_1, 'name1', 'desc1', 1),
-                        (template_id_2, 'name2', 'desc2', 0)]
+                         (template_id_2, 'name2', 'desc2', 0)]
             self._delete_from_template_table([template_id_1, template_id_2])
             self._insert_data_into_template_table(templates)
             template_sp_mapping = [('sp1', template_id_1), ('sp2', template_id_2)]
@@ -1071,6 +1091,7 @@ class TestFCPManager(base.SDKTestCase):
                 "description": "desc1",
                 "host_default": True,
                 "storage_providers": ["sp1"],
+                'min_fcp_paths_count': 2,
                 "statistics": {
                     0: {
                             "total": "1A00",
@@ -1110,6 +1131,7 @@ class TestFCPManager(base.SDKTestCase):
                 "description": "desc2",
                 "host_default": False,
                 "storage_providers": ["sp2"],
+                'min_fcp_paths_count': 2,
                 "statistics": {
                     0: {
                             "total": "1B00",

--- a/zvmsdk/volumeop.py
+++ b/zvmsdk/volumeop.py
@@ -946,7 +946,7 @@ class FCPManager(object):
         # If min_fcp_paths_count is not None,need validate the value
         if min_fcp_paths_count and min_fcp_paths_count > len(fcp_devices_by_path):
             msg = "min_fcp_paths_count %s is larger than fcp device path count %s, " \
-                  "please adjust fcp_devices or min_fcp_paths_count." \
+                  "adjust fcp_devices or min_fcp_paths_count." \
                   % (min_fcp_paths_count, len(fcp_devices_by_path))
             LOG.error(msg)
             raise exception.SDKConflictError(modID='volume', rs=23, msg=msg)

--- a/zvmsdk/volumeop.py
+++ b/zvmsdk/volumeop.py
@@ -1068,8 +1068,9 @@ class FCPManager(object):
         """
         template_dict = {}
         for item in raw_data:
-            id, name, description, is_default, sp_name = item
-            min_fcp_paths_count = self.db.get_min_fcp_paths_count(id)
+            id, name, description, is_default, min_fcp_paths_count, sp_name = item
+            if min_fcp_paths_count < 0:
+                min_fcp_paths_count = self.db.get_path_count(id)
             if not template_dict.get(id, None):
                 template_dict[id] = {"id": id,
                                      "name": name,

--- a/zvmsdk/volumeop.py
+++ b/zvmsdk/volumeop.py
@@ -93,11 +93,12 @@ class VolumeOperatorAPI(object):
 
     def volume_refresh_bootmap(self, fcpchannel, wwpn, lun,
                                wwid='',
-                               transportfiles='', guest_networks=None):
+                               transportfiles='', guest_networks=None, min_fcp_paths_count=None):
         return self._volume_manager.volume_refresh_bootmap(fcpchannel, wwpn,
                                             lun, wwid=wwid,
                                             transportfiles=transportfiles,
-                                            guest_networks=guest_networks)
+                                            guest_networks=guest_networks,
+                                            min_fcp_paths_count=min_fcp_paths_count)
 
     def get_volume_connector(self, assigner_id, reserve,
                              fcp_template_id=None, sp_name=None):
@@ -120,17 +121,20 @@ class VolumeOperatorAPI(object):
     def create_fcp_template(self, name, description: str = '',
                             fcp_devices: str = '',
                             host_default: bool = False,
-                            default_sp_list: list = None):
+                            default_sp_list: list = [],
+                            min_fcp_paths_count: int = None):
         return self._volume_manager.fcp_mgr.create_fcp_template(
-            name, description, fcp_devices, host_default, default_sp_list)
+            name, description, fcp_devices, host_default, default_sp_list,
+            min_fcp_paths_count)
 
     def edit_fcp_template(self, fcp_template_id, name=None,
                           description=None, fcp_devices=None,
-                          host_default=None, default_sp_list=None):
+                          host_default=None, default_sp_list=None,
+                          min_fcp_paths_count=None):
         return self._volume_manager.fcp_mgr.edit_fcp_template(
             fcp_template_id, name=name, description=description,
             fcp_devices=fcp_devices, host_default=host_default,
-            default_sp_list=default_sp_list)
+            default_sp_list=default_sp_list, min_fcp_paths_count=min_fcp_paths_count)
 
     def get_fcp_templates(self, template_id_list=None, assigner_id=None,
                           default_sp_list=None, host_default=None):
@@ -915,7 +919,8 @@ class FCPManager(object):
     def create_fcp_template(self, name, description: str = '',
                             fcp_devices: str = '',
                             host_default: bool = False,
-                            default_sp_list: list = None):
+                            default_sp_list: list = None,
+                            min_fcp_paths_count: int = None):
         """Create a fcp template and return the basic information of
         the created template, for example:
         {
@@ -923,8 +928,9 @@ class FCPManager(object):
             'name': 'bjcb-test-template',
             'id': '36439338-db14-11ec-bb41-0201018b1dd2',
             'description': 'This is Default template',
-                'host_default': True,
-                'storage_providers': ['sp4', 'v7k60']
+            'host_default': True,
+            'storage_providers': ['sp4', 'v7k60'],
+            'min_fcp_paths_count': 2
             }
         }
         """
@@ -935,21 +941,31 @@ class FCPManager(object):
         tmpl_id = str(uuid.uuid1())
         # Get fcp devices info index by path
         fcp_devices_by_path = utils.expand_fcp_list(fcp_devices)
+        # If min_fcp_paths_count is not None,need validate the value
+        # self.validate_min_fcp_paths_count(fcp_devices, min_fcp_paths_count)
+        if min_fcp_paths_count and min_fcp_paths_count > len(fcp_devices_by_path):
+            msg = "min_fcp_paths_count %s is larger than fcp device path count %s " \
+                  "which is not allowed." % (min_fcp_paths_count, len(fcp_devices_by_path))
+            LOG.error(msg)
+            raise exception.ValidationError(msg)
         # Insert related records in FCP database
         self.db.create_fcp_template(tmpl_id, name, description,
                                     fcp_devices_by_path, host_default,
-                                    default_sp_list)
+                                    default_sp_list, min_fcp_paths_count)
+        min_fcp_paths_count_db = self.db.get_min_fcp_paths_count(tmpl_id)
         # Return template basic info
         LOG.info("A FCP template was created with ID %s." % tmpl_id)
         return {'fcp_template': {'name': name,
                 'id': tmpl_id,
                 'description': description,
                 'host_default': host_default,
-                'storage_providers': default_sp_list if default_sp_list else []}}
+                'storage_providers': default_sp_list if default_sp_list else [],
+                'min_fcp_paths_count': min_fcp_paths_count_db}}
 
     def edit_fcp_template(self, fcp_template_id, name=None,
                           description=None, fcp_devices=None,
-                          host_default=None, default_sp_list=None):
+                          host_default=None, default_sp_list=None,
+                          min_fcp_paths_count=None):
         """ Edit a FCP device template
 
         The kwargs values are pre-validated in two places:
@@ -973,6 +989,8 @@ class FCPManager(object):
         :param default_sp_list: (list)
           Example:
             ["SP1", "SP2"]
+        :param min_fcp_paths_count  the min fcp paths count, if it is None,
+                                    will not update this field in db.
         :return:
           Example
             {
@@ -981,19 +999,21 @@ class FCPManager(object):
                 'id': '36439338-db14-11ec-bb41-0201018b1dd2',
                 'description': 'This is Default template',
                 'host_default': True,
-                'storage_providers': ['sp4', 'v7k60']
+                'storage_providers': ['sp4', 'v7k60'],
+                'min_fcp_paths_count': 2
               }
             }
         """
         LOG.info("Enter: edit_fcp_template with args {}".format(
             (fcp_template_id, name, description, fcp_devices,
-             host_default, default_sp_list)))
+             host_default, default_sp_list, min_fcp_paths_count)))
         # DML in FCP database
         result = self.db.edit_fcp_template(fcp_template_id, name=name,
                                            description=description,
                                            fcp_devices=fcp_devices,
                                            host_default=host_default,
-                                           default_sp_list=default_sp_list)
+                                           default_sp_list=default_sp_list,
+                                           min_fcp_paths_count=min_fcp_paths_count)
         LOG.info("Exit: edit_fcp_template")
         return result
 
@@ -1047,12 +1067,14 @@ class FCPManager(object):
         template_dict = {}
         for item in raw_data:
             id, name, description, is_default, sp_name = item
+            min_fcp_paths_count = self.db.get_min_fcp_paths_count(id)
             if not template_dict.get(id, None):
                 template_dict[id] = {"id": id,
                                      "name": name,
                                      "description": description,
                                      "host_default": bool(is_default),
-                                     "storage_providers": []}
+                                     "storage_providers": [],
+                                     "min_fcp_paths_count": min_fcp_paths_count}
             # one fcp template can be multiple sp's default template
             if sp_name and sp_name not in template_dict[id]["storage_providers"]:
                 template_dict[id]["storage_providers"].append(sp_name)
@@ -1730,14 +1752,16 @@ class FCPVolumeManager(object):
 
     def volume_refresh_bootmap(self, fcpchannels, wwpns, lun,
                                wwid='',
-                               transportfiles=None, guest_networks=None):
+                               transportfiles=None, guest_networks=None,
+                               min_fcp_paths_count=None):
         ret = None
         with zvmutils.acquire_lock(self._lock):
             LOG.debug('Enter lock scope of volume_refresh_bootmap.')
             ret = self._smtclient.volume_refresh_bootmap(fcpchannels, wwpns,
                                         lun, wwid=wwid,
                                         transportfiles=transportfiles,
-                                        guest_networks=guest_networks)
+                                        guest_networks=guest_networks,
+                                        min_fcp_paths_count=min_fcp_paths_count)
         LOG.debug('Exit lock of volume_refresh_bootmap with ret %s.' % ret)
         return ret
 


### PR DESCRIPTION
In this PR:
1. if user specifies min_fcp_paths_count when creating or editing fcp template, this attibutes will be saved to template table.
2. add parameter min_fcp_paths_count for api volume_refresh_bootmap

Signed-off-by: xingjing <xingjing@cn.ibm.com>