### PR TITLE
ignore errors from sync_db when restart sdkserver

### DIFF
--- a/zvmsdk/volumeop.py
+++ b/zvmsdk/volumeop.py
@@ -533,7 +533,8 @@ class FCPManager(object):
 
     def sync_db(self):
         """Sync FCP DB with the FCP info queried from zVM"""
-        self._sync_db_with_zvm()
+        with zvmutils.ignore_errors():
+            self._sync_db_with_zvm()
 
     def _get_all_fcp_info(self, assigner_id, status=None):
         fcp_info = self._smtclient.get_fcp_info_by_status(assigner_id, status)


### PR DESCRIPTION

when there is no FCP configured in the z/VM LPAR and even if SMAPI is down, we should let sdkserver service to start normally.
https://github.com/openmainframeproject/feilong/issues/675

Signed-off-by: dyyang <dyyang@cn.ibm.com>