### PR TITLE
Update code for min_fcp_paths_count, and optimize format

### DIFF
--- a/zvmsdk/database.py
+++ b/zvmsdk/database.py
@@ -1143,7 +1143,8 @@ class FCPDbOperator(object):
             }
         :param host_default: (bool)
         :param default_sp_list: (list)
-        :param min_fcp_paths_count: (int) by default, it is -1
+        :param min_fcp_paths_count: (int) if it is None, -1 will be saved
+                                    to template table as default value.
         :return: NULL
         """
         # first check the template exist or not
@@ -1180,15 +1181,15 @@ class FCPDbOperator(object):
             if host_default is True:
                 conn.execute("UPDATE template SET is_default=?", (False,))
             # 2. insert a new record in template table
-            #    if min_fcp_paths_count is None or less than 1, will not insert it to db
-            if not min_fcp_paths_count or min_fcp_paths_count < 1:
+            #    if min_fcp_paths_count is None, will not insert it to db
+            if not min_fcp_paths_count:
                 tmpl_basics = (fcp_template_id, name, description, host_default)
-                sql = "INSERT INTO template (id, name, description, " \
-                      "is_default) VALUES (?, ?, ?, ?)"
+                sql = ("INSERT INTO template (id, name, description, "
+                       "is_default) VALUES (?, ?, ?, ?)")
             else:
                 tmpl_basics = (fcp_template_id, name, description, host_default, min_fcp_paths_count)
-                sql = "INSERT INTO template (id, name, description, " \
-                      "is_default, min_fcp_paths_count) VALUES (?, ?, ?, ?, ?)"
+                sql = ("INSERT INTO template (id, name, description, "
+                       "is_default, min_fcp_paths_count) VALUES (?, ?, ?, ?, ?)")
             conn.execute(sql, tmpl_basics)
             # 3. insert new records in template_fcp_mapping
             conn.executemany("INSERT INTO template_fcp_mapping (fcp_id, "
@@ -1223,9 +1224,9 @@ class FCPDbOperator(object):
                 min_fcp_paths_count = self.get_min_fcp_paths_count_from_db(fcp_template_id)
 
             if min_fcp_paths_count > fcp_devices_path_count:
-                msg = "min_fcp_paths_count %s is larger than fcp device path count %s. " \
-                      "Adjust the fcp_devices setting or " \
-                      "min_fcp_paths_count." % (min_fcp_paths_count, fcp_devices_path_count)
+                msg = ("min_fcp_paths_count %s is larger than fcp device path count %s. "
+                       "Adjust the fcp_devices setting or "
+                       "min_fcp_paths_count." % (min_fcp_paths_count, fcp_devices_path_count))
                 LOG.error(msg)
                 raise exception.SDKConflictError(modID=self._module_id, rs=23, msg=msg)
 
@@ -1270,7 +1271,7 @@ class FCPDbOperator(object):
         :param default_sp_list: (list)
           Example:
             ["SP1", "SP2"]
-        :param min_fcp_paths_count: if it is -1 or None, then will not update this field in db.
+        :param min_fcp_paths_count: if it is None, then will not update this field in db.
         :return:
           Example
             {

--- a/zvmsdk/volumeop.py
+++ b/zvmsdk/volumeop.py
@@ -945,9 +945,9 @@ class FCPManager(object):
         fcp_devices_by_path = utils.expand_fcp_list(fcp_devices)
         # If min_fcp_paths_count is not None,need validate the value
         if min_fcp_paths_count and min_fcp_paths_count > len(fcp_devices_by_path):
-            msg = "min_fcp_paths_count %s is larger than fcp device path count %s, " \
-                  "adjust fcp_devices or min_fcp_paths_count." \
-                  % (min_fcp_paths_count, len(fcp_devices_by_path))
+            msg = ("min_fcp_paths_count %s is larger than fcp device path count %s, "
+                   "adjust fcp_devices or min_fcp_paths_count."
+                   % (min_fcp_paths_count, len(fcp_devices_by_path)))
             LOG.error(msg)
             raise exception.SDKConflictError(modID='volume', rs=23, msg=msg)
         # Insert related records in FCP database
@@ -1762,8 +1762,8 @@ class FCPVolumeManager(object):
         else:
             min_fcp_paths_count = self.db.get_min_fcp_paths_count(fcp_template_id)
             if min_fcp_paths_count == 0:
-                errmsg = "No FCP devices were found in the FCP template %s," \
-                         "stop refreshing bootmap." % fcp_template_id
+                errmsg = ("No FCP devices were found in the FCP template %s,"
+                          "stop refreshing bootmap." % fcp_template_id)
                 LOG.error(errmsg)
                 raise exception.SDKBaseException(msg=errmsg)
         with zvmutils.acquire_lock(self._lock):


### PR DESCRIPTION
1. Removed the unneccessary check for min_fcp_paths_count when create and edit fcp template.
2. Replace backslash with parentheses for long multi-lines string.

Signed-off-by: xingjing <xingjing@cn.ibm.com>