### PR TITLE
add param 'do_rollback' for volume attach and detach

### DIFF
--- a/zvmsdk/sdkwsgi/validation/parameter_types.py
+++ b/zvmsdk/sdkwsgi/validation/parameter_types.py
@@ -591,6 +591,7 @@ connection_info = {
         'mount_point': {'type': 'string'},
         'is_root_volume': boolean,
         'update_connections_only': boolean,
+        'do_rollback': boolean
     },
     'required': ['assigner_id', 'zvm_fcp', 'target_wwpn',
                  'target_lun', 'multipath', 'os_version',


### PR DESCRIPTION
Add param 'do_rollback' for the functions:
- def _do_detach
- def _do_attach

The functions contain multiple phases;
if 'do_rollback' is True (the default), rollback will be done if any phase fails. Otherwise, we try completing as many phases as possible, i.e. no rollback will be done if any phase fails.

Signed-off-by: Da Long Wang <shdlwang@cn.ibm.com>