### PR TITLE
Return list of instance stats instead of dict.

### DIFF
--- a/zvmsdk/monitor.py
+++ b/zvmsdk/monitor.py
@@ -77,7 +77,7 @@ class ZVMMonitor(object):
                     'shared_mem_kb': shared_mem
                     }
 
-        return stats_data
+        return [{k: v} for k, v in stats_data.items()]
 
     def inspect_vnics(self, uid_list):
         vnics = self._get_inspect_data('vnics', uid_list)


### PR DESCRIPTION
zvm/driver fetch stats of single VM by calling api to zvmsdk at a time, which cause unnecessary stress and log in zvmsdk.
This way zvmsdk will return list of instance stats at once instead of one at a time.
issue: https://github.ibm.com/zvc/planning/issues/10809