### PR TITLE
change the attach/detach lock in ZCC layer to a Per-VM-level lock

### DIFF
--- a/zvmsdk/volumeop.py
+++ b/zvmsdk/volumeop.py
@@ -53,6 +53,7 @@ DEDICATE = 'dedicate'
 
 _LOCK_RESERVE_FCP = threading.RLock()
 
+
 def get_volumeop():
     global _VolumeOP
     if not _VolumeOP:
@@ -2279,6 +2280,7 @@ class FCPVolumeManager(object):
                              % (fcp, _userid, _reserved, _conns, _tmpl_id))
             raise
 
+    @utils.synchronized('volumeAttachOrDetach-{assigner_id}')
     def get_volume_connector(self, assigner_id, reserve,
                              fcp_template_id=None, sp_name=None):
         """Get connector information of the instance for attaching to volumes.


### PR DESCRIPTION
When attaching a volume, the following functions are called sequentially
- get_volume_connector()
- attach()

When detaching a volume, the following functions are called sequentially
- detach() 
- get_volume_connector() 

This PR implements a synchronized lock with specified lock name to decorate the above functions.
So that volume attachment and/or detachment are sequentially processed against each VM

Signed-off-by: Da Long Wang <shdlwang@cn.ibm.com>