### PR TITLE
[master]Fix NIC not coupled issue when default_nic_dev contains a lower-case …

### DIFF
--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -2234,7 +2234,7 @@ class SMTClient(object):
 
         user_direct = self.get_user_direct(userid)
         new_user_direct = []
-        nicdef = "NICDEF %s" % nic_vdev
+        nicdef = "NICDEF %s" % nic_vdev.upper()
         for ent in user_direct:
             if len(ent) > 0:
                 new_user_direct.append(ent)

--- a/zvmsdk/tests/unit/test_smtclient.py
+++ b/zvmsdk/tests/unit/test_smtclient.py
@@ -2258,6 +2258,28 @@ class SDKSMTClientTestCases(base.SDKTestCase):
                                       "VS1",
                                       active=True)
 
+    @mock.patch.object(smtclient.SMTClient, 'get_user_direct')
+    @mock.patch.object(smtclient.SMTClient, '_lock_user_direct')
+    @mock.patch.object(smtclient.SMTClient, '_replace_user_direct')
+    @mock.patch.object(smtclient.SMTClient, '_couple_nic')
+    def test_couple_nic_to_vswitch_nic_in_lowercase(self, couple_nic, replace,
+                                   lock, get_user):
+        replace_data = ["USER ABC", "NICDEF 1E00 DEVICE 3",
+                        "NICDEF 1E00 LAN SYSTEM VS1 VLAN 8 PORTTYPE TRUNK"]
+        get_user.return_value = ["USER ABC", "NICDEF 1E00 DEVICE 3"]
+        self._smtclient.couple_nic_to_vswitch("fake_userid",
+                                               "1e00",
+                                               "VS1",
+                                               active=True,
+                                               vlan_id=8,
+                                               port_type='TRUNK')
+        lock.assert_called_with("fake_userid")
+        replace.assert_called_with("fake_userid", replace_data)
+        couple_nic.assert_called_with("fake_userid",
+                                      "1e00",
+                                      "VS1",
+                                      active=True)
+
     @mock.patch.object(smtclient.SMTClient, '_uncouple_nic')
     def test_uncouple_nic_from_vswitch(self, uncouple_nic):
         self._smtclient.uncouple_nic_from_vswitch("fake_userid",


### PR DESCRIPTION
…letter

When default_nic_dev is set to a nic device number that contains a lower-case letter, such as 1e00, the NIC in guest is not coupled correctly, due to the code has bug in handling lower-case letter.

This commit fix the bug.

Signed-off-by: Shu Juan Zhang <zshujuan@cn.ibm.com>