### PR TITLE
add_util_to_return_cpc_info

### DIFF
--- a/zvmsdk/tests/unit/test_volumeop.py
+++ b/zvmsdk/tests/unit/test_volumeop.py
@@ -1446,12 +1446,12 @@ class TestFCPVolumeManager(base.SDKTestCase):
 
     @mock.patch("zvmsdk.utils.get_smt_userid")
     @mock.patch("zvmsdk.volumeop.FCPManager._get_all_fcp_info")
-    @mock.patch("zvmsdk.utils.get_lpar_name")
-    def test_get_volume_connector_unreserve(self, get_lpar_name,
+    @mock.patch("zvmsdk.utils.get_zvm_name")
+    def test_get_volume_connector_unreserve(self, get_zvm_name,
                                             get_all_fcp_info,
                                             get_smt_userid):
         """Test get_volume_connector when reserve parameter is False"""
-        get_lpar_name.return_value = "fakehos1"
+        get_zvm_name.return_value = "fakehos1"
         get_smt_userid.return_value = "fakesmt"
         fcp_list = ['opnstk1: FCP device number: A83C',
                     'opnstk1:   Status: Active',
@@ -1522,15 +1522,15 @@ class TestFCPVolumeManager(base.SDKTestCase):
     @mock.patch("zvmsdk.utils.get_pchid_by_chpid")
     @mock.patch("zvmsdk.utils.get_smt_userid")
     @mock.patch("zvmsdk.volumeop.FCPManager.get_all_fcp_pool")
-    @mock.patch("zvmsdk.utils.get_lpar_name")
-    def test_get_volume_connector_reserve(self, get_lpar_name,
+    @mock.patch("zvmsdk.utils.get_zvm_name")
+    def test_get_volume_connector_reserve(self, get_zvm_name,
                                           get_all_fcp_pool,
                                           get_smt_userid,
                                           get_pchid_by_chpid,
                                           print_all_pchids):
         """Test get_volume_connector when reserve parameter is True"""
         print_all_pchids.return_value = None
-        get_lpar_name.return_value = "fakehos1"
+        get_zvm_name.return_value = "fakehos1"
         get_smt_userid.return_value = "fakesmt"
         fcp_list = ['opnstk1: FCP device number: A83C',
                     'opnstk1:   Status: Free',

--- a/zvmsdk/volumeop.py
+++ b/zvmsdk/volumeop.py
@@ -1,7 +1,7 @@
 #  Copyright Contributors to the Feilong Project.
 #  SPDX-License-Identifier: Apache-2.0
-
-#    Copyright 2017, 2022 IBM Corp.
+#
+#    Copyright 2017, 2023 IBM Corp.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -2350,9 +2350,9 @@ class FCPVolumeManager(object):
                 raise exception.SDKVolumeOperationError(
                     rs=11, userid=assigner_id, msg=errmsg)
 
-            # get lpar name of the userid,
+            # get z/VM name of the userid,
             # if no host name got, raise exception
-            zvm_host = zvmutils.get_lpar_name()
+            zvm_host = zvmutils.get_zvm_name()
             if zvm_host == '':
                 errmsg = "failed to get z/VM LPAR name."
                 LOG.error(errmsg)


### PR DESCRIPTION
- By filtering the result of Linux command zhypinfo by layer,
  - :param layer: (str) possible values are cpc, lpar, zvm and all.
  - :return zhyp_info: (dict) contain the layer(s) specified by param layer
    - including cpc name, cpc SN, lpar name, etc.