### PR TITLE
Check status of multipathd service in attach detach scripts

### DIFF
--- a/zvmsdk/volumeops/templates/rhel7_attach_volume.j2
+++ b/zvmsdk/volumeops/templates/rhel7_attach_volume.j2
@@ -7,6 +7,29 @@ target_filename="{{ target_filename }}"
 
 echo "Enter RHEL7 attach script with parameters: FCP list:${fcp_list[@]}, INPUT WWPNS:${input_wwpns[@]}, LUN:$lun, target_filename:$target_filename"
 
+# ensure multipathd service is up
+echo "Begin to enable dm-multipath mode ..."
+enable_multipath_mod=`lsmod | grep dm_multipath`
+if [ -z "$enable_multipath_mod" ];then
+    modprobe dm-multipath
+    echo -e "#blacklist {
+    #	devnode \"*\"
+    #}
+    " > /etc/multipath.conf
+    mpathconf
+    systemctl restart multipathd.service
+    echo "dm-multipath mode enabled successfully"
+else
+    echo "dm-multipath mode is already enabled"
+fi
+echo "Checking status of multipathd service ..."
+check_multipathd_service=`systemctl is-active --quiet multipathd`
+exit_code=$?
+if [[ $exit_code != 0 ]]; then
+    echo "Attach script terminated because multipathd service is not active!"
+    exit $exit_code
+fi
+
 # because jinja2's problem, we can not use # to count the array_size
 fcp_count=0
 for fcp in ${fcp_list[@]}
@@ -192,22 +215,6 @@ if [ $FoundDiskPath -eq 1 ]; then
 else
     echo "Error happens during attachment because the device file of $fcp not found, will exit with code 1."
     exit 1
-fi
-
-# ensure multipathd service is up
-echo "Begin to enable dm-multipath mode ..."
-enable_multipath_mod=`lsmod | grep dm_multipath`
-if [ -z "$enable_multipath_mod" ];then
-    modprobe dm-multipath
-    echo -e "#blacklist {
-    #	devnode \"*\"
-    #}
-    " > /etc/multipath.conf
-    mpathconf
-    systemctl restart multipathd.service
-    echo "dm-multipath mode enabled successfully"
-else
-    echo "dm-multipath mode is already enabled"
 fi
 
 # read the WWN from page 0x83 value for a SCSI device

--- a/zvmsdk/volumeops/templates/rhel7_detach_volume.j2
+++ b/zvmsdk/volumeops/templates/rhel7_detach_volume.j2
@@ -9,6 +9,15 @@ is_last_volume="{{ is_last_volume }}"
 
 echo "Enter RHEL7 detach script with parameters: FCP list:${fcp_list[@]}, INPUT WWPNS:${input_wwpns[@]}, LUN:$lun, target_filename:$target_filename, is_last_volume: $is_last_volume."
 
+# ensure multipathd service is up
+echo "Checking status of multipathd service ..."
+check_multipathd_service=`systemctl is-active --quiet multipathd`
+exit_code=$?
+if [[ $exit_code != 0 ]]; then
+    echo "Detach script terminated because multipathd service is not active!"
+    exit $exit_code
+fi
+
 # Print info of each FCP
 for fcp in ${fcp_list[@]}
 do
@@ -130,7 +139,7 @@ if [ "$output" ]; then
         exit_code=2
     fi
 fi
-echo "Exit code for multipath -f: $exit_code"
+echo "Flushing a multipath device map $map_name exit with code: $exit_code"
 #if above code didn't succeed, exit now.
 if [[ $exit_code != 0 ]]; then
     exit $exit_code

--- a/zvmsdk/volumeops/templates/rhel8_attach_volume.j2
+++ b/zvmsdk/volumeops/templates/rhel8_attach_volume.j2
@@ -7,6 +7,30 @@ target_filename="{{ target_filename }}"
 
 echo "Enter RHEL8 attach script with parameters: FCP list:${fcp_list[@]}, INPUT WWPNS:${input_wwpns[@]}, LUN:$lun, target_filename:$target_filename"
 
+# ensure multipathd service is up
+echo "Begin to enable dm-multipath mode ..."
+enable_multipath_mod=`lsmod | grep dm_multipath`
+if [ -z "$enable_multipath_mod" ];then
+    modprobe dm-multipath
+    echo -e "#blacklist {
+    #	devnode \"*\"
+    #}
+    " > /etc/multipath.conf
+    mpathconf
+    systemctl restart multipathd.service
+    echo "dm-multipath mode enabled successfully"
+else
+    echo "dm-multipath mode is already enabled"
+fi
+
+echo "Checking status of multipathd service ..."
+check_multipathd_service=`systemctl is-active --quiet multipathd`
+exit_code=$?
+if [[ $exit_code != 0 ]]; then
+    echo "Attach script terminated because multipathd service is not active!"
+    exit $exit_code
+fi
+
 # because jinja2's problem, we can not use # to count the array_size
 fcp_count=0
 for fcp in ${fcp_list[@]}
@@ -196,22 +220,6 @@ if [ $FoundDiskPath -eq 1 ]; then
 else
     echo "Error happens during attachment because the device file of $fcp not found, will exit with code 1."
     exit 1
-fi
-
-# ensure multipathd service is up
-echo "Begin to enable dm-multipath mode ..."
-enable_multipath_mod=`lsmod | grep dm_multipath`
-if [ -z "$enable_multipath_mod" ];then
-    modprobe dm-multipath
-    echo -e "#blacklist {
-    #	devnode \"*\"
-    #}
-    " > /etc/multipath.conf
-    mpathconf
-    systemctl restart multipathd.service
-    echo "dm-multipath mode enabled successfully"
-else
-    echo "dm-multipath mode is already enabled"
 fi
 
 # read the WWN from page 0x83 value for a SCSI device

--- a/zvmsdk/volumeops/templates/rhel8_detach_volume.j2
+++ b/zvmsdk/volumeops/templates/rhel8_detach_volume.j2
@@ -9,6 +9,15 @@ is_last_volume="{{ is_last_volume }}"
 
 echo "Enter RHEL8 detach script with parameters: FCP list:${fcp_list[@]}, INPUT WWPNS:${input_wwpns[@]}, LUN:$lun, target_filename:$target_filename, is_last_volume: $is_last_volume."
 
+# ensure multipathd service is up
+echo "Checking status of multipathd service ..."
+check_multipathd_service=`systemctl is-active --quiet multipathd`
+exit_code=$?
+if [[ $exit_code != 0 ]]; then
+    echo "Detach script terminated because multipathd service is not active!"
+    exit $exit_code
+fi
+
 # Print info of each FCP
 for fcp in ${fcp_list[@]}
 do
@@ -131,7 +140,7 @@ if [ "$output" ]; then
         exit_code=2
     fi
 fi
-echo "Exit code for multipath -f: $exit_code"
+echo "Flushing a multipath device map $map_name exit with code: $exit_code"
 #if above code didn't succeed, exit now.
 if [[ $exit_code != 0 ]]; then
     exit $exit_code

--- a/zvmsdk/volumeops/templates/sles_attach_volume.j2
+++ b/zvmsdk/volumeops/templates/sles_attach_volume.j2
@@ -7,6 +7,30 @@ target_filename="{{ target_filename }}"
 
 echo "Enter SLES attach script with parameters: FCP list:${fcp_list[@]}, INPUT WWPNS:${input_wwpns[@]}, LUN:$lun, target_filename:$target_filename"
 
+# ensure multipathd service is up
+echo "Begin to enable dm-multipath mode ..."
+enable_multipath_mod=`lsmod | grep dm_multipath`
+if [ -z "$enable_multipath_mod" ];then
+    modprobe dm-multipath
+    echo -e "#blacklist {
+    #	devnode \"*\"
+    #}
+    " > /etc/multipath.conf
+    mpathconf
+    systemctl restart multipathd.service
+    echo "dm-multipath mode enabled successfully"
+else
+    echo "dm-multipath mode is already enabled"
+fi
+
+echo "Checking status of multipathd service ..."
+check_multipathd_service=`systemctl is-active --quiet multipathd`
+exit_code=$?
+if [[ $exit_code != 0 ]]; then
+    echo "Attach script terminated because multipathd service is not active!"
+    exit $exit_code
+fi
+
 # because jinja2's problem, we can not use # to count the array_size
 fcp_count=0
 for fcp in ${fcp_list[@]}
@@ -192,22 +216,6 @@ if [ $FoundDiskPath -eq 1 ]; then
 else
     echo "Error happens during attachment because the device file of $fcp not found, will exit with code 1."
     exit 1
-fi
-
-# ensure multipathd service is up
-echo "Begin to enable dm-multipath mode ..."
-enable_multipath_mod=`lsmod | grep dm_multipath`
-if [ -z "$enable_multipath_mod" ];then
-    modprobe dm-multipath
-    echo -e "#blacklist {
-    #   devnode \"*\"
-    #}
-    " > /etc/multipath.conf
-    mpathconf
-    systemctl restart multipathd.service
-    echo "dm-multipath mode enabled successfully"
-else
-    echo "dm-multipath mode is already enabled"
 fi
 
 WWID=`/lib/udev/scsi_id --page 0x83 --whitelisted $diskPath`

--- a/zvmsdk/volumeops/templates/sles_detach_volume.j2
+++ b/zvmsdk/volumeops/templates/sles_detach_volume.j2
@@ -9,6 +9,15 @@ is_last_volume="{{ is_last_volume }}"
 
 echo "Enter SLES detach script with parameters: FCP list:${fcp_list[@]}, INPUT WWPNS:${input_wwpns[@]}, LUN:$lun, target_filename:$target_filename, is_last_volume: $is_last_volume."
 
+# ensure multipathd service is up
+echo "Checking status of multipathd service ..."
+check_multipathd_service=`systemctl is-active --quiet multipathd`
+exit_code=$?
+if [[ $exit_code != 0 ]]; then
+    echo "Detach script terminated because multipathd service is not active!"
+    exit $exit_code
+fi
+
 # Print info of each FCP
 for fcp in ${fcp_list[@]}
 do
@@ -128,7 +137,7 @@ if [ "$output" ]; then
         exit_code=2
     fi
 fi
-echo "Exit code for multipath -f: $exit_code"
+echo "Flushing a multipath device map $map_name exit with code: $exit_code"
 #if above code didn't succeed, exit now.
 if [[ $exit_code != 0 ]]; then
     exit $exit_code

--- a/zvmsdk/volumeops/templates/ubuntu_attach_volume.j2
+++ b/zvmsdk/volumeops/templates/ubuntu_attach_volume.j2
@@ -18,6 +18,15 @@ target_filename="{{ target_filename }}"
 
 echo "Enter UBUNTU attach script with parameters: FCP list:${fcp_list[@]}, INPUT WWPNS:${input_wwpns[@]}, LUN:$lun lun_id:$lun_id, target_filename:$target_filename."
 
+# ensure multipathd service is up
+echo "Checking status of multipathd service ..."
+check_multipathd_service=`systemctl is-active --quiet multipathd`
+exit_code=$?
+if [[ $exit_code != 0 ]]; then
+    echo "Attach script terminated because multipathd service is not active!"
+    exit $exit_code
+fi
+
 # because jinja2's problem, we can not use # to count the array_size
 fcp_count=0
 for fcp in ${fcp_list[@]}

--- a/zvmsdk/volumeops/templates/ubuntu_detach_volume.j2
+++ b/zvmsdk/volumeops/templates/ubuntu_detach_volume.j2
@@ -19,6 +19,15 @@ is_last_volume="{{ is_last_volume }}"
 
 echo "Enter UBUNTU detach script with parameters: FCP:${fcp_list[@]}, INPUT WWPNS:${input_wwpns[@]}, LUN:$lun, LUN ID: $lun_id, target_filename:$target_filename, is_last_volume: $is_last_volume."
 
+# ensure multipathd service is up
+echo "Checking status of multipathd service ..."
+check_multipathd_service=`systemctl is-active --quiet multipathd`
+exit_code=$?
+if [[ $exit_code != 0 ]]; then
+    echo "Detach script terminated because multipathd service is not active!"
+    exit $exit_code
+fi
+
 # Print info of each FCP
 for fcp in ${fcp_list[@]}
 do
@@ -141,7 +150,7 @@ if [ "$output" ]; then
         exit_code=2
     fi
 fi
-echo "Exit code for multipath -f: $exit_code"
+echo "Flushing a multipath device map $map_name exit with code: $exit_code"
 #if above code didn't succeed, exit now.
 if [[ $exit_code != 0 ]]; then
     exit $exit_code


### PR DESCRIPTION
Only modprobe dm_multipath is not enough when executing attach detach
scripts, should make sure multipathd service is active.

Signed-off-by: CaoBiao <bjcb@cn.ibm.com>