### PR TITLE
change description and fcp_devices to optional

### DIFF
--- a/zvmconnector/restclient.py
+++ b/zvmconnector/restclient.py
@@ -509,9 +509,7 @@ def req_set_fcp_usage(start_index, *args, **kwargs):
 
 def req_create_fcp_template(start_index, *args, **kwargs):
     url = '/volumes/fcptemplates'
-    body = {'name': args[start_index],
-            'description': args[start_index + 1],
-            'fcp_devices': args[start_index + 2]}
+    body = {'name': args[start_index]}
     fill_kwargs_in_body(body, **kwargs)
     return url, body
 
@@ -942,7 +940,7 @@ DATABASE = {
         'request': req_set_fcp_usage},
     'create_fcp_template': {
         'method': 'POST',
-        'args_required': 3,
+        'args_required': 1,
         'params_path': 0,
         'request': req_create_fcp_template},
     'edit_fcp_template': {

--- a/zvmsdk/api.py
+++ b/zvmsdk/api.py
@@ -1804,7 +1804,8 @@ class SDKAPI(object):
         return self._volumeop.set_fcp_usage(userid, fcp, reserved,
                                             connections, fcp_template_id)
 
-    def create_fcp_template(self, name, description, fcp_devices,
+    def create_fcp_template(self, name, description: str = '',
+                            fcp_devices: str = '',
                             host_default: bool = False,
                             default_sp_list: list = []):
         """API for creating a FCP template in database.

--- a/zvmsdk/sdkwsgi/handlers/volume.py
+++ b/zvmsdk/sdkwsgi/handlers/volume.py
@@ -110,13 +110,13 @@ class VolumeAction(object):
     @validation.schema(volume.create_fcp_template)
     def create_fcp_template(self, body=None):
         name = body.get('name')
-        description = body.get('description')
-        fcp_devices = body.get('fcp_devices', None)
+        description = body.get('description', '')
+        fcp_devices = body.get('fcp_devices', '')
         host_default = body.get('host_default', False)
         # ensure host_default parameter is boolean type
         # because of the database's requirements
         valid_true_values = [True, 'True', 'TRUE', 'true', '1',
-                         'ON', 'On', 'on', 'YES', 'Yes', 'yes']
+                             'ON', 'On', 'on', 'YES', 'Yes', 'yes']
         if host_default in valid_true_values:
             host_default = True
         else:
@@ -124,7 +124,8 @@ class VolumeAction(object):
         default_sp_list = body.get('storage_providers', None)
 
         ret = self.client.send_request('create_fcp_template', name,
-                                       description, fcp_devices,
+                                       description=description,
+                                       fcp_devices=fcp_devices,
                                        host_default=host_default,
                                        default_sp_list=default_sp_list)
         return ret

--- a/zvmsdk/sdkwsgi/schemas/volume.py
+++ b/zvmsdk/sdkwsgi/schemas/volume.py
@@ -148,7 +148,7 @@ create_fcp_template = {
             'type': 'array'
         }
     },
-    'required': ['name', 'description', 'fcp_devices'],
+    'required': ['name'],
     'additionalProperties': False,
 }
 

--- a/zvmsdk/tests/unit/sdkclientcases/test_restclient.py
+++ b/zvmsdk/tests/unit/sdkclientcases/test_restclient.py
@@ -943,7 +943,9 @@ class RESTClientTestCase(unittest.TestCase):
         request.return_value = self.response
         get_token.return_value = self._tmp_token()
 
-        self.client.call("create_fcp_template", 'tmpl name', 'desc text', '1a00,1a03-1a04;1b00-1b05',
+        self.client.call("create_fcp_template", 'tmpl name',
+                         description='desc text',
+                         fcp_devices='1a00,1a03-1a04;1b00-1b05',
                          host_default=True, default_sp_list=['v5k', 'v7k', 'd8k'])
         request.assert_called_with(method, full_uri,
                                    data=body, headers=header,
@@ -953,7 +955,9 @@ class RESTClientTestCase(unittest.TestCase):
                 'description': 'desc text',
                 'fcp_devices': '1a00,1a03-1a04;1b00-1b05'}
         body = json.dumps(body)
-        self.client.call("create_fcp_template", 'tmpl name', 'desc text', '1a00,1a03-1a04;1b00-1b05')
+        self.client.call("create_fcp_template", 'tmpl name',
+                         description='desc text',
+                         fcp_devices='1a00,1a03-1a04;1b00-1b05')
         request.assert_called_with(method, full_uri,
                                    data=body, headers=header,
                                    verify=False)

--- a/zvmsdk/tests/unit/sdkwsgi/handlers/test_volume.py
+++ b/zvmsdk/tests/unit/sdkwsgi/handlers/test_volume.py
@@ -160,9 +160,21 @@ class HandlersVolumeTest(unittest.TestCase):
                 'storage_providers': []}
         self.req.body = json.dumps(body)
         volume.create_fcp_template(self.req)
-        mock_send_request.assert_called_once_with('create_fcp_template', 'tmpl name', 'desc text',
-                                                  '1a00-1a0f;1b00, 1b05-1b0f', host_default=True,
+        mock_send_request.assert_called_once_with('create_fcp_template', 'tmpl name',
+                                                  description='desc text',
+                                                  fcp_devices='1a00-1a0f;1b00, 1b05-1b0f',
+                                                  host_default=True,
                                                   default_sp_list=[])
+
+    @mock.patch('zvmconnector.connector.ZVMConnector.send_request')
+    def test_create_fcp_template_default_values(self, mock_send_request):
+        """Test the default values was set correctly when create fcp template."""
+        mock_send_request.return_value = {'overallRC': 0}
+        body = {'name': 'tmpl name'}
+        self.req.body = json.dumps(body)
+        volume.create_fcp_template(self.req)
+        mock_send_request.assert_called_once_with('create_fcp_template', 'tmpl name', description='',
+                                                  fcp_devices='', host_default=False, default_sp_list=None)
 
     @mock.patch('zvmconnector.connector.ZVMConnector.send_request')
     def test_edit_fcp_template(self, mock_send_request):

--- a/zvmsdk/volumeop.py
+++ b/zvmsdk/volumeop.py
@@ -117,7 +117,8 @@ class VolumeOperatorAPI(object):
                                                   reserved, connections,
                                                   fcp_template_id)
 
-    def create_fcp_template(self, name, description, fcp_devices,
+    def create_fcp_template(self, name, description: str = '',
+                            fcp_devices: str = '',
                             host_default: bool = False,
                             default_sp_list: list = None):
         return self._volume_manager.fcp_mgr.create_fcp_template(
@@ -911,7 +912,8 @@ class FCPManager(object):
         self.sync_fcp_table_with_zvm(fcp_dict_in_zvm)
         LOG.info("Exit: Sync FCP DB with FCP info queried from z/VM.")
 
-    def create_fcp_template(self, name, description, fcp_devices,
+    def create_fcp_template(self, name, description: str = '',
+                            fcp_devices: str = '',
                             host_default: bool = False,
                             default_sp_list: list = None):
         """Create a fcp template and return the basic information of


### PR DESCRIPTION
when creating a fcp template, change parameters description and fcp_devices
from required to optional to make it consistent with nova api.

Signed-off-by: CaoBiao <bjcb@cn.ibm.com>