### PR TITLE
Report error if only 1 path is found when BFV

### DIFF
--- a/zthin-parts/zthin/bin/refresh_bootmap
+++ b/zthin-parts/zthin/bin/refresh_bootmap
@@ -1165,8 +1165,8 @@ function refreshFCPBootmap {
   done
 
   # check whether there is valid combination of FCP and target wwpns found from the `lszfcp -P`
-  if [[ $valid_paths_count -eq 0 ]]; then
-      printError "Exit MSG:  No valid path found between FCP devices: ${INPUT_FCPS[*]} and wwpns: ${INPUT_WWPNS[*]}."
+  if [[ $valid_paths_count -le 1 ]]; then
+      printError "Exit MSG: At least 2 paths are required for the server to boot, but ${valid_paths_count} valid path found between FCP devices: ${INPUT_FCPS[*]} and wwpns: ${INPUT_WWPNS[*]}."
       exit 18
   fi
   # Usable FCP: Only the FCPs that we can find a valid target WWPN via the `lszfcp -P` can be defined


### PR DESCRIPTION
we require multipath available for the server to boot, so abort the deploy if 0 or only 1 path detected.