### PR TITLE
retry when lszfcp -P sometimes has no output

### DIFF
--- a/zvmsdk/volumeops/templates/rhel7_attach_volume.j2
+++ b/zvmsdk/volumeops/templates/rhel7_attach_volume.j2
@@ -41,7 +41,7 @@ echo "Checking status of multipathd service ..."
 check_multipathd_service=`systemctl is-active --quiet multipathd`
 exit_code=$?
 if [[ $exit_code != 0 ]]; then
-    echo "Attach script terminated because multipathd service is not active, exit with code 1."
+    echo "Attach script terminated because multipathd service is not active, exit with code $MULTIPATH_SERVICE_NOT_ACTIVE."
     exit $MULTIPATH_SERVICE_NOT_ACTIVE
 fi
 
@@ -54,7 +54,7 @@ do
 done
 
 if [[ $fcp_count -eq 0 ]]; then
-    echo "fcp_list is empty, exit with code 2."
+    echo "fcp_list is empty, exit with code $INVALID_PARAMETERS."
     exit $INVALID_PARAMETERS
 fi
 
@@ -117,21 +117,40 @@ echo -e "lszfcp -P output port info:\n$lszfcp_output"
 declare -A valid_dict
 for fcp in ${fcp_list[@]}
 do
-    wwpns_shown_in_sys=`ls /sys/bus/ccw/drivers/zfcp/0.0.$fcp/ | grep "0x"`
-    echo -e "WWPNs shown under /sys/bus/ccw/drivers/zfcp/0.0.$fcp/:\n$wwpns_shown_in_sys"
-    for wwpn in ${input_wwpns[@]}
+    # Retry each FCP device to make sure there are matched WWPNs for it
+    Timeout=10
+    while [[ $Timeout -gt 0 ]]
     do
-        fcp_wwpn_str="0.0.${fcp} ${wwpn}"
-        if [[ $lszfcp_output =~ $fcp_wwpn_str ]]; then
-            echo "$fcp_wwpn_str matched with content in ouput of lszfcp"
-            # add this combination into valid_dict
-            if [[ -z ${valid_dict[$fcp]} ]]; then
-                valid_dict+=([$fcp]="$wwpn")
-            else
-                old_value=${valid_dict[$fcp]}
-                new_value=${old_value}" "$wwpn
-                valid_dict[$fcp]=$new_value
+        # Get WWPNs under /sys/bus/ccw/drivers/zfcp/.
+        wwpns_shown_in_sys=`ls /sys/bus/ccw/drivers/zfcp/0.0.$fcp/ | grep "0x"`
+        echo -e "Target WWPNs shown under /sys/bus/ccw/drivers/zfcp/0.0.$fcp/:\n$wwpns_shown_in_sys"
+        # Try to find match between system WWPNs(from lszfcp output or under /sys) and input WWPNs
+        found_match=0
+        for wwpn in ${input_wwpns[@]}
+        do
+            fcp_wwpn_str="0.0.${fcp} ${wwpn}"
+            if [[ $lszfcp_output =~ $fcp_wwpn_str || $wwpns_shown_in_sys =~ $wwpn ]]; then
+                found_match=1
+                echo "$fcp_wwpn_str matched with the ouput of lszfcp or WWPNs shown under /sys/bus/ccw/drivers/zfcp/."
+                # Add this combination into valid_dict
+                if [[ -z ${valid_dict[$fcp]} ]]; then
+                    valid_dict+=([$fcp]="$wwpn")
+                else
+                    old_value=${valid_dict[$fcp]}
+                    new_value=${old_value}" "$wwpn
+                    valid_dict[$fcp]=$new_value
+                fi
             fi
+        done
+        # If no matched wwpn found, need retry
+        if [[ $found_match -eq 0 ]]; then
+            sleep 1
+            Timeout=$((Timeout-1))
+            echo "Retrying to get the target WWPNs for FCP device $fcp, $Timeout seconds left..."
+            lszfcp_output=`lszfcp -P | awk '{print $1}' | awk -F'/' '{print $1,$2}'`
+        else
+            echo "Found target WWPNs ${valid_dict[$fcp]} for FCP device $fcp."
+            break
         fi
     done
 done
@@ -144,7 +163,7 @@ do
     valid_fcp_count=$((valid_fcp_count+=1))
 done
 if [[ $valid_fcp_count -eq 0 ]]; then
-    echo "Can not find the intersection between input wwpns: ${input_wwpns[@]} and lszfcp output: $lszfcp_output, exit with code 3."
+    echo "Can not find the intersection between input wwpns: ${input_wwpns[@]} and lszfcp output: $lszfcp_output, exit with code $INVALID_WWPNS."
     exit $INVALID_WWPNS
 fi
 
@@ -228,7 +247,7 @@ done
 if [ $FoundDiskPath -eq 1 ]; then
     echo "The storage device is ready and found disk path: $diskPath."
 else
-    echo "Error happens during attachment because the device file of $fcp not found, will exit with code 4."
+    echo "Error happens during attachment because the device file of $fcp not found, will exit with code $DEVICE_PATH_NOT_FOUND."
     exit $DEVICE_PATH_NOT_FOUND
 fi
 

--- a/zvmsdk/volumeops/templates/rhel7_detach_volume.j2
+++ b/zvmsdk/volumeops/templates/rhel7_detach_volume.j2
@@ -26,7 +26,7 @@ echo "Checking status of multipathd service ..."
 check_multipathd_service=`systemctl is-active --quiet multipathd`
 exit_code=$?
 if [[ $exit_code != 0 ]]; then
-    echo "Detach script terminated because multipathd service is not active, exit with code 1."
+    echo "Detach script terminated because multipathd service is not active, exit with code $MULTIPATH_SERVICE_NOT_ACTIVE."
     exit $MULTIPATH_SERVICE_NOT_ACTIVE
 fi
 
@@ -54,21 +54,40 @@ echo "lszfcp -P output port info: $lszfcp_output ."
 declare -A valid_dict
 for fcp in ${fcp_list[@]}
 do
-    wwpns_shown_in_sys=`ls /sys/bus/ccw/drivers/zfcp/0.0.$fcp/ | grep "0x"`
-    echo -e "WWPNs shown under /sys/bus/ccw/drivers/zfcp/0.0.$fcp/:\n$wwpns_shown_in_sys"
-    for wwpn in ${input_wwpns[@]}
+    # Retry each FCP device to make sure there are matched WWPNs for it
+    Timeout=10
+    while [[ $Timeout -gt 0 ]]
     do
-        fcp_wwpn_str="0.0.${fcp} ${wwpn}"
-        if [[ $lszfcp_output =~ $fcp_wwpn_str ]]; then
-            echo "$fcp_wwpn_str matched with content in ouput of lszfcp"
-            # add this combination into valid_dict
-            if [[ -z ${valid_dict[$fcp]} ]]; then
-                valid_dict+=([$fcp]="$wwpn")
-            else
-                old_value=${valid_dict[$fcp]}
-                new_value=${old_value}" "$wwpn
-                valid_dict[$fcp]=$new_value
+        # Get WWPNs under /sys/bus/ccw/drivers/zfcp/.
+        wwpns_shown_in_sys=`ls /sys/bus/ccw/drivers/zfcp/0.0.$fcp/ | grep "0x"`
+        echo -e "Target WWPNs shown under /sys/bus/ccw/drivers/zfcp/0.0.$fcp/:\n$wwpns_shown_in_sys"
+        # Try to find match between system WWPNs(from lszfcp output or under /sys) and input WWPNs
+        found_match=0
+        for wwpn in ${input_wwpns[@]}
+        do
+            fcp_wwpn_str="0.0.${fcp} ${wwpn}"
+            if [[ $lszfcp_output =~ $fcp_wwpn_str || $wwpns_shown_in_sys =~ $wwpn ]]; then
+                found_match=1
+                echo "$fcp_wwpn_str matched with the ouput of lszfcp or WWPNs shown under /sys/bus/ccw/drivers/zfcp/."
+                # Add this combination into valid_dict
+                if [[ -z ${valid_dict[$fcp]} ]]; then
+                    valid_dict+=([$fcp]="$wwpn")
+                else
+                    old_value=${valid_dict[$fcp]}
+                    new_value=${old_value}" "$wwpn
+                    valid_dict[$fcp]=$new_value
+                fi
             fi
+        done
+        # If no matched wwpn found, need retry
+        if [[ $found_match -eq 0 ]]; then
+            sleep 1
+            Timeout=$((Timeout-1))
+            echo "Retrying to get the target WWPNs for FCP device $fcp, $Timeout seconds left..."
+            lszfcp_output=`lszfcp -P | awk '{print $1}' | awk -F'/' '{print $1,$2}'`
+        else
+            echo "Found target WWPNs ${valid_dict[$fcp]} for FCP device $fcp."
+            break
         fi
     done
 done
@@ -80,7 +99,7 @@ do
     valid_fcp_count=$((valid_fcp_count+=1))
 done
 if [[ $valid_fcp_count -eq 0 ]]; then
-    echo "Can not find the intersection between input wwpns: ${input_wwpns[@]} and lszfcp output: $lszfcp_output, exit with code 3."
+    echo "Can not find the intersection between input wwpns: ${input_wwpns[@]} and lszfcp output: $lszfcp_output, exit with code $INVALID_WWPNS."
     exit $INVALID_WWPNS
 fi
 
@@ -114,7 +133,7 @@ do
 done
 # if no disk path found, exit with code 4
 if [[ -z $diskPath ]]; then
-    echo "No valid paths found between FCP devices: ${fcp_list[@]} and WWPNS: ${input_wwpns}, exit with code 4."
+    echo "No valid paths found between FCP devices: ${fcp_list[@]} and WWPNS: ${input_wwpns}, exit with code $DEVICE_PATH_NOT_FOUND."
     exit $DEVICE_PATH_NOT_FOUND
 fi
 

--- a/zvmsdk/volumeops/templates/rhel8_attach_volume.j2
+++ b/zvmsdk/volumeops/templates/rhel8_attach_volume.j2
@@ -40,7 +40,7 @@ echo "Checking status of multipathd service ..."
 check_multipathd_service=`systemctl is-active --quiet multipathd`
 exit_code=$?
 if [[ $exit_code != 0 ]]; then
-    echo "Attach script terminated because multipathd service is not active, exit with code 1."
+    echo "Attach script terminated because multipathd service is not active, exit with code $MULTIPATH_SERVICE_NOT_ACTIVE."
     exit $MULTIPATH_SERVICE_NOT_ACTIVE
 fi
 
@@ -53,7 +53,7 @@ do
 done
 
 if [[ $fcp_count -eq 0 ]]; then
-    echo "fcp_list is empty, exit with code 2."
+    echo "fcp_list is empty, exit with code $INVALID_PARAMETERS."
     exit $INVALID_PARAMETERS
 fi
 
@@ -114,21 +114,40 @@ echo -e "lszfcp -P output port info:\n$lszfcp_output "
 declare -A valid_dict
 for fcp in ${fcp_list[@]}
 do
-    wwpns_shown_in_sys=`ls /sys/bus/ccw/drivers/zfcp/0.0.$fcp/ | grep "0x"`
-    echo -e "WWPNs shown under /sys/bus/ccw/drivers/zfcp/0.0.$fcp/:\n$wwpns_shown_in_sys"
-    for wwpn in ${input_wwpns[@]}
+    # Retry each FCP device to make sure there are matched WWPNs for it
+    Timeout=10
+    while [[ $Timeout -gt 0 ]]
     do
-        fcp_wwpn_str="0.0.${fcp} ${wwpn}"
-        if [[ $lszfcp_output =~ $fcp_wwpn_str ]]; then
-            echo "$fcp_wwpn_str matched with content in ouput of lszfcp"
-            # add this combination into valid_dict
-            if [[ -z ${valid_dict[$fcp]} ]]; then
-                valid_dict+=([$fcp]="$wwpn")
-            else
-                old_value=${valid_dict[$fcp]}
-                new_value=${old_value}" "$wwpn
-                valid_dict[$fcp]=$new_value
+        # Get WWPNs under /sys/bus/ccw/drivers/zfcp/.
+        wwpns_shown_in_sys=`ls /sys/bus/ccw/drivers/zfcp/0.0.$fcp/ | grep "0x"`
+        echo -e "Target WWPNs shown under /sys/bus/ccw/drivers/zfcp/0.0.$fcp/:\n$wwpns_shown_in_sys"
+        # Try to find match between system WWPNs(from lszfcp output or under /sys) and input WWPNs
+        found_match=0
+        for wwpn in ${input_wwpns[@]}
+        do
+            fcp_wwpn_str="0.0.${fcp} ${wwpn}"
+            if [[ $lszfcp_output =~ $fcp_wwpn_str || $wwpns_shown_in_sys =~ $wwpn ]]; then
+                found_match=1
+                echo "$fcp_wwpn_str matched with the ouput of lszfcp or WWPNs shown under /sys/bus/ccw/drivers/zfcp/."
+                # Add this combination into valid_dict
+                if [[ -z ${valid_dict[$fcp]} ]]; then
+                    valid_dict+=([$fcp]="$wwpn")
+                else
+                    old_value=${valid_dict[$fcp]}
+                    new_value=${old_value}" "$wwpn
+                    valid_dict[$fcp]=$new_value
+                fi
             fi
+        done
+        # If no matched wwpn found, need retry
+        if [[ $found_match -eq 0 ]]; then
+            sleep 1
+            Timeout=$((Timeout-1))
+            echo "Retrying to get the target WWPNs for FCP device $fcp, $Timeout seconds left..."
+            lszfcp_output=`lszfcp -P | awk '{print $1}' | awk -F'/' '{print $1,$2}'`
+        else
+            echo "Found target WWPNs ${valid_dict[$fcp]} for FCP device $fcp."
+            break
         fi
     done
 done
@@ -141,7 +160,7 @@ do
     valid_fcp_count=$((valid_fcp_count+=1))
 done
 if [[ $valid_fcp_count -eq 0 ]]; then
-    echo "Can not find the intersection between input wwpns: ${input_wwpns[@]} and lszfcp output: $lszfcp_output, exit with code 3."
+    echo "Can not find the intersection between input wwpns: ${input_wwpns[@]} and lszfcp output: $lszfcp_output, exit with code $INVALID_WWPNS."
     exit $INVALID_WWPNS
 fi
 
@@ -222,7 +241,7 @@ do
         # if devices still not ready, wait another 5 seconds and retry
         if [ $FoundDiskPath -eq 0 ]; then
             sleep 1
-            Timeout=$((Timeout-=1))
+            Timeout=$((Timeout-1))
             echo "Sleep 1 second to wait the devices ready, timeout left: $Timeout"
         fi
     done
@@ -231,7 +250,7 @@ done
 if [ $FoundDiskPath -eq 1 ]; then
     echo "The storage device is ready and found disk path: $diskPath."
 else
-    echo "Error happens during attachment because the device file of $fcp not found, will exit with code 4."
+    echo "Error happens during attachment because the device file of $fcp not found, will exit with code $DEVICE_PATH_NOT_FOUND."
     exit $DEVICE_PATH_NOT_FOUND
 fi
 

--- a/zvmsdk/volumeops/templates/rhel8_detach_volume.j2
+++ b/zvmsdk/volumeops/templates/rhel8_detach_volume.j2
@@ -27,7 +27,7 @@ echo "Checking status of multipathd service ..."
 check_multipathd_service=`systemctl is-active --quiet multipathd`
 exit_code=$?
 if [[ $exit_code != 0 ]]; then
-    echo "Detach script terminated because multipathd service is not active, exit with code 1."
+    echo "Detach script terminated because multipathd service is not active, exit with code $MULTIPATH_SERVICE_NOT_ACTIVE."
     exit $MULTIPATH_SERVICE_NOT_ACTIVE
 fi
 
@@ -56,21 +56,40 @@ echo -e "lszfcp -P output port info:\n$lszfcp_output "
 declare -A valid_dict
 for fcp in ${fcp_list[@]}
 do
-    wwpns_shown_in_sys=`ls /sys/bus/ccw/drivers/zfcp/0.0.$fcp/ | grep "0x"`
-    echo -e "WWPNs shown under /sys/bus/ccw/drivers/zfcp/0.0.$fcp/:\n$wwpns_shown_in_sys"
-    for wwpn in ${input_wwpns[@]}
+    # Retry each FCP device to make sure there are matched WWPNs for it
+    Timeout=10
+    while [[ $Timeout -gt 0 ]]
     do
-        fcp_wwpn_str="0.0.${fcp} ${wwpn}"
-        if [[ $lszfcp_output =~ $fcp_wwpn_str ]]; then
-            echo "$fcp_wwpn_str matched with content in ouput of lszfcp"
-            # add this combination into valid_dict
-            if [[ -z ${valid_dict[$fcp]} ]]; then
-                valid_dict+=([$fcp]="$wwpn")
-            else
-                old_value=${valid_dict[$fcp]}
-                new_value=${old_value}" "$wwpn
-                valid_dict[$fcp]=$new_value
+        # Get WWPNs under /sys/bus/ccw/drivers/zfcp/.
+        wwpns_shown_in_sys=`ls /sys/bus/ccw/drivers/zfcp/0.0.$fcp/ | grep "0x"`
+        echo -e "Target WWPNs shown under /sys/bus/ccw/drivers/zfcp/0.0.$fcp/:\n$wwpns_shown_in_sys"
+        # Try to find match between system WWPNs(from lszfcp output or under /sys) and input WWPNs
+        found_match=0
+        for wwpn in ${input_wwpns[@]}
+        do
+            fcp_wwpn_str="0.0.${fcp} ${wwpn}"
+            if [[ $lszfcp_output =~ $fcp_wwpn_str || $wwpns_shown_in_sys =~ $wwpn ]]; then
+                found_match=1
+                echo "$fcp_wwpn_str matched with the ouput of lszfcp or WWPNs shown under /sys/bus/ccw/drivers/zfcp/."
+                # Add this combination into valid_dict
+                if [[ -z ${valid_dict[$fcp]} ]]; then
+                    valid_dict+=([$fcp]="$wwpn")
+                else
+                    old_value=${valid_dict[$fcp]}
+                    new_value=${old_value}" "$wwpn
+                    valid_dict[$fcp]=$new_value
+                fi
             fi
+        done
+        # If no matched wwpn found, need retry
+        if [[ $found_match -eq 0 ]]; then
+            sleep 1
+            Timeout=$((Timeout-1))
+            echo "Retrying to get the target WWPNs for FCP device $fcp, $Timeout seconds left..."
+            lszfcp_output=`lszfcp -P | awk '{print $1}' | awk -F'/' '{print $1,$2}'`
+        else
+            echo "Found target WWPNs ${valid_dict[$fcp]} for FCP device $fcp."
+            break
         fi
     done
 done
@@ -82,7 +101,7 @@ do
     valid_fcp_count=$((valid_fcp_count+=1))
 done
 if [[ $valid_fcp_count -eq 0 ]]; then
-    echo "Can not find the intersection between input wwpns: ${input_wwpns[@]} and lszfcp output: $lszfcp_output, exit with code 3."
+    echo "Can not find the intersection between input wwpns: ${input_wwpns[@]} and lszfcp output: $lszfcp_output, exit with code $INVALID_WWPNS."
     exit $INVALID_WWPNS
 fi
 
@@ -116,7 +135,7 @@ do
 done
 # if no disk path found, exit with code 4
 if [[ -z $diskPath ]]; then
-    echo "No valid paths found between FCP devices: ${fcp_list[@]} and WWPNS: ${input_wwpns}, exit with code 4."
+    echo "No valid paths found between FCP devices: ${fcp_list[@]} and WWPNS: ${input_wwpns}, exit with code $DEVICE_PATH_NOT_FOUND."
     exit $DEVICE_PATH_NOT_FOUND
 fi
 

--- a/zvmsdk/volumeops/templates/sles_attach_volume.j2
+++ b/zvmsdk/volumeops/templates/sles_attach_volume.j2
@@ -39,7 +39,7 @@ echo "Checking status of multipathd service ..."
 check_multipathd_service=`systemctl is-active --quiet multipathd`
 exit_code=$?
 if [[ $exit_code != 0 ]]; then
-    echo "Attach script terminated because multipathd service is not active, exit with code 1."
+    echo "Attach script terminated because multipathd service is not active, exit with code $MULTIPATH_SERVICE_NOT_ACTIVE."
     exit $MULTIPATH_SERVICE_NOT_ACTIVE
 fi
 
@@ -52,7 +52,7 @@ do
 done
 
 if [[ $fcp_count -eq 0 ]]; then
-    echo "fcp_list is empty, exit with code 2."
+    echo "fcp_list is empty, exit with code $INVALID_PARAMETERS."
     exit $INVALID_PARAMETERS
 fi
 
@@ -113,21 +113,40 @@ echo -e "lszfcp -P output port info:\n$lszfcp_output"
 declare -A valid_dict
 for fcp in ${fcp_list[@]}
 do
-    wwpns_shown_in_sys=`ls /sys/bus/ccw/drivers/zfcp/0.0.$fcp/ | grep "0x"`
-    echo -e "WWPNs shown under /sys/bus/ccw/drivers/zfcp/0.0.$fcp/:\n$wwpns_shown_in_sys"
-    for wwpn in ${input_wwpns[@]}
+    # Retry each FCP device to make sure there are matched WWPNs for it
+    Timeout=10
+    while [[ $Timeout -gt 0 ]]
     do
-        fcp_wwpn_str="0.0.${fcp} ${wwpn}"
-        if [[ $lszfcp_output =~ $fcp_wwpn_str ]]; then
-            echo "$fcp_wwpn_str matched with content in ouput of lszfcp"
-            # add this combination into valid_dict
-            if [[ -z ${valid_dict[$fcp]} ]]; then
-                valid_dict+=([$fcp]="$wwpn")
-            else
-                old_value=${valid_dict[$fcp]}
-                new_value=${old_value}" "$wwpn
-                valid_dict[$fcp]=$new_value
+        # Get WWPNs under /sys/bus/ccw/drivers/zfcp/.
+        wwpns_shown_in_sys=`ls /sys/bus/ccw/drivers/zfcp/0.0.$fcp/ | grep "0x"`
+        echo -e "Target WWPNs shown under /sys/bus/ccw/drivers/zfcp/0.0.$fcp/:\n$wwpns_shown_in_sys"
+        # Try to find match between system WWPNs(from lszfcp output or under /sys) and input WWPNs
+        found_match=0
+        for wwpn in ${input_wwpns[@]}
+        do
+            fcp_wwpn_str="0.0.${fcp} ${wwpn}"
+            if [[ $lszfcp_output =~ $fcp_wwpn_str || $wwpns_shown_in_sys =~ $wwpn ]]; then
+                found_match=1
+                echo "$fcp_wwpn_str matched with the ouput of lszfcp or WWPNs shown under /sys/bus/ccw/drivers/zfcp/."
+                # Add this combination into valid_dict
+                if [[ -z ${valid_dict[$fcp]} ]]; then
+                    valid_dict+=([$fcp]="$wwpn")
+                else
+                    old_value=${valid_dict[$fcp]}
+                    new_value=${old_value}" "$wwpn
+                    valid_dict[$fcp]=$new_value
+                fi
             fi
+        done
+        # If no matched wwpn found, need retry
+        if [[ $found_match -eq 0 ]]; then
+            sleep 1
+            Timeout=$((Timeout-1))
+            echo "Retrying to get the target WWPNs for FCP device $fcp, $Timeout seconds left..."
+            lszfcp_output=`lszfcp -P | awk '{print $1}' | awk -F'/' '{print $1,$2}'`
+        else
+            echo "Found target WWPNs ${valid_dict[$fcp]} for FCP device $fcp."
+            break
         fi
     done
 done
@@ -140,7 +159,7 @@ do
     valid_fcp_count=$((valid_fcp_count+=1))
 done
 if [[ $valid_fcp_count -eq 0 ]]; then
-    echo "Can not find the intersection between input wwpns: ${input_wwpns[@]} and lszfcp output: $lszfcp_output, exit with code 3."
+    echo "Can not find the intersection between input wwpns: ${input_wwpns[@]} and lszfcp output: $lszfcp_output, exit with code $INVALID_WWPNS."
     exit $INVALID_WWPNS
 fi
 
@@ -226,7 +245,7 @@ done
 if [ $FoundDiskPath -eq 1 ]; then
     echo "The storage device is ready and found disk path: $diskPath."
 else
-    echo "Error happens during attachment because the device file of $fcp not found, will exit with code 4."
+    echo "Error happens during attachment because the device file of $fcp not found, will exit with code $DEVICE_PATH_NOT_FOUND."
     exit $DEVICE_PATH_NOT_FOUND
 fi
 
@@ -249,6 +268,6 @@ udevadm control --reload
 udevadm trigger --sysname-match=dm-*
 echo "Undev rules reload done"
 
-echo "Exit RHEL8 attach script"
+echo "Exit SLES attach script"
 exit $OK
 

--- a/zvmsdk/volumeops/templates/sles_detach_volume.j2
+++ b/zvmsdk/volumeops/templates/sles_detach_volume.j2
@@ -26,7 +26,7 @@ echo "Checking status of multipathd service ..."
 check_multipathd_service=`systemctl is-active --quiet multipathd`
 exit_code=$?
 if [[ $exit_code != 0 ]]; then
-    echo "Detach script terminated because multipathd service is not active, exit with code 1."
+    echo "Detach script terminated because multipathd service is not active, exit with code $MULTIPATH_SERVICE_NOT_ACTIVE."
     exit $MULTIPATH_SERVICE_NOT_ACTIVE
 fi
 
@@ -54,21 +54,40 @@ echo "lszfcp output port info: $lszfcp_output ."
 declare -A valid_dict
 for fcp in ${fcp_list[@]}
 do
-    wwpns_shown_in_sys=`ls /sys/bus/ccw/drivers/zfcp/0.0.$fcp/ | grep "0x"`
-    echo -e "WWPNs shown under /sys/bus/ccw/drivers/zfcp/0.0.$fcp/:\n$wwpns_shown_in_sys"
-    for wwpn in ${input_wwpns[@]}
+    # Retry each FCP device to make sure there are matched WWPNs for it
+    Timeout=10
+    while [[ $Timeout -gt 0 ]]
     do
-        fcp_wwpn_str="0.0.${fcp} ${wwpn}"
-        if [[ $lszfcp_output =~ $fcp_wwpn_str ]]; then
-            echo "$fcp_wwpn_str matched with content in ouput of lszfcp"
-            # add this combination into valid_dict
-            if [[ -z ${valid_dict[$fcp]} ]]; then
-                valid_dict+=([$fcp]="$wwpn")
-            else
-                old_value=${valid_dict[$fcp]}
-                new_value=${old_value}" "$wwpn
-                valid_dict[$fcp]=$new_value
+        # Get WWPNs under /sys/bus/ccw/drivers/zfcp/.
+        wwpns_shown_in_sys=`ls /sys/bus/ccw/drivers/zfcp/0.0.$fcp/ | grep "0x"`
+        echo -e "Target WWPNs shown under /sys/bus/ccw/drivers/zfcp/0.0.$fcp/:\n$wwpns_shown_in_sys"
+        # Try to find match between system WWPNs(from lszfcp output or under /sys) and input WWPNs
+        found_match=0
+        for wwpn in ${input_wwpns[@]}
+        do
+            fcp_wwpn_str="0.0.${fcp} ${wwpn}"
+            if [[ $lszfcp_output =~ $fcp_wwpn_str || $wwpns_shown_in_sys =~ $wwpn ]]; then
+                found_match=1
+                echo "$fcp_wwpn_str matched with the ouput of lszfcp or WWPNs shown under /sys/bus/ccw/drivers/zfcp/."
+                # Add this combination into valid_dict
+                if [[ -z ${valid_dict[$fcp]} ]]; then
+                    valid_dict+=([$fcp]="$wwpn")
+                else
+                    old_value=${valid_dict[$fcp]}
+                    new_value=${old_value}" "$wwpn
+                    valid_dict[$fcp]=$new_value
+                fi
             fi
+        done
+        # If no matched wwpn found, need retry
+        if [[ $found_match -eq 0 ]]; then
+            sleep 1
+            Timeout=$((Timeout-1))
+            echo "Retrying to get the target WWPNs for FCP device $fcp, $Timeout seconds left..."
+            lszfcp_output=`lszfcp -P | awk '{print $1}' | awk -F'/' '{print $1,$2}'`
+        else
+            echo "Found target WWPNs ${valid_dict[$fcp]} for FCP device $fcp."
+            break
         fi
     done
 done
@@ -80,7 +99,7 @@ do
     valid_fcp_count=$((valid_fcp_count+=1))
 done
 if [[ $valid_fcp_count -eq 0 ]]; then
-    echo "Can not find the intersection between input wwpns: ${input_wwpns[@]} and lszfcp output: $lszfcp_output, exit with code 3."
+    echo "Can not find the intersection between input wwpns: ${input_wwpns[@]} and lszfcp output: $lszfcp_output, exit with code $INVALID_WWPNS."
     exit $INVALID_WWPNS
 fi
 
@@ -114,7 +133,7 @@ do
 done
 # if no disk path found, exit with code 4
 if [[ -z $diskPath ]]; then
-    echo "No valid paths found between FCP devices: ${fcp_list[@]} and WWPNS: ${input_wwpns}, exit with code 4."
+    echo "No valid paths found between FCP devices: ${fcp_list[@]} and WWPNS: ${input_wwpns}, exit with code $DEVICE_PATH_NOT_FOUND."
     exit $DEVICE_PATH_NOT_FOUND
 fi
 
@@ -202,6 +221,6 @@ udevadm control --reload
 udevadm trigger --sysname-match=dm-*
 echo "Undev rules reload done"
 
-echo "Exit RHEL8 detach script"
+echo "Exit SLES detach script"
 exit $OK
 

--- a/zvmsdk/volumeops/templates/ubuntu_attach_volume.j2
+++ b/zvmsdk/volumeops/templates/ubuntu_attach_volume.j2
@@ -35,7 +35,7 @@ echo "Checking status of multipathd service ..."
 check_multipathd_service=`systemctl is-active --quiet multipathd`
 exit_code=$?
 if [[ $exit_code != 0 ]]; then
-    echo "Attach script terminated because multipathd service is not active, exit with code 1."
+    echo "Attach script terminated because multipathd service is not active, exit with code $MULTIPATH_SERVICE_NOT_ACTIVE."
     exit $MULTIPATH_SERVICE_NOT_ACTIVE
 fi
 
@@ -48,7 +48,7 @@ do
 done
 
 if [[ $fcp_count -eq 0 ]]; then
-    echo "fcp_list is empty, exit with code 2."
+    echo "fcp_list is empty, exit with code $INVALID_PARAMETERS."
     exit $INVALID_PARAMETERS
 fi
 
@@ -110,21 +110,40 @@ echo -e "lszfcp -P output port info:\n$lszfcp_output"
 declare -A valid_dict
 for fcp in ${fcp_list[@]}
 do
-    wwpns_shown_in_sys=`ls /sys/bus/ccw/drivers/zfcp/0.0.$fcp/ | grep "0x"`
-    echo -e "WWPNs shown under /sys/bus/ccw/drivers/zfcp/0.0.$fcp/:\n$wwpns_shown_in_sys"
-    for wwpn in ${input_wwpns[@]}
+    # Retry each FCP device to make sure there are matched WWPNs for it
+    Timeout=10
+    while [[ $Timeout -gt 0 ]]
     do
-        fcp_wwpn_str="0.0.${fcp} ${wwpn}"
-        if [[ $lszfcp_output =~ $fcp_wwpn_str ]]; then
-            echo "$fcp_wwpn_str matched with content in ouput of lszfcp"
-            # add this combination into valid_dict
-            if [[ -z ${valid_dict[$fcp]} ]]; then
-                valid_dict+=([$fcp]="$wwpn")
-            else
-                old_value=${valid_dict[$fcp]}
-                new_value=${old_value}" "$wwpn
-                valid_dict[$fcp]=$new_value
+        # Get WWPNs under /sys/bus/ccw/drivers/zfcp/.
+        wwpns_shown_in_sys=`ls /sys/bus/ccw/drivers/zfcp/0.0.$fcp/ | grep "0x"`
+        echo -e "Target WWPNs shown under /sys/bus/ccw/drivers/zfcp/0.0.$fcp/:\n$wwpns_shown_in_sys"
+        # Try to find match between system WWPNs(from lszfcp output or under /sys) and input WWPNs
+        found_match=0
+        for wwpn in ${input_wwpns[@]}
+        do
+            fcp_wwpn_str="0.0.${fcp} ${wwpn}"
+            if [[ $lszfcp_output =~ $fcp_wwpn_str || $wwpns_shown_in_sys =~ $wwpn ]]; then
+                found_match=1
+                echo "$fcp_wwpn_str matched with the ouput of lszfcp or WWPNs shown under /sys/bus/ccw/drivers/zfcp/."
+                # Add this combination into valid_dict
+                if [[ -z ${valid_dict[$fcp]} ]]; then
+                    valid_dict+=([$fcp]="$wwpn")
+                else
+                    old_value=${valid_dict[$fcp]}
+                    new_value=${old_value}" "$wwpn
+                    valid_dict[$fcp]=$new_value
+                fi
             fi
+        done
+        # If no matched wwpn found, need retry
+        if [[ $found_match -eq 0 ]]; then
+            sleep 1
+            Timeout=$((Timeout-1))
+            echo "Retrying to get the target WWPNs for FCP device $fcp, $Timeout seconds left..."
+            lszfcp_output=`lszfcp -P | awk '{print $1}' | awk -F'/' '{print $1,$2}'`
+        else
+            echo "Found target WWPNs ${valid_dict[$fcp]} for FCP device $fcp."
+            break
         fi
     done
 done
@@ -137,7 +156,7 @@ do
     valid_fcp_count=$((valid_fcp_count+=1))
 done
 if [[ $valid_fcp_count -eq 0 ]]; then
-    echo "Can not find the intersection between input wwpns: ${input_wwpns[@]} and lszfcp output: $lszfcp_output, exit with code 3."
+    echo "Can not find the intersection between input wwpns: ${input_wwpns[@]} and lszfcp output: $lszfcp_output, exit with code $INVALID_WWPNS."
     exit $INVALID_WWPNS
 fi
 
@@ -209,7 +228,7 @@ done
 if [ $FoundDiskPath -eq 1 ]; then
     echo "The storage device is ready and found disk path: $diskPath."
 else
-    echo "Error happens during attachment because the device file of $fcp not found, will exit with code 4."
+    echo "Error happens during attachment because the device file of $fcp not found, will exit with code $DEVICE_PATH_NOT_FOUND."
     exit $DEVICE_PATH_NOT_FOUND
 fi
 
@@ -232,6 +251,6 @@ udevadm control --reload
 udevadm trigger --sysname-match=dm-*
 echo "Undev rules reload done"
 
-echo "Exit RHEL8 attach script"
+echo "Exit UBUNTU attach script"
 exit $OK
 

--- a/zvmsdk/volumeops/templates/ubuntu_detach_volume.j2
+++ b/zvmsdk/volumeops/templates/ubuntu_detach_volume.j2
@@ -37,7 +37,7 @@ echo "Checking status of multipathd service ..."
 check_multipathd_service=`systemctl is-active --quiet multipathd`
 exit_code=$?
 if [[ $exit_code != 0 ]]; then
-    echo "Detach script terminated because multipathd service is not active, exit with code 1."
+    echo "Detach script terminated because multipathd service is not active, exit with code $MULTIPATH_SERVICE_NOT_ACTIVE."
     exit $MULTIPATH_SERVICE_NOT_ACTIVE
 fi
 
@@ -65,21 +65,40 @@ echo "lszfcp -P output port info: $lszfcp_output ."
 declare -A valid_dict
 for fcp in ${fcp_list[@]}
 do
-    wwpns_shown_in_sys=`ls /sys/bus/ccw/drivers/zfcp/0.0.$fcp/ | grep "0x"`
-    echo -e "WWPNs shown under /sys/bus/ccw/drivers/zfcp/0.0.$fcp/:\n$wwpns_shown_in_sys"
-    for wwpn in ${input_wwpns[@]}
+    # Retry each FCP device to make sure there are matched WWPNs for it
+    Timeout=10
+    while [[ $Timeout -gt 0 ]]
     do
-        fcp_wwpn_str="0.0.${fcp} ${wwpn}"
-        if [[ $lszfcp_output =~ $fcp_wwpn_str ]]; then
-            echo "$fcp_wwpn_str matched with content in ouput of lszfcp"
-            # add this combination into valid_dict
-            if [[ -z ${valid_dict[$fcp]} ]]; then
-                valid_dict+=([$fcp]="$wwpn")
-            else
-                old_value=${valid_dict[$fcp]}
-                new_value=${old_value}" "$wwpn
-                valid_dict[$fcp]=$new_value
+        # Get WWPNs under /sys/bus/ccw/drivers/zfcp/.
+        wwpns_shown_in_sys=`ls /sys/bus/ccw/drivers/zfcp/0.0.$fcp/ | grep "0x"`
+        echo -e "Target WWPNs shown under /sys/bus/ccw/drivers/zfcp/0.0.$fcp/:\n$wwpns_shown_in_sys"
+        # Try to find match between system WWPNs(from lszfcp output or under /sys) and input WWPNs
+        found_match=0
+        for wwpn in ${input_wwpns[@]}
+        do
+            fcp_wwpn_str="0.0.${fcp} ${wwpn}"
+            if [[ $lszfcp_output =~ $fcp_wwpn_str || $wwpns_shown_in_sys =~ $wwpn ]]; then
+                found_match=1
+                echo "$fcp_wwpn_str matched with the ouput of lszfcp or WWPNs shown under /sys/bus/ccw/drivers/zfcp/."
+                # Add this combination into valid_dict
+                if [[ -z ${valid_dict[$fcp]} ]]; then
+                    valid_dict+=([$fcp]="$wwpn")
+                else
+                    old_value=${valid_dict[$fcp]}
+                    new_value=${old_value}" "$wwpn
+                    valid_dict[$fcp]=$new_value
+                fi
             fi
+        done
+        # If no matched wwpn found, need retry
+        if [[ $found_match -eq 0 ]]; then
+            sleep 1
+            Timeout=$((Timeout-1))
+            echo "Retrying to get the target WWPNs for FCP device $fcp, $Timeout seconds left..."
+            lszfcp_output=`lszfcp -P | awk '{print $1}' | awk -F'/' '{print $1,$2}'`
+        else
+            echo "Found target WWPNs ${valid_dict[$fcp]} for FCP device $fcp."
+            break
         fi
     done
 done
@@ -91,7 +110,7 @@ do
     valid_fcp_count=$((valid_fcp_count+=1))
 done
 if [[ $valid_fcp_count -eq 0 ]]; then
-    echo "Can not find the intersection between input wwpns: ${input_wwpns[@]} and lszfcp output: $lszfcp_output, exit with code 3."
+    echo "Can not find the intersection between input wwpns: ${input_wwpns[@]} and lszfcp output: $lszfcp_output, exit with code $INVALID_WWPNS."
     exit $INVALID_WWPNS
 fi
 
@@ -125,7 +144,7 @@ do
 done
 # if no disk path found, exit with code 4
 if [[ -z $diskPath ]]; then
-    echo "No valid paths found between FCP devices: ${fcp_list[@]} and WWPNS: ${input_wwpns}, exit with code 4."
+    echo "No valid paths found between FCP devices: ${fcp_list[@]} and WWPNS: ${input_wwpns}, exit with code $DEVICE_PATH_NOT_FOUND."
     exit $DEVICE_PATH_NOT_FOUND
 fi
 
@@ -204,6 +223,6 @@ udevadm control --reload
 udevadm trigger --sysname-match=dm-*
 echo "Undev rules reload done"
 
-echo "Exit RHEL8 detach script"
+echo "Exit UBUNTU detach script"
 exit $OK
 


### PR DESCRIPTION
lszfcp -P sometimes has no output, so need retry and if still no output will use wwpns under /sys/bus/ccw/drivers/zfcp/.

Signed-off-by: CaoBiao <bjcb@cn.ibm.com>