### PR TITLE
fix bug when sync wwpns of fcp

### DIFF
--- a/zvmsdk/tests/unit/test_volumeop.py
+++ b/zvmsdk/tests/unit/test_volumeop.py
@@ -817,13 +817,13 @@ class TestFCPManager(base.SDKTestCase):
                      '20076d8500005181', '27', 'free', 'none',
                      template_id),
             '1b01': ('1b01', 'user2', 1, 1, 'c05076de33000003',
-                     '20076d8500005181', '27', 'active', 'owner1',
+                     'c05076de3300264b', '27', 'active', 'owner1',
                      template_id),
             '1b02': ('1b02', '', 0, 0, 'c05076de33000b02',
                      '20076d8500005181', '27', 'free', 'none',
                      template_id),
             '1b03': ('1b03', 'unit0001', 2, 1, 'c05076de33000004',
-                     '20076d8500005185', '30', 'active', 'unit0001',
+                     'c05076de3300264b', '30', 'active', 'unit0001',
                      template_id)
         }
         try:

--- a/zvmsdk/tests/unit/test_volumeop.py
+++ b/zvmsdk/tests/unit/test_volumeop.py
@@ -767,16 +767,17 @@ class TestFCPManager(base.SDKTestCase):
         # remove dirty data from other test cases
         self.db_op.bulk_delete_from_fcp_table(fcp_id_list)
         self._insert_data_into_fcp_table(fcp_info_list)
-        # fcp info in zvm
-        # 1a01: is in zvm, but wwpns,state,owner are changed
-        #       should update these columns
-        # 1a02: is not found in zvm, should be remove from db
-        # 1b01: is in zvm, wwpn is changed, but in use(connections != 0)
-        #       so should not update its NPIV wwpns
-        #       physical WWPN will change
-        # 1b02: is new in zvm, should add to db
-        # 1b03: is in zvm, owner and chpid are changed
-        #       should be updated
+        # FCP devices info in z/VM
+        # 1a01: is in z/VM, but WWPNs, state, owner are changed,
+        #       should update these columns.
+        # 1a02: is not found in z/VM, should be removed from db.
+        # 1b01: is in z/VM, WWPNs are changed, but it is in use
+        #       (reserved != 0 or connections != 0), so should not update
+        #       its NPIV and physical WWPNs.
+        # 1b02: is new in z/VM, should add to db.
+        # 1b03: is in z/VM, WWPNs, owner and CHPID changed,
+        #       should update values for owner and CHPID, but should NOT
+        #       update WWPNs because the FCP device is in use.
         fcp_info_in_zvm = [
             'opnstk1: FCP device number: 1A01',
             'opnstk1:   Status: Free',

--- a/zvmsdk/volumeop.py
+++ b/zvmsdk/volumeop.py
@@ -442,6 +442,9 @@ class FCP(object):
     def set_npiv_port(self, new_npiv_port: str):
         self._npiv_port = new_npiv_port
 
+    def set_physical_port(self, new_phy_port: str):
+        self._physical_port = new_phy_port
+
     def get_physical_port(self):
         return self._physical_port
 
@@ -861,39 +864,49 @@ class FCPManager(object):
             (fcp_id, userid, connections, reserved, wwpn_npiv_db,
              wwpn_phy_db, chpid_db, fcp_state_db,
              fcp_owner_db, tmpl_id) = fcp_dict_in_db[fcp]
-            # Check WWPNs changed or not
+            # Get physical WWPN and NPIV WWPN queried from z/VM
             wwpn_phy_zvm = fcp_dict_in_zvm[fcp].get_physical_port()
             wwpn_npiv_zvm = fcp_dict_in_zvm[fcp].get_npiv_port()
-            # For an in-used FCP device,
-            # if its npiv_wwpn_zvm is changed in zvm,
-            # we will not update the npiv_wwpn_db in FCP DB;
-            # because the npiv_wwpn_db is need when detaching volumes,
-            # so as to delete the host-mapping from storage provider backend.
-            # Hence, we use npiv_wwpn_db to override npiv_wwpn_zvm
-            # in fcp_dict_in_zvm[fcp]
-            if (wwpn_npiv_zvm != wwpn_npiv_db and
-                    (0 != connections or 0 != reserved)):
-                fcp_dict_in_zvm[fcp].set_npiv_port(wwpn_npiv_db)
-            # Check chpid changed or not
+            # Get CHPID queried from z/VM
             chpid_zvm = fcp_dict_in_zvm[fcp].get_chpid()
-            # Check state changed or not
+            # Get FCP device state queried from z/VM
             # Possible state returned by ZVM:
             # 'active', 'free' or 'offline'
             fcp_state_zvm = fcp_dict_in_zvm[fcp].get_dev_status()
-            # Check owner changed or not
-            # Possbile FCP owner returned by ZVM:
+            # Get owner of FCP device queried from z/VM
+            # Possible FCP owner returned by ZVM:
             # VM userid: if the FCP is attached to a VM
             # A String "NONE": if the FCP is not attached
             fcp_owner_zvm = fcp_dict_in_zvm[fcp].get_owner()
-            if wwpn_phy_db != wwpn_phy_zvm:
-                fcp_ids_need_update.add(fcp)
-            elif wwpn_npiv_db != wwpn_npiv_zvm:
-                fcp_ids_need_update.add(fcp)
-            elif chpid_db != chpid_zvm:
+            # Check WWPNs need update or not
+            if wwpn_npiv_db == '' or (connections == 0 and reserved == 0):
+                # The WWPNs are secure to be updated when:
+                # case1(wwpn_npiv_db == ''): the wwpn_npiv_db is empty, for example, upgraded from 114.
+                # case2(connections == 0 and reserved == 0): the FCP device is not in use.
+                if wwpn_npiv_db != wwpn_npiv_zvm or wwpn_phy_db != wwpn_phy_zvm:
+                    # only need to update wwpns when they are different
+                    fcp_ids_need_update.add(fcp)
+            else:
+                # For an in-used FCP device, even its WWPNs(wwpn_npiv_zvm, wwpn_phy_zvm) are changed in z/VM,
+                # we can NOT update the wwpn_npiv, wwpn_phy columns in FCP DB because the host mapping from
+                # storage provider backend is still using the old WWPNs recorded in FCP DB.
+                # To detach the volume and delete the host mapping successfully, we need make sure the WWPNs records
+                # in FCP DB unchanged in this case.
+                # Because we will copy all properties in fcp_dict_in_zvm[fcp] to DB when update an FCP property (for
+                # example, state, owner, etc), we overwrite the (wwpn_npiv_zvm, wwpn_phy_zvm) in fcp_dict_in_zvm[fcp]
+                # to old (wwpn_npiv_db, wwpn_phy_db), so that their values will not be changed when update other
+                # properties.
+                fcp_dict_in_zvm[fcp].set_npiv_port(wwpn_npiv_db)
+                fcp_dict_in_zvm[fcp].set_physical_port(wwpn_phy_db)
+            # Other cases need to update FCP record in DB
+            if chpid_db != chpid_zvm:
+                # Check chpid changed or not
                 fcp_ids_need_update.add(fcp)
             elif fcp_state_db != fcp_state_zvm:
+                # Check state changed or not
                 fcp_ids_need_update.add(fcp)
             elif fcp_owner_db != fcp_owner_zvm:
+                # Check owner changed or not
                 fcp_ids_need_update.add(fcp)
             else:
                 LOG.debug("No need to update record of FCP "


### PR DESCRIPTION
when upgrade from ICIC 1.1.4, the fcp table has no WWPNs
if directly upgrade to 1.1.6, will has no WWPNs for in-use FCP devices.
and when sync database, current code will not sync wwpns of in-use FCP devices.

as a result, after upgrade, there is no wwpns for in-use FCP devices.

for issue: https://github.ibm.com/zvc/planning/issues/10248

Signed-off-by: CaoBiao <bjcb@cn.ibm.com>