### PR TITLE
replace all `fcp template` or `fcp device template` to new name

### DIFF
--- a/doc/source/errcode.csv
+++ b/doc/source/errcode.csv
@@ -86,9 +86,9 @@
 409;None;409;19;Failed to resize memory of guest: '%(userid)s', error: user definition is not in expected format, cann't get the defined/max/reserved storage.
 409;None;409;20;Failed to resize memory of guest: '%(userid)s', error: the requested memory size: '%(req)im' exceeds the maximum memory size defined: '%(max)im'.
 409;None;409;21;Failed to live resize memory of guest: %(userid)s, error: the memory size to be increased: '%(inc)im' is greater than the maximum reserved memory size: '%(max)im'.
-409;None;409;22;Failed to delete FCP device template, error: %(msg)s
-409;None;409;23;Failed to create or update FCP device template, error: %(msg)s
-409;None;409;24;Failed to edit FCP device template, error: %(msg)s
+409;None;409;22;Failed to delete FCP Multipath Template, error: %(msg)s
+409;None;409;23;Failed to create or update FCP Multipath Template, error: %(msg)s
+409;None;409;24;Failed to edit FCP Multipath Template, error: %(msg)s
 **The operated object is deleted**
 410;None;410;;The operated object is deleted
 **ZVM SDK Internal Error**

--- a/zvmsdk/api.py
+++ b/zvmsdk/api.py
@@ -1603,7 +1603,7 @@ class SDKAPI(object):
 
         :param str userid: the user id of the guest
         :param boolean reserve: the flag to reserve FCP device
-        :param str fcp_template_id: the fcp template id
+        :param str fcp_template_id: the FCP Multipath Template id
                which FCP devices are allocated by
         :param str sp_name: the storage provider name
         """
@@ -1614,12 +1614,12 @@ class SDKAPI(object):
                          default_sp_list= None, host_default=None):
         """Get template base info
         :param template_id_list: (list) a list of template id,
-        if it is None, get fcp templates with other parameter
+        if it is None, get FCP Multipath Templates with other parameter
         :param assigner_id: (str) a string of VM userid
         :param host_default: (boolean) whether or not get host default fcp
         template
         :param default_sp_list: (list) a list of storage provider, to get the
-        list of storage provider's default fcp templates
+        list of storage provider's default FCP Multipath Templates
         :return: (dict) the base info of template
         example:
         {
@@ -1656,7 +1656,7 @@ class SDKAPI(object):
     def get_fcp_templates_details(self, template_id_list=None,
                                   raw=False, statistics=True,
                                   sync_with_zvm=False):
-        """Get fcp templates detail info.
+        """Get FCP Multipath Templates detail info.
         :param template_list: (list) if is None,
                               will get all the templates on the host
         :return: (dict) the raw and/or statistic data
@@ -1799,7 +1799,7 @@ class SDKAPI(object):
         :param int reserved: the value set to reserved value of FCP database
         :param int connections: the value set to connections value of
                                 FCP database
-        :param str fcp_template_id: the ID of the FCP template.
+        :param str fcp_template_id: the ID of the FCP Multipath Template.
         """
         return self._volumeop.set_fcp_usage(userid, fcp, reserved,
                                             connections, fcp_template_id)
@@ -1809,7 +1809,7 @@ class SDKAPI(object):
                             host_default: bool = False,
                             default_sp_list: list = [],
                             min_fcp_paths_count: int = None):
-        """API for creating a FCP template in database.
+        """API for creating a FCP Multipath Template in database.
 
         :param str name: the name of the template
         :param str description: the description for the template
@@ -1818,8 +1818,8 @@ class SDKAPI(object):
         :param bool host_default: this template is default to this
             host or not
         :param list default_sp_list: the list of storage providers that will
-            use this FCP template as default FCP template. If None, it means
-            no storage provider would use this FCP template as default.
+            use this FCP Multipath Template as default FCP Multipath Template. If None, it means
+            no storage provider would use this FCP Multipath Template as default.
         :param min_fcp_paths_count: The minimum number of FCP paths that
             should be defined to a vm when attachinga data volume to a vm or
             BFV (deploying a vm from SCSI image).
@@ -1831,7 +1831,7 @@ class SDKAPI(object):
     def edit_fcp_template(self, fcp_template_id, name=None,
                           description=None, fcp_devices=None,
                           host_default=None, default_sp_list=None, min_fcp_paths_count: int = None):
-        """ Edit a FCP device template
+        """ Edit a FCP Multipath Template.
 
         The kwargs values are pre-validated in two places:
           validate kwargs types

--- a/zvmsdk/database.py
+++ b/zvmsdk/database.py
@@ -320,10 +320,10 @@ class FCPDbOperator(object):
         #   owner: VM userid representing an unique VM,
         #          it is read from z/VM hypervisor and
         #          may differ with assigner_id
-        #   tmpl_id: indicate from which FCP template this FCP device was
-        #             allocated, not to which FCP template this FCP
+        #   tmpl_id: indicate from which FCP Multipath Template this FCP device was
+        #             allocated, not to which FCP Multipath Template this FCP
         #             device belong. because a FCP device may belong
-        #             to multiple FCP templates.
+        #             to multiple FCP Multipath Templates.
         fcp_info_tables['fcp'] = (
             "CREATE TABLE IF NOT EXISTS fcp("
             "fcp_id         char(4)     NOT NULL COLLATE NOCASE,"
@@ -338,7 +338,7 @@ class FCPDbOperator(object):
             "tmpl_id        varchar(32) NOT NULL DEFAULT '' COLLATE NOCASE,"
             "PRIMARY KEY (fcp_id))")
 
-        # table for FCP templates:
+        # table for FCP Multipath Templates:
         #   id: template id, the primary key
         #   name: the name of the template
         #   description: the description for this template
@@ -739,7 +739,7 @@ class FCPDbOperator(object):
 
     @staticmethod
     def update_basic_info_of_fcp_template(record):
-        """ update basic info of a fcp template
+        """ update basic info of a FCP Multipath Template
             in table template
 
             :param record (tuple)
@@ -778,12 +778,12 @@ class FCPDbOperator(object):
     @staticmethod
     def bulk_set_sp_default_by_fcp_template(template_id,
                                             sp_name_list):
-        """ Set a default FCP template
+        """ Set a default FCP Multipath Template
             for multiple storage providers
 
             The function only manipulate table(template_fcp_mapping)
 
-            :param template_id: the FCP device template id
+            :param template_id: the FCP Multipath Template ID
             :param sp_name_list: a list of storage provider hostname
 
             :return NULL
@@ -1040,7 +1040,7 @@ class FCPDbOperator(object):
         allocated_paths = len(fcp_list)
         total_paths = len(path_list)
         if allocated_paths < total_paths:
-            LOG.info("Not all paths of FCP device template(id={}) "
+            LOG.info("Not all paths of FCP Multipath Template (id={}) "
                      "have available FCP devices. "
                      "The count of minimum FCP device path is {}. "
                      "The count of total paths is {}. "
@@ -1066,10 +1066,10 @@ class FCPDbOperator(object):
     def create_fcp_template(self, fcp_template_id, name, description,
                             fcp_devices_by_path, host_default,
                             default_sp_list, min_fcp_paths_count=None):
-        """ Insert records of new fcp template in fcp DB
+        """ Insert records of new FCP Multipath Template in fcp DB
 
-        :param fcp_template_id: fcp template id
-        :param name: fcp template name
+        :param fcp_template_id: FCP Multipath Template ID
+        :param name: FCP Multipath Template name
         :param description: description
         :param fcp_devices_by_path:
             Example:
@@ -1098,7 +1098,7 @@ class FCPDbOperator(object):
             # if already exist, raise exception
             if self.fcp_template_exist_in_db(fcp_template_id):
                 raise exception.SDKObjectAlreadyExistError(
-                    obj_desc=("FCP device template "
+                    obj_desc=("FCP Multipath Template "
                               "(id: %s) " % fcp_template_id),
                     modID=self._module_id)
             # then check the SP records exist in template_sp_mapping or not
@@ -1154,7 +1154,7 @@ class FCPDbOperator(object):
 
     def _validate_min_fcp_paths_count(self, fcp_devices, min_fcp_paths_count, fcp_template_id):
         """
-        When to edit FCP template, if min_fcp_paths_count is not None or
+        When to edit FCP Multipath Template, if min_fcp_paths_count is not None or
         fcp_devices is not None (None means no need to update this field, but keep the original value),
         need to validate the values.
         min_fcp_paths_count should not be larger than fcp_device_path_count.
@@ -1197,7 +1197,7 @@ class FCPDbOperator(object):
     def edit_fcp_template(self, fcp_template_id, name=None, description=None,
                           fcp_devices=None, host_default=None,
                           default_sp_list=None, min_fcp_paths_count=None):
-        """ Edit a FCP device template
+        """ Edit a FCP Multipath Template.
 
         The kwargs values are pre-validated in two places:
           validate kwargs types
@@ -1242,12 +1242,12 @@ class FCPDbOperator(object):
         # util current thread exits the with-block.
         # Refer to 'def get_fcp_conn' for thread lock
         with get_fcp_conn():
-            # DQL: validate: FCP device template
+            # DQL: validate: FCP Multipath Template
             if not self.fcp_template_exist_in_db(fcp_template_id):
-                obj_desc = ("FCP device template {}".format(fcp_template_id))
+                obj_desc = ("FCP Multipath Template {}".format(fcp_template_id))
                 raise exception.SDKObjectNotExistError(obj_desc=obj_desc)
 
-            # DQL: validate: add or delete path from FCP template.
+            # DQL: validate: add or delete path from FCP Multipath Template.
             # If fcp_devices is None, it means user do not want to
             # modify fcp_devices, so skip the validation;
             # otherwise, perform the validation.
@@ -1262,8 +1262,8 @@ class FCPDbOperator(object):
                         inuse_fcp = utils.shrink_fcp_list(
                             [fcp['fcp_id'] for fcp in inuse_fcp])
                         detail = ("The FCP devices ({}) are allocated to virtual machines "
-                                  "by the FCP device template (id={}). "
-                                  "Adding or deleting a FCP device path from a FCP device template "
+                                  "by the FCP Multipath Template (id={}). "
+                                  "Adding or deleting a FCP device path from a FCP Multipath Template "
                                   "is not allowed if there is any FCP device allocated from the template. "
                                   "You must deallocate those FCP devices "
                                   "before adding or deleting a path from the template."
@@ -1313,7 +1313,7 @@ class FCPDbOperator(object):
                 inter_set = set(fcp_from_input) & set(fcp_in_db)
                 del_set = set(fcp_in_db) - set(fcp_from_input)
                 # only unused FCP devices can be
-                # deleted from a FCP device template.
+                # deleted from a FCP Multipath Template.
                 # Two types of unused FCP devices:
                 # 1. connections/reserved == None:
                 #   the fcp only exists in table(template_fcp_mapping),
@@ -1326,7 +1326,7 @@ class FCPDbOperator(object):
                     if (fcp_in_db[fcp]['connections'] not in (None, 0) or
                             fcp_in_db[fcp]['reserved'] not in (None, 0)):
                         not_allow_for_del.add(fcp)
-                # For a FCP device included in multiple FCP device templates,
+                # For a FCP device included in multiple FCP Multipath Templates,
                 # the FCP device is allowed to be deleted from the current template
                 # only if it is allocated from another template rather than the current one
                 inuse_fcp_devices = self.get_inuse_fcp_device_by_fcp_template(fcp_template_id)
@@ -1338,7 +1338,7 @@ class FCPDbOperator(object):
                         list(not_allow_for_del))
                     detail = ("The FCP devices ({}) are missing from the FCP device list. "
                               "These FCP devices are allocated to virtual machines "
-                              "from the FCP device template (id={}). "
+                              "from the FCP Multipath Template (id={}). "
                               "Deleting the allocated FCP devices from this template is not allowed. "
                               "You must ensure those FCP devices are included in the FCP device list."
                               .format(not_allow_for_del, fcp_template_id))
@@ -1352,7 +1352,7 @@ class FCPDbOperator(object):
                     for fcp_id in del_set]
                 self.bulk_delete_fcp_device_from_fcp_template(
                     records_to_delete)
-                LOG.info("FCP devices ({}) removed from FCP template {}."
+                LOG.info("FCP devices ({}) removed from FCP Multipath Template {}."
                          .format(utils.shrink_fcp_list(list(del_set)),
                                  fcp_template_id))
                 # 2. insert into table template_fcp_mapping
@@ -1361,7 +1361,7 @@ class FCPDbOperator(object):
                     for fcp_id in add_set]
                 self.bulk_insert_fcp_device_into_fcp_template(
                     records_to_insert)
-                LOG.info("FCP devices ({}) added into FCP template {}."
+                LOG.info("FCP devices ({}) added into FCP Multipath Template {}."
                          .format(utils.shrink_fcp_list(list(add_set)),
                                  fcp_template_id))
                 # 3. update table template_fcp_mapping
@@ -1374,7 +1374,7 @@ class FCPDbOperator(object):
                             fcp_from_input[fcp], fcp, fcp_template_id)
                         self.update_path_of_fcp_device(record_to_update)
                         LOG.info("FCP device ({}) updated into "
-                                 "FCP template {} from path {} to path {}."
+                                 "FCP Multipath Template {} from path {} to path {}."
                                  .format(fcp, fcp_template_id,
                                          fcp_in_db[fcp]['path'],
                                          fcp_from_input[fcp]))
@@ -1393,7 +1393,7 @@ class FCPDbOperator(object):
                     else tmpl_basic[0]['min_fcp_paths_count'],
                     fcp_template_id)
                 self.update_basic_info_of_fcp_template(record_to_update)
-                LOG.info("FCP template basic info updated.")
+                LOG.info("FCP Multipath Template basic info updated.")
 
             # DML: table template_sp_mapping
             if default_sp_list is not None:
@@ -1425,8 +1425,8 @@ class FCPDbOperator(object):
             }}
 
     def get_fcp_templates(self, template_id_list=None):
-        """Get fcp templates base info by template_id_list.
-        If template_id_list is None, will get all the fcp templates in db.
+        """Get FCP Multipath Templates base info by template_id_list.
+        If template_id_list is None, will get all the FCP Multipath Templates in db.
 
         return format:
         [(id|name|description|is_default|min_fcp_paths_count|sp_name)]
@@ -1451,7 +1451,7 @@ class FCPDbOperator(object):
         return raw
 
     def get_host_default_fcp_template(self, host_default=True):
-        """Get the host default fcp template base info.
+        """Get the host default FCP Multipath Template base info.
         return format: (id|name|description|is_default|sp_name)
 
         when the  template is more than one SP's default,
@@ -1478,7 +1478,7 @@ class FCPDbOperator(object):
         return raw
 
     def get_sp_default_fcp_template(self, sp_host_list):
-        """Get the sp_host_list default fcp template.
+        """Get the sp_host_list default FCP Multipath Template.
         """
         cmd = ("SELECT t.id, t.name, t.description, t.is_default, "
                "t.min_fcp_paths_count, ts.sp_name "
@@ -1589,7 +1589,7 @@ class FCPDbOperator(object):
 
     def bulk_delete_fcp_from_template(self, fcp_id_list, fcp_template_id):
         """Delete multiple FCP records from the table template_fcp_mapping in the
-        specified fcp template only if the FCP devices are available."""
+        specified FCP Multipath Template only if the FCP devices are available."""
         records_to_delete = [(fcp_template_id, fcp_id)
                              for fcp_id in fcp_id_list]
         with get_fcp_conn() as conn:
@@ -1602,11 +1602,11 @@ class FCPDbOperator(object):
                 records_to_delete)
 
     def delete_fcp_template(self, template_id):
-        """Remove fcp template record from template, template_sp_mapping,
+        """Remove FCP Multipath Template record from template, template_sp_mapping,
         template_fcp_mapping and fcp tables."""
         with get_fcp_conn() as conn:
             if not self.fcp_template_exist_in_db(template_id):
-                obj_desc = ("FCP device template {} ".format(template_id))
+                obj_desc = ("FCP Multipath Template {} ".format(template_id))
                 raise exception.SDKObjectNotExistError(obj_desc=obj_desc)
             inuse_fcp_devices = self.get_inuse_fcp_device_by_fcp_template(
                 template_id)
@@ -1614,8 +1614,8 @@ class FCPDbOperator(object):
                 inuse_fcp_devices = utils.shrink_fcp_list(
                     [fcp['fcp_id'] for fcp in inuse_fcp_devices])
                 detail = ("The FCP devices ({}) are allocated to virtual machines "
-                          "by the FCP device template (id={}). "
-                          "Deleting a FCP device template is not allowed "
+                          "by the FCP Multipath Template (id={}). "
+                          "Deleting a FCP Multipath Template is not allowed "
                           "if there is any FCP device allocated from the template. "
                           "You must deallocate those FCP devices before deleting the template."
                           .format(inuse_fcp_devices, template_id))
@@ -1627,7 +1627,7 @@ class FCPDbOperator(object):
                          (template_id,))
             conn.execute("DELETE FROM template_fcp_mapping WHERE tmpl_id=?",
                          (template_id,))
-            LOG.info("FCP device template with id %s is removed from "
+            LOG.info("FCP Multipath Template with id %s is removed from "
                      "template, template_sp_mapping and "
                      "template_fcp_mapping tables" % template_id)
 

--- a/zvmsdk/returncode.py
+++ b/zvmsdk/returncode.py
@@ -334,11 +334,11 @@ errors = {
                        "error: the memory size to be increased: '%(inc)im' "
                        "is greater than the maximum reserved memory size: "
                        "'%(max)im'."),
-                  22: ("Failed to delete FCP device template, "
+                  22: ("Failed to delete FCP Multipath Template, "
                        "error: %(msg)s"),
-                  23: ("Failed to create or update FCP device template, "
+                  23: ("Failed to create or update FCP Multipath Template, "
                        "error: %(msg)s"),
-                  24: ("Failed to edit FCP device template, "
+                  24: ("Failed to edit FCP Multipath Template, "
                        "error: %(msg)s")
                   },
                  "The operated object status conflict"

--- a/zvmsdk/tests/unit/sdkwsgi/handlers/test_volume.py
+++ b/zvmsdk/tests/unit/sdkwsgi/handlers/test_volume.py
@@ -241,7 +241,7 @@ class HandlersVolumeTest(unittest.TestCase):
 
     @mock.patch('zvmconnector.connector.ZVMConnector.send_request')
     def test_create_fcp_template_default_values(self, mock_send_request):
-        """Test the default values was set correctly when create fcp template."""
+        """Test the default values was set correctly when create a FCP Multipath Template."""
         mock_send_request.return_value = {'overallRC': 0}
         body = {'name': 'tmpl name'}
         self.req.body = json.dumps(body)

--- a/zvmsdk/tests/unit/test_database.py
+++ b/zvmsdk/tests/unit/test_database.py
@@ -355,7 +355,7 @@ class FCPDbOperatorTestCase(base.SDKTestCase):
 
     def _prepare_fcp_info_for_a_test_fcp_template(self):
         """ Prepare FCP device info for test
-        1. create a fcp template with fcp_devices
+        1. create a FCP Multipath Template with fcp_devices
         2. set some of the fcp_devices as inuse
 
         Note: Remember to do cleanup after using the func
@@ -825,7 +825,7 @@ class FCPDbOperatorTestCase(base.SDKTestCase):
     #########################################################
     def test_get_allocated_fcps_from_assigner(self):
         """Test API get_allocated_fcps_from_assigner"""
-        # prepare data for fcp template "1111;2222"
+        # prepare data for FCP Multipath Template "1111;2222"
         # insert test data into table template_fcp_mapping
         template_id = 'fakehost-1111-1111-1111-111111111111'
         template_fcp = [('1111', template_id, 0),
@@ -870,7 +870,7 @@ class FCPDbOperatorTestCase(base.SDKTestCase):
             self.db_op.bulk_delete_fcp_from_template(fcp_id_list, template_id)
 
     def test_get_reserved_fcps_from_assigner(self):
-        # prepare data for fcp template "1111;2222"
+        # prepare data for FCP Multipath Template "1111;2222"
         # insert test data into table fcp
         template_id = 'fakehost-1111-1111-1111-111111111111'
         fcp_info_list = [('1111', 'user1', 0, 0, 'c05076de33000111',
@@ -938,7 +938,7 @@ class FCPDbOperatorTestCase(base.SDKTestCase):
            an empty list(i.e. [])
            if no expected pair found
         '''
-        # prepare data for fcp template "1111;2222"
+        # prepare data for FCP Multipath Template "1111;2222"
         template_id = 'fakehost-1111-1111-1111-111111111111'
         # insert test data into table fcp
         # Usage in test data:
@@ -1043,7 +1043,7 @@ class FCPDbOperatorTestCase(base.SDKTestCase):
            an empty list(i.e. [])
            if no expected pair found
         '''
-        # prepare data for fcp template "1a00-1a04;1b00-1b04"
+        # prepare data for FCP Multipath Template "1a00-1a04;1b00-1b04"
         template_id = 'fakehost-1111-1111-1111-111111111111'
         # insert test data into table fcp
         # Usage in test data:
@@ -1147,7 +1147,7 @@ class FCPDbOperatorTestCase(base.SDKTestCase):
             self.db_op.delete_fcp_template(template_id)
 
     def test_create_fcp_template_with_name_and_desc(self):
-        """Create fcp template only with name and description, other parameters are all default values"""
+        """Create a FCP Multipath Template only with name and description, other parameters are all default values"""
         fcp_template_id = 'fake_tmpl_id'
         name = 'tmpl_1'
         description = 'this is the description.'
@@ -1230,13 +1230,13 @@ class FCPDbOperatorTestCase(base.SDKTestCase):
         }
         try:
             # case1:
-            # validate: FCP device template
-            obj_desc = ("FCP device template {}".format(tmpl_id))
+            # validate: FCP Multipath Template
+            obj_desc = ("FCP Multipath Template {}".format(tmpl_id))
             with self.assertRaises(exception.SDKObjectNotExistError) as cm:
                 self.db_op.edit_fcp_template(tmpl_id, **kwargs)
             # The following 3 assertions are the same
             # (Pdb) pp str(cm.exception)
-            # 'FCP device template fake_id_0000 does not exist.'
+            # 'FCP Multipath Template fake_id_0000 does not exist.'
             self.assertIn(obj_desc, cm.exception.message)
             self.assertIn(obj_desc, str(cm.exception))
             self.assertRaisesRegex(exception.SDKObjectNotExistError,
@@ -1245,7 +1245,7 @@ class FCPDbOperatorTestCase(base.SDKTestCase):
                                    tmpl_id, **kwargs)
 
             # case2:
-            # validate: add or delete path from FCP template
+            # validate: add or delete path from FCP Multipath Template
             # preparation:
             #   a. create_fcp_template
             #   b. bulk_insert_zvm_fcp_info_into_fcp_table
@@ -1643,11 +1643,11 @@ class FCPDbOperatorTestCase(base.SDKTestCase):
             self.db_op.delete_fcp_template(tmpl_id_1)
 
             # case3: delete a non-exist template
-            obj_desc = ("FCP device template {}".format(tmpl_id_1))
+            obj_desc = ("FCP Multipath Template {}".format(tmpl_id_1))
             with self.assertRaises(exception.SDKObjectNotExistError) as cm:
                 self.db_op.delete_fcp_template(tmpl_id_1)
             # The following 3 assertions are the same
-            # 'FCP device template fake_id_0000 does not exist.'
+            # 'FCP Multipath Template fake_id_0000 does not exist.'
             self.assertIn(obj_desc, cm.exception.message)
             self.assertIn(obj_desc, str(cm.exception))
             self.assertRaisesRegex(exception.SDKObjectNotExistError,

--- a/zvmsdk/tests/unit/test_volumeop.py
+++ b/zvmsdk/tests/unit/test_volumeop.py
@@ -576,8 +576,8 @@ class TestFCPManager(base.SDKTestCase):
         self._insert_data_into_template_table(templates)
         try:
             self.assertRaisesRegex(exception.SDKVolumeOperationError,
-                                   "No FCP template is specified and no "
-                                   "default FCP template is found.",
+                                   "No FCP Multipath Template is specified and no "
+                                   "default FCP Multipath Template is found.",
                                    self.fcpops.reserve_fcp_devices,
                                    assinger_id, template_id, sp_name)
         finally:
@@ -1536,7 +1536,7 @@ class TestFCPVolumeManager(base.SDKTestCase):
             self._delete_from_template_table(template_id_list)
 
     def test_get_volume_connector_reserve_with_error(self):
-        """The specified FCP template doesn't exist, should raise error."""
+        """The specified FCP Multipath Template doesn't exist, should raise error."""
         assigner_id = 'fakeuser'
         fcp_template_id = '0001'
         sp_name = 'v7k60'

--- a/zvmsdk/volumeop.py
+++ b/zvmsdk/volumeop.py
@@ -614,8 +614,8 @@ class FCPManager(object):
         """
         Reserve FCP devices by assigner_id and fcp_template_id. In this method:
         1. If fcp_template_id is specified, then use it. If not, get the sp
-           default FCP template, if no sp default template, use host default
-           FCP template.
+           default FCP Multipath Template, if no sp default template, use host default
+           FCP Multipath Template.
            If host default template is not found, then raise error.
         2. Get FCP list from db by assigner and fcp_template whose reserve=1
         3. If fcp_list is not empty, just to use them.
@@ -631,24 +631,24 @@ class FCPManager(object):
         with database.get_fcp_conn():
             fcp_tmpl_id = fcp_template_id
             if not fcp_tmpl_id:
-                LOG.info("FCP template id is not specified when reserving FCP "
+                LOG.info("FCP Multipath Template id is not specified when reserving FCP "
                          "devices for assigner %s." % assigner_id)
                 if sp_name:
-                    LOG.info("Get the default FCP template id for Storage "
+                    LOG.info("Get the default FCP Multipath Template id for Storage "
                              "Provider %s " % sp_name)
                     default_tmpl = self.db.get_sp_default_fcp_template([sp_name])
                 if not sp_name or not default_tmpl:
-                    LOG.info("Can not find the default FCP template id for "
+                    LOG.info("Can not find the default FCP Multipath Template id for "
                              "storage provider %s. Get the host default FCP "
                              "template id for assigner %s" % (sp_name,
                                                               assigner_id))
                     default_tmpl = self.db.get_host_default_fcp_template()
                 if default_tmpl:
                     fcp_tmpl_id = default_tmpl[0][0]
-                    LOG.info("The default FCP template id is %s." % fcp_tmpl_id)
+                    LOG.info("The default FCP Multipath Template id is %s." % fcp_tmpl_id)
                 else:
-                    errmsg = ("No FCP template is specified and "
-                              "no default FCP template is found.")
+                    errmsg = ("No FCP Multipath Template is specified and "
+                              "no default FCP Multipath Template is found.")
                     LOG.error(errmsg)
                     raise exception.SDKVolumeOperationError(rs=11,
                                                             userid=assigner_id,
@@ -663,7 +663,7 @@ class FCPManager(object):
                 fcp_list = self.db.get_allocated_fcps_from_assigner(
                     assigner_id, fcp_tmpl_id)
                 LOG.info("Previously allocated records %s for "
-                         "instance %s in fcp template %s." %
+                         "instance %s in FCP Multipath Template %s." %
                          ([f['fcp_id'] for f in fcp_list],
                           assigner_id, fcp_tmpl_id))
                 if not fcp_list:
@@ -701,11 +701,11 @@ class FCPManager(object):
                     assigner_id = assigner_id.upper()
                     self.db.reserve_fcps(fcp_ids, assigner_id, fcp_tmpl_id)
                     LOG.info("Newly allocated %s fcp for %s assigner "
-                             "and FCP template %s" %
+                             "and FCP Multipath Template %s" %
                              (fcp_ids, assigner_id, fcp_tmpl_id))
                 else:
                     # reuse the old ones if fcp_list is not empty
-                    LOG.info("Found allocated fcps %s for %s in FCP template %s, "
+                    LOG.info("Found allocated fcps %s for %s in FCP Multipath Template %s, "
                              "will reuse them."
                              % ([f['fcp_id'] for f in fcp_list],
                                 assigner_id, fcp_tmpl_id))
@@ -720,7 +720,7 @@ class FCPManager(object):
                 return available_list, fcp_tmpl_id
             except Exception as err:
                 errmsg = ("Failed to reserve FCP devices "
-                          "for assigner %s by FCP template %s error: %s"
+                          "for assigner %s by FCP Multipath Template %s error: %s"
                           % (assigner_id, fcp_template_id, err.message))
                 LOG.error(errmsg)
                 raise exception.SDKVolumeOperationError(rs=11,
@@ -768,13 +768,13 @@ class FCPManager(object):
                     if fcp_ids:
                         self.db.unreserve_fcps(fcp_ids)
                         LOG.info("Unreserve fcp device %s from "
-                                 "instance %s and FCP template %s."
+                                 "instance %s and FCP Multipath Template %s."
                                  % (fcp_ids, assigner_id, fcp_template_id))
                     return fcp_list
                 return []
             except Exception as err:
                 errmsg = ("Failed to unreserve FCP devices for "
-                          "assigner %s by FCP template %s. Error: %s"
+                          "assigner %s by FCP Multipath Template %s. Error: %s"
                           % (assigner_id, fcp_template_id, err.message))
                 LOG.error(errmsg)
                 raise exception.SDKVolumeOperationError(rs=11,
@@ -945,7 +945,7 @@ class FCPManager(object):
                     # storage provider backend is still using the old WWPNs recorded in FCP DB.
                     # To detach the volume and delete the host mapping successfully, we need make sure the WWPNs records
                     # in FCP DB unchanged in this case.
-                    # Because we will copy all properties in fcp_dict_in_zvm[fcp] to DB when update an FCP property
+                    # Because we will copy all properties in fcp_dict_in_zvm[fcp] to DB when update a FCP property
                     # (for example, state, owner, etc),
                     # we overwrite the (wwpn_npiv_zvm, wwpn_phy_zvm) in fcp_dict_in_zvm[fcp]
                     # to old (wwpn_npiv_db, wwpn_phy_db), so that their values will not be changed when update other
@@ -987,7 +987,7 @@ class FCPManager(object):
                             host_default: bool = False,
                             default_sp_list: list = None,
                             min_fcp_paths_count: int = None):
-        """Create a fcp template and return the basic information of
+        """Create a FCP Multipath Template and return the basic information of
         the created template, for example:
         {
             'fcp_template': {
@@ -1000,7 +1000,8 @@ class FCPManager(object):
             }
         }
         """
-        LOG.info("Try to create a FCP template with name:%s,"
+        LOG.info("Try to create a"
+                 " FCP Multipath Template with name:%s,"
                  "description:%s, fcp devices: %s, host_default: %s,"
                  "storage_providers: %s, min_fcp_paths_count: %s."
                  % (name, description, fcp_devices, host_default,
@@ -1022,7 +1023,7 @@ class FCPManager(object):
                                     default_sp_list, min_fcp_paths_count)
         min_fcp_paths_count_db = self.db.get_min_fcp_paths_count(tmpl_id)
         # Return template basic info
-        LOG.info("A FCP template was created with ID %s." % tmpl_id)
+        LOG.info("A FCP Multipath Template was created with ID %s." % tmpl_id)
         return {'fcp_template': {'name': name,
                 'id': tmpl_id,
                 'description': description,
@@ -1034,7 +1035,7 @@ class FCPManager(object):
                           description=None, fcp_devices=None,
                           host_default=None, default_sp_list=None,
                           min_fcp_paths_count=None):
-        """ Edit a FCP device template
+        """ Edit a FCP Multipath Template
 
         The kwargs values are pre-validated in two places:
           validate kwargs types
@@ -1144,7 +1145,7 @@ class FCPManager(object):
                                      "host_default": bool(is_default),
                                      "storage_providers": [],
                                      "min_fcp_paths_count": min_fcp_paths_count}
-            # one fcp template can be multiple sp's default template
+            # one FCP Multipath Template can be multiple sp's default template
             if sp_name and sp_name not in template_dict[id]["storage_providers"]:
                 template_dict[id]["storage_providers"].append(sp_name)
         return template_dict
@@ -1191,8 +1192,8 @@ class FCPManager(object):
          reserved, _, _, chpid, state, owner, _) = raw_item
 
         # The raw_item is for each fcp device, so there are multiple
-        # items for each single fcp template.
-        # But the return result needs to group all the items by fcp template,
+        # items for each single FCP Multipath Template.
+        # But the return result needs to group all the items by FCP Multipath Template,
         # so construct a dict statistics_usage[template_id]
         # with template_id as key to group the info.
         # template_id key also will be used to join with template base info
@@ -1233,7 +1234,7 @@ class FCPManager(object):
                 statistics_usage[
                     template_id][path_id]["notfound"].append(fcp_id)
                 LOG.warning("Found a FCP device "
-                            "%s in fcp template %s, but not found in "
+                            "%s in FCP Multipath Template %s, but not found in "
                             "z/VM." % (str(fcp_id), str(template_id)))
             # case H: (state = offline)
             # this FCP in database but offline in z/VM
@@ -1313,7 +1314,7 @@ class FCPManager(object):
             statistics_usage[template_id][path_id]["total"].append(fcp_id)
             statistics_usage[template_id][path_id]["notfound"].append(fcp_id)
             LOG.warning("Found a FCP device "
-                        "%s in fcp template %s, but not found in "
+                        "%s in FCP Multipath Template %s, but not found in "
                         "z/VM." % (str(fcp_id), str(template_id)))
         return statistics_usage
 
@@ -1384,14 +1385,14 @@ class FCPManager(object):
                           default_sp_list=None, host_default=None):
         """Get template base info by template_id_list or filters
         :param template_id_list: (list) a list of template id,
-        if it is None, get fcp templates with other parameter
+        if it is None, get FCP Multipath Templates with other parameter
         :param assigner_id: (str) a string of VM userid
         :param default_sp_list: (list) a list of storage provider or 'all',
-        to get storage provider's default fcp templates
+        to get storage provider's default FCP Multipath Templates
 
         when sp_host_list = ['all'], will get all storage providers' default
-        fcp templates. For example, there are 3 fcp templates are set as
-        storage providers' default template, then all these 3 fcp templates
+        FCP Multipath Templates. For example, there are 3 FCP Multipath Templates are set as
+        storage providers' default template, then all these 3 FCP Multipath Templates
         will return as below:
         {
             "fcp_templates": [
@@ -1427,7 +1428,7 @@ class FCPManager(object):
         }
 
         when sp_host_list is a storage provider name list, will return these
-        providers' default fcp templates.
+        providers' default FCP Multipath Templates.
 
         Example:
         sp_host_list = ['v7k60', 'ds8k60c1']
@@ -1468,7 +1469,7 @@ class FCPManager(object):
                 if not self.db.fcp_template_exist_in_db(template_id):
                     not_exist.append(template_id)
             if not_exist:
-                obj_desc = ("FCP device templates {} ".format(not_exist))
+                obj_desc = ("FCP Multipath Templates {} ".format(not_exist))
                 raise exception.SDKObjectNotExistError(obj_desc=obj_desc)
             raw = self.db.get_fcp_templates(template_id_list)
         elif assigner_id:
@@ -1478,7 +1479,7 @@ class FCPManager(object):
         elif host_default is not None:
             raw = self.db.get_host_default_fcp_template(host_default)
         else:
-            # if no parameter, will get all fcp templates
+            # if no parameter, will get all FCP Multipath Templates
             raw = self.db.get_fcp_templates(template_id_list)
 
         template_list = self.extract_template_info_from_raw_data(raw)
@@ -1489,7 +1490,7 @@ class FCPManager(object):
 
     def get_fcp_templates_details(self, template_id_list=None, raw=False,
                                   statistics=True, sync_with_zvm=False):
-        """Get fcp templates detail info.
+        """Get FCP Multipath Templates detail info.
         :param template_list: (list) if is None, will get all the templates on
         the host
         :return: (dict) the raw and/or statistic data of temlate_list FCP
@@ -1628,7 +1629,7 @@ class FCPManager(object):
                 if not self.db.fcp_template_exist_in_db(template_id):
                     not_exist.append(template_id)
         if not_exist:
-            obj_desc = ("FCP device templates {} ".format(not_exist))
+            obj_desc = ("FCP Multipath Templates {} ".format(not_exist))
             raise exception.SDKObjectNotExistError(obj_desc=obj_desc)
 
         if sync_with_zvm:
@@ -1706,7 +1707,7 @@ class FCPManager(object):
             #         path2: {}}
             # }
             for template_id, base_info in template_info.items():
-                # only the fcp template which has fcp in zvm has
+                # only the FCP Multipath Template which has fcp in zvm has
                 # statistics_usage data
                 if template_id in statistics_usage:
                     base_info.update(
@@ -1734,7 +1735,7 @@ class FCPManager(object):
         return {"fcp_templates": ret}
 
     def delete_fcp_template(self, template_id):
-        """Delete fcp template by id.
+        """Delete FCP Multipath Template by id.
         :param template_id: (str)
         :return: no return result
         """
@@ -1771,7 +1772,7 @@ class FCPVolumeManager(object):
         2. operations on z/VM done by _dedicate_fcp()
            i.e. dedicate FCP device from assigner_id
         3. operations on FCP DB done by get_volume_connector()
-           i.e. reserve FCP device and set FCP device template id from FCP DB
+           i.e. reserve FCP device and set FCP Multipath Template id from FCP DB
 
         :param fcp_list: (list) a list of FCP devices
         :param assigner_id: (str) the userid of the virtual machine
@@ -1945,7 +1946,7 @@ class FCPVolumeManager(object):
         else:
             min_fcp_paths_count = self.db.get_min_fcp_paths_count(fcp_template_id)
             if min_fcp_paths_count == 0:
-                errmsg = ("No FCP devices were found in the FCP template %s,"
+                errmsg = ("No FCP devices were found in the FCP Multipath Template %s,"
                           "stop refreshing bootmap." % fcp_template_id)
                 LOG.error(errmsg)
                 raise exception.SDKBaseException(msg=errmsg)
@@ -2004,7 +2005,7 @@ class FCPVolumeManager(object):
                         _userid, _reserved, _conns, _tmpl_id = self.get_fcp_usage(fcp)
                         LOG.info("After rollback, property of FCP device %s "
                                  "is (assigner_id: %s, reserved:%s, "
-                                 "connections: %s, fcp template id: %s)."
+                                 "connections: %s, FCP Multipath Template id: %s)."
                                  % (fcp, _userid, _reserved, _conns, _tmpl_id))
                 raise
 
@@ -2171,7 +2172,7 @@ class FCPVolumeManager(object):
                     _userid, _reserved, _conns, _tmpl_id = self.get_fcp_usage(fcp)
                     LOG.info("After rollback, property of FCP device %s "
                              "is (assigner_id: %s, reserved:%s, "
-                             "connections: %s, fcp template id: %s)."
+                             "connections: %s, FCP Multipath Template id: %s)."
                              % (fcp, _userid, _reserved, _conns, _tmpl_id))
             raise
 
@@ -2214,7 +2215,7 @@ class FCPVolumeManager(object):
                     rs=11, userid=assigner_id, msg=errmsg)
             """
             Reserve or unreserve FCP device
-            according to assigner id and FCP template id.
+            according to assigner id and FCP Multipath Template id.
             """
             if reserve:
                 LOG.info("get_volume_connector: Enter reserve_fcp_devices.")
@@ -2244,7 +2245,7 @@ class FCPVolumeManager(object):
                            'fcp_template_id': fcp_template_id}
         if not fcp_list:
             errmsg = ("Not enough available FCP devices found from "
-                      "FCP device template(id={})".format(fcp_template_id))
+                      "FCP Multipath Template(id={})".format(fcp_template_id))
             LOG.error(errmsg)
             return empty_connector
 
@@ -2267,7 +2268,7 @@ class FCPVolumeManager(object):
                      'fcp_paths': len(fcp_list),
                      'fcp_template_id': fcp_template_id}
         LOG.info('get_volume_connector returns %s for '
-                 'assigner %s and fcp template %s'
+                 'assigner %s and FCP Multipath Template %s'
                  % (connector, assigner_id, fcp_template_id))
         return connector
 


### PR DESCRIPTION
replace all `fcp template` or `fcp device template` to `FCP Multipath Template`

Signed-off-by: CaoBiao <bjcb@cn.ibm.com>