### PR TITLE
Correct cpu definition numbers during resize

### DIFF
--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -3571,15 +3571,19 @@ class SMTClient(object):
     def _get_defined_cpu_addrs(self, userid):
         user_direct = self.get_user_direct(userid)
         defined_addrs = []
+        defined_addrs_long = []
         max_cpus = 0
         for ent in user_direct:
             if ent.startswith("CPU"):
                 cpu_addr = ent.split()[1].strip().upper()
                 defined_addrs.append(cpu_addr)
+            if ent.startswith("COMMAND DEFINE CPU"):
+                cpu_addr_long = ent.split()[3].strip().upper()
+                defined_addrs_long.append(cpu_addr_long)
             if ent.startswith("MACHINE ESA"):
                 max_cpus = int(ent.split()[2].strip())
 
-        return (max_cpus, defined_addrs)
+        return (max_cpus, defined_addrs, defined_addrs_long)
 
     def _get_available_cpu_addrs(self, used_addrs, max_cpus):
         # Get available CPU addresses that are not defined in user entry
@@ -3608,6 +3612,24 @@ class SMTClient(object):
             active_addrs.append(addr)
         return active_addrs
 
+    def get_active_cpu_offline_addrs(self, userid):
+        # Get the offline cpu addrs in two-digit hex string in upper case
+        # Sample output for 'lscpu --parse=ADDRESS --offline':
+        # # The following is the parsable format, which can be fed to other
+        # # programs. Each different item in every column has an unique ID
+        # # starting from zero.
+        # # Address
+        # 2
+        offline_addrs = []
+        offline_cpus = self.execute_cmd(userid, "lscpu --parse=ADDRESS --offline")
+        for c in offline_cpus:
+            # Skip the comment lines at beginning
+            if c.startswith("# "):
+                continue
+            addr = hex(int(c.strip()))[2:].rjust(2, '0').upper()
+            offline_addrs.append(addr)
+        return offline_addrs
+
     def resize_cpus(self, userid, count):
         # Check defined cpus in user entry. If greater than requested, then
         # delete cpus. Otherwise, add new cpus.
@@ -3617,8 +3639,29 @@ class SMTClient(object):
         # cpu_addrs: list of influenced cpu addrs
         action = 0
         updated_addrs = []
-        (max_cpus, defined_addrs) = self._get_defined_cpu_addrs(userid)
-        defined_count = len(defined_addrs)
+        defined_count = 0
+
+        # Based on the following reasons, we need to delete all short format
+        # 'CPU XX' and ensure long format 'COMMAND DEFINE CPU XX TYPE IFL'
+        # number correct after resize.
+        # 1, For vm not resized after deploying,
+        # only having 'COMMAND DEFINE CPU XX TYPE IFL' format definition.
+        # 2, For vm resized before, having both kinds definitions:
+        # 'COMMAND DEFINE CPU XX TYPE IFL' and 'CPU XX', and their counts
+        # may not be the same, as resize and counting before only
+        # handles 'CPU XX'.
+
+        (max_cpus, defined_addrs_short, defined_addrs_long) = \
+            self._get_defined_cpu_addrs(userid)
+        defined_count_short = len(defined_addrs_short)
+        defined_count_long = len(defined_addrs_long)
+        only_long_def = False
+        if (defined_count_short == 0 and defined_count_long > 0):
+            defined_count = defined_count_long
+            only_long_def = True
+        else:
+            defined_count = defined_count_short
+
         # Check maximum cpu count defined
         if max_cpus == 0:
             LOG.error("Resize for guest '%s' cann't be done. The maximum "
@@ -3644,86 +3687,229 @@ class SMTClient(object):
         elif defined_count < count:
             action = 1
             # add more CPUs
-            available_addrs = self._get_available_cpu_addrs(defined_addrs,
-                                                            max_cpus)
-            # sort the list and get the first few addrs to use
-            available_addrs.sort()
-            # Define new cpus in user directory
-            rd = ''.join(("SMAPI %s API Image_Definition_Update_DM " % userid,
-                          "--operands"))
-            updated_addrs = available_addrs[0:count - defined_count]
-            for addr in updated_addrs:
-                rd += (" -k CPU=CPUADDR=%s" % addr)
+            available_addrs_long = self._get_available_cpu_addrs(
+                defined_addrs_long, max_cpus)
+            available_addrs_long.sort()
 
-            # Add resize support for share of CPU
-            if CONF.zvm.user_default_share_unit > 0:
-                total = CONF.zvm.user_default_share_unit * count
-                rd += (" -k SHARE=RELATIVE=%s" % total)
+            to_delete_addrs_short = []
+            to_delete_addrs_long = []
+            to_add_addrs_long = []
 
-            try:
-                self._request(rd)
-            except exception.SDKSMTRequestFailed as e:
-                msg = ("Define new cpus in user directory for '%s' failed with"
-                       " SMT error: %s" % (userid, e.format_message()))
-                LOG.error(msg)
-                raise exception.SDKGuestOperationError(rs=6, userid=userid,
-                                                       err=e.format_message())
-            LOG.info("New CPUs defined in user directory for '%s' "
-                     "successfully" % userid)
-            return (action, updated_addrs, max_cpus)
-        else:
-            action = 2
-            # Delete CPUs
-            defined_addrs.sort()
-            updated_addrs = defined_addrs[-(defined_count - count):]
-            # Delete the last few cpus in user directory
-            rd = ''.join(("SMAPI %s API Image_Definition_Delete_DM " % userid,
-                          "--operands"))
-            for addr in updated_addrs:
-                rd += (" -k CPU=CPUADDR=%s" % addr)
-            try:
-                self._request(rd)
-            except exception.SDKSMTRequestFailed as e:
-                msg = ("Delete CPUs in user directory for '%s' failed with"
-                       " SMT error: %s" % (userid, e.format_message()))
-                LOG.error(msg)
-                raise exception.SDKGuestOperationError(rs=6, userid=userid,
-                                                       err=e.format_message())
-            LOG.info("CPUs '%s' deleted from user directory for '%s' "
-                     "successfully" % (str(updated_addrs), userid))
-            # Add resize support for share of CPU
-            if CONF.zvm.user_default_share_unit > 0:
-                total = CONF.zvm.user_default_share_unit * count
-                rd = ''.join(("SMAPI %s API Image_Definition_Update_DM " % userid,
-                          "--operands -k SHARE=RELATIVE=%s" % total))
+            if only_long_def:
+                # e.g. 5->7
+                # short : no short, don't add.
+                # long: add
+                to_add_addrs_long = available_addrs_long[0:count - defined_count_long]
+            else:
+                # e.g. 5->3->4, 5->3->6, 5->7->9, or verify old vm which only
+                # has short format 4->6
+
+                # short, delete them all
+                defined_addrs_short.sort()
+                to_delete_addrs_short = defined_addrs_short
+
+                # long, delete or add
+                defined_addrs_long.sort()
+                if defined_count_long < count:
+                    # add. e.g.5->6, 5->9
+                    to_add_addrs_long = available_addrs_long[0:count - defined_count_long]
+                elif defined_count_long > count:
+                    # Delete cpus in user directory, as for the vm resized before,
+                    # need to delete long format in some situations, e.g. 5->3->4,
+                    # as long format "COMMAND DEFINE CPU XX TYPE IFL" not handled
+                    # during resize 5->3 before, although 3->4 is resized up,
+                    # still need to delete 1 for long format. e.g. 5->4
+                    to_delete_addrs_long = defined_addrs_long[-(defined_count_long - count):]
+
+            # Delete the last few cpus in user directory in format "CPU XX"
+            # and "COMMAND DEFINE CPU XX TYPE IFL".
+            if len(to_delete_addrs_short) > 0 or len(to_delete_addrs_long) > 0:
+                rd = ''.join(("SMAPI %s API Image_Definition_Delete_DM " % userid,
+                              "--operands"))
+                if len(to_delete_addrs_short) > 0:
+                    for addr in to_delete_addrs_short:
+                        rd += (" -k CPU=CPUADDR=%s" % addr)
+                if len(to_delete_addrs_long) > 0:
+                    for addr2 in to_delete_addrs_long:
+                        rd += (" -k COMMAND_DEFINE_CPU=CPUADDR=%s" % addr2)
                 try:
                     self._request(rd)
                 except exception.SDKSMTRequestFailed as e:
-                    msg = ("Update share statement in user directory for '%s' failed with"
+                    msg = ("Delete CPUs in user directory for '%s' failed "
+                           "with SMT error: %s"
+                           % (userid, e.format_message()))
+                    LOG.error(msg)
+                    raise exception.SDKGuestOperationError(
+                        rs=6, userid=userid, err=e.format_message())
+                LOG.info("CPUs '%s' and '%s' deleted from user directory"
+                         " for '%s' successfully"
+                         % (str(to_delete_addrs_short),
+                            str(to_delete_addrs_long), userid))
+
+            # Define new cpus in user directory
+            rd = ''.join(("SMAPI %s API Image_Definition_Update_DM " % userid,
+                          "--operands"))
+            need_action = False
+            # May not need to send request at all, because existing long
+            # format items may be enough. e.g. 5->3->5, resize down 5->3
+            # before, as long format items were not handled before,
+            # there are still 5 long format items, so we don't need to
+            # add more even it is resize up to 5 now.
+            if len(to_add_addrs_long) > 0:
+                need_action = True
+                for addr2 in to_add_addrs_long:
+                    rd += (" -k COMMAND_DEFINE_CPU=\'CPUADDR=%s TYPE=IFL\'" % addr2)
+
+            # Add resize support for share of CPU
+            if CONF.zvm.user_default_share_unit > 0:
+                need_action = True
+                total = CONF.zvm.user_default_share_unit * count
+                rd += (" -k SHARE=RELATIVE=%s" % total)
+
+            if need_action:
+                try:
+                    self._request(rd)
+                except exception.SDKSMTRequestFailed as e:
+                    msg = ("Define new cpus in user directory for '%s' failed with"
                            " SMT error: %s" % (userid, e.format_message()))
                     LOG.error(msg)
                     raise exception.SDKGuestOperationError(rs=6, userid=userid,
                                                            err=e.format_message())
-                LOG.info("Update share statment in user directory for '%s' "
-                     "successfully" % userid)
-            return (action, updated_addrs, max_cpus)
+                LOG.info("New CPUs defined '%s' in user directory for '%s' "
+                         "or add resize support for share of CPU successfully"
+                         % (str(to_add_addrs_long), userid))
+                return (action, to_add_addrs_long + to_delete_addrs_long, max_cpus)
+            else:
+                LOG.info("Existing CPUs defined in long format"
+                         " 'COMMAND DEFINE CPU XX TYPE IFL' '%s'"
+                         " in user directory for '%s' are enough"
+                         " for this resize. Don't need to add more."
+                         % (str(defined_addrs_long), userid))
+                return (action, to_add_addrs_long + to_delete_addrs_long, max_cpus)
+        else:
+            action = 2
+            # Delete CPUs
+            available_addrs_short = self._get_available_cpu_addrs(
+                defined_addrs_short, max_cpus)
+            available_addrs_short.sort()
+            available_addrs_long = self._get_available_cpu_addrs(
+                defined_addrs_long, max_cpus)
+            available_addrs_long.sort()
+
+            to_delete_addrs_short = []
+            to_delete_addrs_long = []
+            to_add_addrs_long = []
+
+            if only_long_def:
+                # e.g. 5->3
+                # short : no short, don't add.
+                # long: delete
+                defined_addrs_long.sort()
+                to_delete_addrs_long = defined_addrs_long[-(defined_count_long - count):]
+            else:
+                # e.g. 5->3->2, 5->7->6, 5->7->3, or very old vm which only
+                # has short format 4->2
+
+                # short, delete all.
+                defined_addrs_short.sort()
+                to_delete_addrs_short = defined_addrs_short
+
+                # long, delete or add
+                defined_addrs_long.sort()
+                if defined_count_long < count:
+                    # Add cpus in user directory, for an existing vm
+                    # resized to a larger size cpu before, e.g. 5->7->6, as long
+                    # format "COMMAND DEFINE CPU XX TYPE IFL" not handled during
+                    # resize 5->7 before, although 7->6 now, still need to add 1
+                    # for long format. e.g.5->6,
+                    to_add_addrs_long = available_addrs_long[0:count - defined_count_long]
+                elif defined_count_long > count:
+                    # delete. e.g. 5->2, 5->3
+                    to_delete_addrs_long = defined_addrs_long[-(defined_count_long - count):]
+
+            # Delete the last few cpus in user directory in format "CPU XX"
+            # and "COMMAND DEFINE CPU XX TYPE IFL".
+            if len(to_delete_addrs_short) > 0 or len(to_delete_addrs_long) > 0:
+                rd = ''.join(("SMAPI %s API Image_Definition_Delete_DM " % userid,
+                              "--operands"))
+                if len(to_delete_addrs_short) > 0:
+                    for addr in to_delete_addrs_short:
+                        rd += (" -k CPU=CPUADDR=%s" % addr)
+                if len(to_delete_addrs_long) > 0:
+                    for addr2 in to_delete_addrs_long:
+                        rd += (" -k COMMAND_DEFINE_CPU=CPUADDR=%s" % addr2)
+                try:
+                    self._request(rd)
+                except exception.SDKSMTRequestFailed as e:
+                    msg = ("Delete CPUs in user directory for '%s' failed "
+                           "with SMT error: %s"
+                           % (userid, e.format_message()))
+                    LOG.error(msg)
+                    raise exception.SDKGuestOperationError(
+                        rs=6, userid=userid, err=e.format_message())
+                LOG.info("CPUs '%s' and '%s' deleted from user directory"
+                         " for '%s' successfully"
+                         % (str(to_delete_addrs_short),
+                            str(to_delete_addrs_long), userid))
+
+            # Add new cpus in user directory
+            rd = ''.join(("SMAPI %s API Image_Definition_Update_DM " % userid,
+                          "--operands"))
+            need_action = False
+
+            if len(to_add_addrs_long) > 0:
+                need_action = True
+                for addr2 in to_add_addrs_long:
+                    rd += (" -k COMMAND_DEFINE_CPU=\'CPUADDR=%s TYPE=IFL\'" % addr2)
+
+            # Add resize support for share of CPU
+            if CONF.zvm.user_default_share_unit > 0:
+                need_action = True
+                total = CONF.zvm.user_default_share_unit * count
+                rd += (" -k SHARE=RELATIVE=%s" % total)
+
+            if need_action:
+                try:
+                    self._request(rd)
+                except exception.SDKSMTRequestFailed as e:
+                    msg = ("Define new cpus in user directory for '%s' failed with"
+                           " SMT error: %s" % (userid, e.format_message()))
+                    LOG.error(msg)
+                    raise exception.SDKGuestOperationError(rs=6, userid=userid,
+                                                           err=e.format_message())
+                LOG.info("New CPUs '%s' defined in user directory for '%s'"
+                         " successfully or update share statement in user"
+                         " directory successfully"
+                         % (str(to_add_addrs_long), userid))
+
+            return (action, to_add_addrs_long + to_delete_addrs_long, max_cpus)
 
     def live_resize_cpus(self, userid, count):
-        # Get active cpu count and compare with requested count
-        # If request count is smaller than the current count, then report
-        # error and exit immediately.
+        # Get active cpu(online) count and compare with requested count
         active_addrs = self.get_active_cpu_addrs(userid)
         active_count = len(active_addrs)
-        if active_count > count:
-            LOG.error("Failed to live resize cpus of guest: %(uid)s, "
-                      "current active cpu count: %(cur)i is greater than "
-                      "the requested count: %(req)i." %
-                      {'uid': userid, 'cur': active_count,
-                       'req': count})
-            raise exception.SDKConflictError(modID='guest', rs=2,
-                                             userid=userid,
-                                             active=active_count,
-                                             req=count)
+        active_addrs.sort()
+
+        # Get offline cpu count
+        offline_addrs = self.get_active_cpu_offline_addrs(userid)
+
+        # Backup user directory long format cpu definitions in
+        # defined_addrs_long_bk for rollback
+        (max_cpus, defined_addrs_short_bk, defined_addrs_long_bk) = \
+            self._get_defined_cpu_addrs(userid)
+
+        # If request count is smaller than the current count, then report
+        # error and exit immediately.
+        # if active_count > count:
+        #     LOG.error("Failed to live resize cpus of guest: %(uid)s, "
+        #               "current active cpu count: %(cur)i is greater than "
+        #               "the requested count: %(req)i." %
+        #               {'uid': userid, 'cur': active_count,
+        #                'req': count})
+        #     raise exception.SDKConflictError(modID='guest', rs=2,
+        #                                      userid=userid,
+        #                                      active=active_count,
+        #                                      req=count)
 
         # Static resize CPUs. (add or delete CPUs from user directory)
         (action, updated_addrs, max_cpus) = self.resize_cpus(userid, count)
@@ -3736,103 +3922,183 @@ class SMTClient(object):
                      % userid)
             return
         else:
-            # Get the number of cpus to add to active and check address
-            active_free = self._get_available_cpu_addrs(active_addrs,
-                                                        max_cpus)
-            active_free.sort()
-            active_new = active_free[0:count - active_count]
-            # Do live resize
-            # Define new cpus
-            cmd_str = "vmcp def cpu " + ' '.join(active_new)
-            try:
-                self.execute_cmd(userid, cmd_str)
-            except exception.SDKSMTRequestFailed as err1:
-                # rollback and return
-                msg1 = ("Define cpu of guest: '%s' to active failed with . "
-                       "error: %s." % (userid, err1.format_message()))
-                # Start to do rollback
-                if action == 0:
-                    LOG.error(msg1)
-                else:
-                    LOG.error(msg1 + (" Will revert the user directory "
-                                      "change."))
-                    # Combine influenced cpu addrs
-                    cpu_entries = ""
-                    for addr in updated_addrs:
-                        cpu_entries += (" -k CPU=CPUADDR=%s" % addr)
-                    rd = ''
-                    if action == 1:
-                        # Delete added CPUs
-                        rd = ''.join(("SMAPI %s API Image_Definition_Delete_DM"
-                                      % userid, " --operands"))
-                    else:
-                        # Add deleted CPUs
-                        rd = ''.join(("SMAPI %s API Image_Definition_Create_DM"
-                                      % userid, " --operands"))
-                    rd += cpu_entries
-                    try:
-                        self._request(rd)
-                    except exception.SDKSMTRequestFailed as err2:
-                        msg = ("Failed to revert user directory change for '"
-                               "%s', SMT error: %s" % (userid,
-                                                        err2.format_message()))
-                        LOG.error(msg)
-                    else:
-                        # revert change for share statement
-                        if CONF.zvm.user_default_share_unit > 0:
-                            old = CONF.zvm.user_default_share_unit * active_count
-                            rd = ''.join(("SMAPI %s API Image_Definition_Update_DM " % userid,
-                                     "--operands -k SHARE=RELATIVE=%s" % old))
-                            try:
-                                self._request(rd)
-                            except exception.SDKSMTRequestFailed as e:
-                                msg = ("Failed to revert user directory change of share for '"
-                                   "%s', SMT error: %s" % (userid, e.format_message()))
-                                LOG.error(msg)
-                            else:
-                                LOG.info("Revert user directory change for '%s' "
-                                    "successfully." % userid)
-                        else:
-                            LOG.info("Revert user directory change for '%s' "
-                                "successfully." % userid)
-                # Finally raise the exception
-                raise exception.SDKGuestOperationError(
-                    rs=7, userid=userid, err=err1.format_message())
-        # Activate successfully, rescan in Linux layer to hot-plug new cpus
-        LOG.info("Added new CPUs to active configuration of guest '%s'" %
-                 userid)
-        try:
-            self.execute_cmd(userid, "chcpu -r")
-        except exception.SDKSMTRequestFailed as err:
-            msg = err.format_message()
-            LOG.error("Rescan cpus to hot-plug new defined cpus for guest: "
-                      "'%s' failed with error: %s. No rollback is done and you"
-                      "may need to check the status and restart the guest to "
-                      "make the defined cpus online." % (userid, msg))
-            raise exception.SDKGuestOperationError(rs=8, userid=userid,
-                                                   err=msg)
+            is_ubuntu = False
+            uname_out = self.execute_cmd(userid, "uname -a")
+            if uname_out and len(uname_out) >= 1:
+                distro = uname_out[0]
+            else:
+                distro = ''
+            if 'ubuntu' in distro or 'Ubuntu' in distro \
+                    or 'UBUNTU' in distro:
+                is_ubuntu = True
 
-        uname_out = self.execute_cmd(userid, "uname -a")
-        if uname_out and len(uname_out) >= 1:
-            distro = uname_out[0]
+            if active_count < count:
+                # Add live cpu
+                # Get the number of cpus to add to active and check address
+                active_free = self._get_available_cpu_addrs(active_addrs,
+                                                            max_cpus)
+                active_free.sort()
+                active_new = active_free[0:count - active_count]
+
+                # For addresses disabled, just enable it,
+                # otherwise need to define and trigger cpu scan.
+                to_enable_addrs = [a for a in active_new if a in offline_addrs]
+                to_define_addrs = list(set(active_new) - set(offline_addrs))
+                to_enable_addrs.sort()
+                to_define_addrs.sort()
+
+                # Do live resize.
+                # Including 1, define new cpus; 2, enable cups;
+
+                # 1, Define new cpus
+                if to_define_addrs:
+                    cmd_str = "vmcp def cpu " + ' '.join(to_define_addrs)
+                    try:
+                        self.execute_cmd(userid, cmd_str)
+                    except exception.SDKSMTRequestFailed as err1:
+                        # rollback and return.
+                        # compare updated_addrs with defined_addrs_long_bk.
+                        msg1 = ("Define cpu of guest: '%s' to active failed with "
+                                "error: %s." % (userid, err1.format_message()))
+                        # Start to do rollback
+                        if action == 0:
+                            LOG.error(msg1)
+                        else:
+                            LOG.error(msg1 + (" Will revert the user directory "
+                                              "change."))
+                            self.roll_back_user_directory_definitions(
+                                userid, updated_addrs, defined_addrs_long_bk,
+                                active_count)
+                        # Finally raise the exception
+                        raise exception.SDKGuestOperationError(
+                            rs=7, userid=userid, err=err1.format_message())
+                    # Activate successfully, rescan in Linux layer to hot-plug new cpus
+                    LOG.info("Added new CPUs to active configuration of guest '%s'" %
+                             userid)
+                    try:
+                        self.execute_cmd(userid, "chcpu -r")
+                    except exception.SDKSMTRequestFailed as err:
+                        msg = err.format_message()
+                        LOG.error("Rescan cpus to hot-plug new defined cpus for guest: "
+                                  "'%s' failed with error: %s. No rollback is done and you"
+                                  "may need to check the status and restart the guest to "
+                                  "make the defined cpus online." % (userid, msg))
+                        raise exception.SDKGuestOperationError(rs=8, userid=userid,
+                                                               err=msg)
+
+                    if is_ubuntu:
+                        try:
+                            # need use chcpu -e <cpu-list> to make cpu online for Ubuntu
+                            online_cmd = "chcpu -e " + ','.join(to_define_addrs)
+                            self.execute_cmd(userid, online_cmd)
+                        except exception.SDKSMTRequestFailed as err:
+                            msg = err.format_message()
+                            LOG.error("Enable cpus for ubuntu guest: '%s' "
+                                      "failed with error: %s. No rollback is"
+                                      " done and you may need to check the "
+                                      "status and restart the guest to make"
+                                      " the defined cpus online."
+                                      % (userid, msg))
+                            raise exception.SDKGuestOperationError(rs=15, userid=userid,
+                                                                   err=msg)
+                    LOG.info("Enabled cpus just defined for ubuntu guest: '%s' finished successfully."
+                             % userid)
+
+                # 2, enable cups
+                if to_enable_addrs:
+                    cmd_str = "chcpu -e " + ','.join(to_enable_addrs)
+                    try:
+                        self.execute_cmd(userid, cmd_str)
+                    except exception.SDKSMTRequestFailed as err1:
+                        # rollback and return
+                        msg1 = ("Enable cpu of guest: '%s' to active failed with . "
+                                "error: %s." % (userid, err1.format_message()))
+                        # Start to do rollback
+                        if action == 0:
+                            LOG.error(msg1)
+                        else:
+                            self.roll_back_user_directory_definitions(
+                                userid, updated_addrs, defined_addrs_long_bk,
+                                active_count)
+                        # Finally raise the exception
+                        raise exception.SDKGuestOperationError(
+                            rs=7, userid=userid, err=err1.format_message())
+                    # Enable cups successfully
+                    LOG.info("Enable CPUs to online guest '%s'" % userid)
+
+            elif active_count > count:
+                # Disable online cpus, as not find a way to undefine or delete
+                # a configured cpu. A disabled cpu can only be enabled later,
+                # and not be defined again.
+                to_disable_addrs = active_addrs[-(active_count - count):]
+                cmd_str = "chcpu -d " + ','.join(to_disable_addrs)
+                try:
+                    self.execute_cmd(userid, cmd_str)
+                except exception.SDKSMTRequestFailed as err1:
+                    # rollback and return
+                    msg1 = ("Disable cpu of guest: '%s' to offline failed "
+                            "with error: %s." % (userid,
+                                                 err1.format_message()))
+                    if action == 0:
+                        LOG.error(msg1)
+                    else:
+                        # Start to do rollback
+                        self.roll_back_user_directory_definitions(
+                            userid, updated_addrs, defined_addrs_long_bk,
+                            active_count)
+                    # Finally raise the exception
+                    raise exception.SDKGuestOperationError(
+                        rs=7, userid=userid, err=err1.format_message())
+                # Disable cups successfully
+                LOG.info("Disable CPUs to offline guest '%s'" % userid)
+
+    def roll_back_user_directory_definitions(self, userid, updated_addrs,
+                                             defined_addrs_long_bk,
+                                             active_count):
+        # Only need to roll back cpu definition in long
+        # format: "COMMAND DEFINE CPU XX TYPE IFL".
+        # All the impacted cpus are either been added
+        # or deleted.
+        to_add_rollback_addrs = [a for a in updated_addrs if a in defined_addrs_long_bk]
+        to_del_rollback_addrs = list(set(updated_addrs) - set(to_add_rollback_addrs))
+        to_add_rollback_addrs.sort()
+        to_del_rollback_addrs.sort()
+        if to_add_rollback_addrs:
+            rd = ''.join(("SMAPI %s API Image_Definition_Update_DM " % userid,
+                          "--operands"))
+            for addr in to_add_rollback_addrs:
+                rd += (" -k COMMAND_DEFINE_CPU=\'CPUADDR=%s TYPE=IFL\'" % addr)
         else:
-            distro = ''
-        if 'ubuntu' in distro or 'Ubuntu' in distro \
-                or 'UBUNTU' in distro:
-            try:
-                # need use chcpu -e <cpu-list> to make cpu online for Ubuntu
-                online_cmd = "chcpu -e " + ','.join(active_new)
-                self.execute_cmd(userid, online_cmd)
-            except exception.SDKSMTRequestFailed as err:
-                msg = err.format_message()
-                LOG.error("Enable cpus for guest: '%s' failed with error: %s. "
-                          "No rollback is done and you may need to check the "
-                          "status and restart the guest to make the defined "
-                          "cpus online." % (userid, msg))
-                raise exception.SDKGuestOperationError(rs=15, userid=userid,
-                                                       err=msg)
-        LOG.info("Live resize cpus for guest: '%s' finished successfully."
-                 % userid)
+            rd = ''.join(("SMAPI %s API Image_Definition_Delete_DM " % userid,
+                          "--operands"))
+            for addr in to_del_rollback_addrs:
+                rd += (" -k COMMAND_DEFINE_CPU=CPUADDR=%s" % addr)
+
+        try:
+            self._request(rd)
+        except exception.SDKSMTRequestFailed as err2:
+            msg = ("Failed to revert user directory change for '"
+                   "%s', SMT error: %s" % (userid,
+                                           err2.format_message()))
+            LOG.error(msg)
+        else:
+            # revert change for share statement
+            if CONF.zvm.user_default_share_unit > 0:
+                old = CONF.zvm.user_default_share_unit * active_count
+                rd = ''.join(("SMAPI %s API Image_Definition_Update_DM " % userid,
+                              "--operands -k SHARE=RELATIVE=%s" % old))
+                try:
+                    self._request(rd)
+                except exception.SDKSMTRequestFailed as e:
+                    msg = ("Failed to revert user directory change of share for '"
+                           "%s', SMT error: %s" % (userid, e.format_message()))
+                    LOG.error(msg)
+                else:
+                    LOG.info("Revert user directory change for '%s' "
+                             "successfully." % userid)
+            else:
+                LOG.info("Revert user directory change for '%s' "
+                         "successfully." % userid)
 
     def _get_defined_memory(self, userid):
         user_direct = self.get_user_direct(userid)


### PR DESCRIPTION
## What changed:
### Cold resize
1, Check if the user direct contains short format `CPU XX`:
--> if yes, then count short format `CPU XX `to as current CPU definition
--> if no, then count long format `COMMAND DEFINE CPU XX TYPE IFL` as current CPU definition
2, In the resize_cpu function, no matter resize up or resize down:
--> delete all short format `CPU xx`
--> handle the long format `COMMAND DEFINE CPU XX TYPE IFL` to make it correct to match with the VM's cpu value defined in openstack
3, Only return impacted(added or deleted) only format `COMMAND DEFINE CPU XX TYPE IFL`

### Live resize
1, Compare vm current active cpu count <--> target count:
--> if  current active < target, live resize up. How to do it, refer to item2.
--> if current active > target, live resize down, by disable cpus `chcpu -d XX` 


2, get offline cpu address by `lscpu --parse=ADDRESS --offline`, to resize up, check
--> the to be added address **IN** offline address list, enable it by `chcpu -e XX` .
--> otherwise, it's a new cpu, need to define and trigger cpu scan again by `vmcp def cpu XX` +   `chcpu -r`. Note: for ubuntu vm, for this new cpu, needs extra step `chcpu -e XX`, like before.

3, Rollback scope: Only roll back user directory long format `COMMAND DEFINE CPU XX TYPE IFL`. Even short format `CPU xx` are removed during live_resize_cpus -> resize_cpus, don't rollback them.

4, Save user directory status at the beginning of live resize for rollback purpose. If rollback happens, compare _back long format addresses_ <---> _the impacted addresses returned by resize_cpus_
--> the impacted addresses **IN** back long format addresses, add them back to user directory
--> otherwise delete them from user directory

5, Remove the condition check that only allowing resize up in UI, API and live_resize_cpus. So from now on, it supports resize down.


## Backgroud
### Problems:
1, deploy a zvm vm with 7 cpus.
2, shutdown the VM then do the resize, change cpu to 5.
3, after resize complete you logon the VM (first start it )
and the vcpu is still 5.

### Root cause:
1, For a vm just deployed, there is only long format in its user directory. No short format. e.g. deploy a vm with 5 cpus.
```
[root@core1-cmp-m5407-hxy zvmsdk]# smcli Image_Query_DM -T HXY00004
USER HXY00004 LBYONLY 4096m 64G G
INCLUDE ZCCDFLT
COMMAND SET VCONFIG MODE LINUX
COMMAND DEFINE CPU 00 TYPE IFL
COMMAND DEFINE CPU 01 TYPE IFL
COMMAND DEFINE CPU 02 TYPE IFL
COMMAND DEFINE CPU 03 TYPE IFL
COMMAND DEFINE CPU 04 TYPE IFL
COMMAND DEF STOR RESERVED 61440M
IPL 0100
LOGONBY IAASADM
MACHINE ESA 32
SHARE RELATIVE 500
NICDEF 1000 TYPE QDIO DEVICES 3 MACID 45FE07 LAN SYSTEM VSICIC
MDISK 0100 3390 116511 14564 M40701 MR
*DVHOPT LNK0 LOG1 RCM1 SMS0 NPW1 LNGAMENG PWC20230616 CRCXX
```
2, With the code today(without any change), it only cares and handles short format, when
* checking and counting current CPU definition
* add cpu delete cpu

3, e.g. deploy a vm with 5 cpu, resize to 3 cpus, it does not go to 'delete' section of the code in resize_cpus method. Instead, it goes to 'add' section, because there is no short format, so defined_count is 0, count is 3, so it goes to add section, add add 3 short items.

```
[root@core1-cmp-m5407-hxy zvmsdk]# smcli Image_Query_DM -T HXY00004
USER HXY00004 LBYONLY 4096m 64G G
INCLUDE ZCCDFLT
COMMAND SET VCONFIG MODE LINUX
COMMAND DEFINE CPU 00 TYPE IFL
COMMAND DEFINE CPU 01 TYPE IFL
COMMAND DEFINE CPU 02 TYPE IFL
COMMAND DEFINE CPU 03 TYPE IFL
COMMAND DEFINE CPU 04 TYPE IFL
COMMAND DEF STOR RESERVED 61440M
CPU 00
CPU 01
CPU 02
IPL 0100
LOGONBY IAASADM
MACHINE ESA 32
SHARE RELATIVE 500
NICDEF 1000 TYPE QDIO DEVICES 3 MACID 45FE07 LAN SYSTEM VSICIC
MDISK 0100 3390 116511 14564 M40701 MR
*DVHOPT LNK0 LOG1 RCM1 SMS0 NPW1 LNGAMENG PWC20230616 CRCXX
```


