### PR TITLE
Implement the mechanism to return hypervisor hostname with suffix

### DIFF
--- a/zvmsdk/constants.py
+++ b/zvmsdk/constants.py
@@ -146,3 +146,5 @@ FILE_TYPE = {
 
 SDK_DATA_PATH = '/var/lib/zvmsdk/'
 IUCV_AUTH_USERID_PATH = '/etc/zvmsdk/iucv_authorized_userid'
+
+HYPERVISOR_HOSTNAME_SUFFIX_FILE = '.zvmsdk_hypervisor_hostname_suffix'


### PR DESCRIPTION
When "$HOME/.zvmsdk_hypervisor_hostname_suffix" file exists, host_get_info will return zvm_host and hypervisor_hostname as `<hypervisor_hostname>.<suffix>` .

`<suffix>` is read from $HOME/.zvmsdk_hypervisor_hostname_suffix .