### PR TITLE
fix UT issues of setting up log and cleanups

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -46,8 +46,9 @@ commands =
   rm -f /tmp/sdk_image.sqlite
   rm -f /tmp/sdk_fcp.sqlite
   rm -f /tmp/sdk_network.sqlite
-  rm -f /tmp/FakeID
+  rm -rf /tmp/FakeID
   rm -rf test-results
+  rm -rf /tmp/zvmsdk_ut_logs
   {[testenv]commands-smt}
   {[testenv]commands-zvmsdk}
   mkdir test-results
@@ -60,7 +61,8 @@ commands =
   rm -f /tmp/sdk_image.sqlite
   rm -f /tmp/sdk_fcp.sqlite
   rm -f /tmp/sdk_network.sqlite
-  rm -f /tmp/FakeID
+  rm -rf /tmp/FakeID
+  rm -rf /tmp/zvmsdk_ut_logs
 
   {[testenv]commands-zvmsdk}
 

--- a/zvmsdk/log.py
+++ b/zvmsdk/log.py
@@ -32,10 +32,7 @@ class Logger():
     def setup(self, log_dir, log_level, log_file_name='zvmsdk.log'):
         # make sure target directory exists
         if not os.path.exists(log_dir):
-            if os.access(log_dir, os.W_OK):
-                os.makedirs(log_dir)
-            else:
-                log_dir = '/tmp/'
+            os.makedirs(log_dir)
 
         # Setup log level
         self.updateloglevel(log_level)

--- a/zvmsdk/tests/unit/base.py
+++ b/zvmsdk/tests/unit/base.py
@@ -36,6 +36,7 @@ class SDKTestCase(unittest.TestCase):
         set_conf('zvm', 'disk_pool', 'ECKD:TESTPOOL')
         set_conf('image', 'sdk_image_repository', '/tmp/')
         set_conf('zvm', 'namelist', 'TSTNLIST')
+        set_conf('logging', 'log_dir', '/tmp/zvmsdk_ut_logs/')
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
1. fix the logging setup issue
2. use /tmp dir as the log folder for ut
3. do cleanups after ut finished
4. FakeID is a directory, add -r option when cleanup

Signed-off-by: dyyang <dyyang@cn.ibm.com>