### PR TITLE
Support indicated userid

### DIFF
--- a/doc/source/parameters.yaml
+++ b/doc/source/parameters.yaml
@@ -176,6 +176,12 @@ guest_comment_list:
   in: body
   required: false
   type: list
+guest_meta_data:
+  description: |
+    meta data of the virtual machine.
+  in: body
+  required: false
+  type: dict
 user_profile_guest:
   description: |
     Profile of guest, ``null`` is also allowed.

--- a/doc/source/restapi.rst
+++ b/doc/source/restapi.rst
@@ -186,6 +186,7 @@ Create a vm in z/VM
   - loaddev: guest_loaddev
   - account: guest_account
   - comment_list: guest_comment_list
+  - meta_data: guest_meta_data
 
 
 * Request sample:

--- a/zvmsdk/api.py
+++ b/zvmsdk/api.py
@@ -1,7 +1,7 @@
 #  Copyright Contributors to the Feilong Project.
 #  SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2017,2022 IBM Corp.
+# Copyright 2017,2023 IBM Corp.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -797,7 +797,7 @@ class SDKAPI(object):
                      ipl_from='', ipl_param='', ipl_loadparam='',
                      dedicate_vdevs=None, loaddev={}, account='',
                      comment_list=None, cschedule='', cshare='',
-                     rdomain='', pcif=''):
+                     rdomain='', pcif='', meta_data=None):
         """create a vm in z/VM
 
         :param userid: (str) the userid of the vm to be created
@@ -954,7 +954,7 @@ class SDKAPI(object):
                                          ipl_from, ipl_param, ipl_loadparam,
                                          dedicate_vdevs, loaddev, account,
                                          comment_list, cschedule, cshare,
-                                         rdomain, pcif)
+                                         rdomain, pcif, meta_data)
 
     @check_guest_exist()
     def guest_live_resize_cpus(self, userid, cpu_cnt):

--- a/zvmsdk/sdkwsgi/handlers/guest.py
+++ b/zvmsdk/sdkwsgi/handlers/guest.py
@@ -1,7 +1,7 @@
 #  Copyright Contributors to the Feilong Project.
 #  SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2017-2020 IBM Corp.
+# Copyright 2017-2023 IBM Corp.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -84,6 +84,8 @@ class VMHandler(object):
             kwargs_list['rdomain'] = guest['rdomain']
         if 'pcif' in guest_keys:
             kwargs_list['pcif'] = guest['pcif']
+        if 'meta_data' in guest_keys:
+            kwargs_list['meta_data'] = guest['meta_data']
 
         info = self.client.send_request('guest_create', userid, vcpus,
                                         memory, **kwargs_list)

--- a/zvmsdk/sdkwsgi/schemas/guest.py
+++ b/zvmsdk/sdkwsgi/schemas/guest.py
@@ -1,7 +1,7 @@
 #  Copyright Contributors to the Feilong Project.
 #  SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2017,2018 IBM Corp.
+# Copyright 2017,2023 IBM Corp.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -42,7 +42,8 @@ create = {
                 'cschedule': parameter_types.cpupool,
                 'cshare': parameter_types.share,
                 'rdomain': parameter_types.rdomain,
-                'pcif': parameter_types.pcif
+                'pcif': parameter_types.pcif,
+                'meta_data': parameter_types.meta_data
             },
             'required': ['userid', 'vcpus', 'memory'],
             'additionalProperties': False,

--- a/zvmsdk/sdkwsgi/validation/parameter_types.py
+++ b/zvmsdk/sdkwsgi/validation/parameter_types.py
@@ -412,6 +412,10 @@ comment_list = {
     }
 }
 
+meta_data = {
+    'type': 'object',
+}
+
 live_migrate_parms = {
     'type': 'object',
     'properties': {

--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -1,7 +1,7 @@
 #  Copyright Contributors to the Feilong Project.
 #  SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2017,2022 IBM Corp.
+# Copyright 2017,2023 IBM Corp.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -610,7 +610,7 @@ class SMTClient(object):
     def create_vm(self, userid, cpu, memory, disk_list, profile,
                   max_cpu, max_mem, ipl_from, ipl_param, ipl_loadparam,
                   dedicate_vdevs, loaddev, account, comment_list,
-                  cschedule='', cshare='', rdomain='', pcif=''):
+                  cschedule='', cshare='', rdomain='', pcif='', meta_data=None):
         """ Create VM and add disks if specified. """
         if memory % 1024 == 0:
             mem = str(int(memory / 1024)) + 'G'
@@ -758,6 +758,7 @@ class SMTClient(object):
                 LOG.error(msg)
                 raise exception.SDKSMTRequestFailed(err.results, msg)
 
+        # TODO: storage meta_data to DB
         # Add the guest to db immediately after user created
         action = "add guest '%s' to database" % userid
         with zvmutils.log_and_reraise_sdkbase_error(action):

--- a/zvmsdk/tests/unit/test_api.py
+++ b/zvmsdk/tests/unit/test_api.py
@@ -178,7 +178,7 @@ class SDKAPITestCase(base.SDKTestCase):
         create_vm.assert_called_once_with(self.userid, vcpus, memory,
                                   disk_list, user_profile, max_cpu, max_mem,
                                   '', '', '', [], {}, '', None, '', '', '',
-                                  '')
+                                  '', None)
 
     @mock.patch("zvmsdk.vmops.VMOps.create_vm")
     def test_guest_create_with_account(self, create_vm):
@@ -196,7 +196,7 @@ class SDKAPITestCase(base.SDKTestCase):
         create_vm.assert_called_once_with(self.userid, vcpus, memory,
                                   disk_list, user_profile, max_cpu, max_mem,
                                   '', '', '', [], {}, account, None, '', '',
-                                  '', '')
+                                  '', '', None)
 
     @mock.patch("zvmsdk.vmops.VMOps.create_vm")
     def test_guest_create_with_cpupool(self, create_vm):
@@ -214,7 +214,7 @@ class SDKAPITestCase(base.SDKTestCase):
         create_vm.assert_called_once_with(self.userid, vcpus, memory,
                                   disk_list, user_profile, max_cpu, max_mem,
                                   '', '', '', [], {}, '', None, cschedule, '',
-                                  '', '')
+                                  '', '', None)
 
     @mock.patch("zvmsdk.vmops.VMOps.create_vm")
     def test_guest_create_with_share(self, create_vm):
@@ -232,7 +232,7 @@ class SDKAPITestCase(base.SDKTestCase):
         create_vm.assert_called_once_with(self.userid, vcpus, memory,
                                   disk_list, user_profile, max_cpu, max_mem,
                                   '', '', '', [], {}, '', None, '', cshare, '',
-                                  '')
+                                  '', None)
 
     @mock.patch("zvmsdk.vmops.VMOps.create_vm")
     def test_guest_create_with_rdomain(self, create_vm):
@@ -250,7 +250,7 @@ class SDKAPITestCase(base.SDKTestCase):
         create_vm.assert_called_once_with(self.userid, vcpus, memory,
                                   disk_list, user_profile, max_cpu, max_mem,
                                   '', '', '', [], {}, '', None, '', '',
-                                  rdomain, '')
+                                  rdomain, '', None)
 
     @mock.patch("zvmsdk.vmops.VMOps.create_vm")
     def test_guest_create_with_pcif(self, create_vm):
@@ -268,7 +268,7 @@ class SDKAPITestCase(base.SDKTestCase):
         create_vm.assert_called_once_with(self.userid, vcpus, memory,
                                   disk_list, user_profile, max_cpu, max_mem,
                                   '', '', '', [], {}, '', None, '', '',
-                                  '', pcif)
+                                  '', pcif, None)
 
     @mock.patch("zvmsdk.vmops.VMOps.create_vm")
     def test_guest_create_with_comment(self, create_vm):
@@ -286,7 +286,7 @@ class SDKAPITestCase(base.SDKTestCase):
         create_vm.assert_called_once_with(self.userid, vcpus, memory,
                                   disk_list, user_profile, max_cpu, max_mem,
                                   '', '', '', [], {}, '', comment_list, '',
-                                  '', '', '')
+                                  '', '', '', None)
 
     @mock.patch("zvmsdk.vmops.VMOps.create_vm")
     def test_guest_create_with_default_profile(self, create_vm):
@@ -303,7 +303,7 @@ class SDKAPITestCase(base.SDKTestCase):
         create_vm.assert_called_once_with(self.userid, vcpus, memory,
                                   disk_list, 'abc', max_cpu, max_mem,
                                   '', '', '', [], {}, '', None, '', '', '',
-                                  '')
+                                  '', None)
 
     @mock.patch("zvmsdk.vmops.VMOps.create_vm")
     def test_guest_create_with_no_disk_pool(self, create_vm):
@@ -336,7 +336,7 @@ class SDKAPITestCase(base.SDKTestCase):
         create_vm.assert_called_once_with(self.userid, vcpus, memory,
                                           disk_list, user_profile, 32, '64G',
                                           '', '', '', [], {}, '', None, '',
-                                          '', '', '')
+                                          '', '', '', None)
 
     @mock.patch("zvmsdk.vmops.VMOps.create_vm")
     def test_guest_create_no_disk_pool_force_mdisk(self, create_vm):
@@ -382,7 +382,7 @@ class SDKAPITestCase(base.SDKTestCase):
         create_vm.assert_called_once_with(self.userid, vcpus, memory,
                                           disk_list, user_profile, 32, '64G',
                                           '', '', '', [], {}, '', None, '',
-                                          '', '', '')
+                                          '', '', '', None)
 
     @mock.patch("zvmsdk.imageops.ImageOps.image_query")
     def test_image_query(self, image_query):

--- a/zvmsdk/tests/unit/test_vmops.py
+++ b/zvmsdk/tests/unit/test_vmops.py
@@ -85,11 +85,11 @@ class SDKVMOpsTestCase(base.SDKTestCase):
         comment_list = ['comment1', 'comment2 is here']
         self.vmops.create_vm(userid, cpu, memory, disk_list, user_profile,
                              max_cpu, max_mem, '', '', '', vdevs, loaddev,
-                             account, comment_list, '', '', '', '')
+                             account, comment_list, '', '', '', '', None)
         create_vm.assert_called_once_with(userid, cpu, memory, disk_list,
                                           user_profile, max_cpu, max_mem,
                                           '', '', '', vdevs, loaddev, account,
-                                          comment_list, '', '', '', '')
+                                          comment_list, '', '', '', '', None)
         namelistadd.assert_called_once_with('TSTNLIST', userid)
 
     @mock.patch("zvmsdk.smtclient.SMTClient.process_additional_minidisks")

--- a/zvmsdk/vmops.py
+++ b/zvmsdk/vmops.py
@@ -1,7 +1,7 @@
 #  Copyright Contributors to the Feilong Project.
 #  SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2017,2022 IBM Corp.
+# Copyright 2017,2023 IBM Corp.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -224,7 +224,7 @@ class VMOps(object):
     def create_vm(self, userid, cpu, memory, disk_list,
                   user_profile, max_cpu, max_mem, ipl_from,
                   ipl_param, ipl_loadparam, dedicate_vdevs, loaddev, account,
-                  comment_list, cschedule, cshare, rdomain, pcif):
+                  comment_list, cschedule, cshare, rdomain, pcif, meta_data):
         """Create z/VM userid into user directory for a z/VM instance."""
         LOG.info("Creating the user directory for vm %s", userid)
 
@@ -234,7 +234,7 @@ class VMOps(object):
                                    ipl_param, ipl_loadparam,
                                    dedicate_vdevs, loaddev, account,
                                    comment_list, cschedule, cshare, rdomain,
-                                   pcif)
+                                   pcif, meta_data)
 
         # add userid into smapi namelist
         self._smtclient.namelist_add(self._namelist, userid)


### PR DESCRIPTION
 Add a parameter meta_data in guest_create

    Add parameter meta_data to support the indicated userid
    when creating the virtual machine.
    userid is used to create the virtual machine and if meta_data
    has data, it includes openstack instance id in a dict:
    {'openstack_instance_id': instance.name}
    This argument can be extended for future use.
