### PR TITLE
zcc_tool_to_get_pchids_info_from_all_fcp_templates

### DIFF
--- a/scripts/zvmsdk-getpchid
+++ b/scripts/zvmsdk-getpchid
@@ -1,0 +1,167 @@
+#!/usr/bin/python
+#
+#  Copyright Contributors to the Feilong Project.
+#  SPDX-License-Identifier: Apache-2.0
+#
+#    Copyright 2023, 2023 IBM Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+
+import json
+import logging
+import argparse
+from datetime import datetime
+from zvmsdk import database
+from zvmsdk import utils
+from zvmsdk import volumeop
+
+
+LOG = logging.getLogger(__name__)
+LOG_DIR = '/var/log/zvmsdk/'
+LOG_PREFIX = 'zvmsdk-getpchid'
+
+#################################################
+#            Common Utility Methods             #
+#################################################
+
+def _parse_arguments():
+    """Parses the arguments from the command line that was input"""
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter,
+        description='The command is used to get the FCP devices \n'
+                    '(allocated from any FCP multipath template) \n'
+                    'and the PCHIDs information from all FCP multipath templates.\n\n'
+    )
+    return parser.parse_args()
+
+
+def setup_logging():
+    """Setup logging"""
+    timestamp = datetime.now().strftime('%Y-%m-%d-%H%M%S')
+    log_file = '{}{}_{}.log'.format(LOG_DIR, LOG_PREFIX, timestamp)
+    logging.basicConfig(
+        filename=log_file,
+        format='%(asctime)s %(levelname)-8s %(message)s',
+        level=logging.INFO,
+        datefmt='%Y-%m-%d %H:%M:%S'
+    )
+
+
+#################################################
+#            Main Operation Methods             #
+#################################################
+
+def get_fcp_devices_per_pchid():
+    """ Get PCHIDs and FCP devices from all FCP multipath templates
+
+    :return: (dict)
+    example:
+        {
+            "cpc_sn": "0000000000082F57",
+            "cpc_name": "M54",
+            "lpar": "ZVM4OCP3",
+            "hypervisor_hostname": "BOEM5403",
+            "pchids": [
+                {
+                    "pchid": "02E0",
+                    "fcp_devices": "1A01 - 1A03",
+                    "fcp_devices_count": 3
+                },
+                {
+                    "pchid": "03FC",
+                    "fcp_devices": "1B02, 1B05",
+                    "fcp_devices_count": 2
+                },
+                {
+                    "pchid": "0240",
+                    "fcp_devices": "",
+                    "fcp_devices_count": 0
+                },
+                {
+                    "pchid": "0260",
+                    "fcp_devices": "",
+                    "fcp_devices_count": 0
+                }
+            ]
+        }
+    """
+
+    # init FCPManager, which sync FCP DB with the FCP info queried from zVM
+    fcp_mgr = volumeop.FCPManager()
+    # put all related DB queries in one DB session
+    with database.get_fcp_conn():
+        # get the PCHIDs of all the FCP devices
+        # that are included in any FCP multipath template
+        # all_pchids ex: a list of pchids
+        # ['0240', '0260' '03FC', '02E0']
+        all_pchids = fcp_mgr.db.get_pchids_from_all_fcp_templates()
+        # get the PCHIDs of all the inuse FCP devices
+        # inuse_pchids ex:
+        # (dict) PCHIDs as keys, FCP devices as values
+        # {
+        #    '02E0': '1A01 - 1A03',
+        #    '03FC': '1B02, 1B05'
+        # }
+        inuse_pchids = fcp_mgr.db.get_pchids_of_all_inuse_fcp_devices()
+
+    # get the unused PCHIDs
+    # unuse_pchids ex:
+    # ['0240', '0260']
+    unuse_pchids = set(all_pchids) - set(inuse_pchids)
+    # log
+    LOG.info("all pchids in FCP multipath templates: {}".format(all_pchids))
+    LOG.info("inuse pchids in FCP multipath templates: {}".format(inuse_pchids))
+    LOG.info("unused pchids in FCP multipath templates: {}".format(unuse_pchids))
+    # get zhypinfo
+    zhypinfo = utils.get_zhypinfo()
+    cpc_sn = utils.get_cpc_sn(zhypinfo=zhypinfo)
+    cpc_name = utils.get_cpc_name(zhypinfo=zhypinfo)
+    lpar = utils.get_lpar_name(zhypinfo=zhypinfo)
+    hypervisor_hostname = utils.get_zvm_name()
+    # init result
+    result =  {'cpc_sn': cpc_sn,
+               'cpc_name': cpc_name,
+               'hypervisor_hostname': hypervisor_hostname,
+               'lpar': lpar,
+               'pchids': []}
+    # process inuse_pchids
+    for pd in inuse_pchids:
+        item = {
+            'pchid': pd,
+            'fcp_devices': inuse_pchids[pd],
+            'fcp_devices_count': len(
+                utils.expand_fcp_list(inuse_pchids[pd])[0])}
+        result['pchids'].append(item)
+    # process unuse_pchids
+    for pd in unuse_pchids:
+        item = {
+            'pchid': pd,
+            'fcp_devices': '',
+            'fcp_devices_count': 0}
+        result['pchids'].append(item)
+    LOG.info('result : {}'.format(result))
+    return result
+
+#################################################
+#               Main Entry Point                #
+#################################################
+
+if __name__ == "__main__":
+    # Parse the arguments that were provided on the command line
+    _parse_arguments()
+    # setup_logging
+    setup_logging()
+    # Get PCHIDs and FCP devices from all FCP templates
+    result = get_fcp_devices_per_pchid()
+    print(json.dumps(result))

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,7 @@
-# Copyright 2017 IBM Corp.
+#  Copyright Contributors to the Feilong Project.
+#  SPDX-License-Identifier: Apache-2.0
+#
+#    Copyright 2017, 2023 IBM Corp.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -61,7 +64,7 @@ setuptools.setup(
         ]
     },
     scripts=['scripts/sdkserver', 'zvmsdk/sdkwsgi/zvmsdk-wsgi',
-             'scripts/zvmsdk-gentoken'],
+             'scripts/zvmsdk-gentoken', 'scripts/zvmsdk-getpchid'],
     data_files=[('/lib/systemd/system', ['data/sdkserver.service']),
                 ('/var/lib/zvmsdk', ['data/setupDisk']),
                 ('/etc/sudoers.d', ['data/sudoers-zvmsdk']),

--- a/zvmsdk/utils.py
+++ b/zvmsdk/utils.py
@@ -1,7 +1,7 @@
 #  Copyright Contributors to the Feilong Project.
 #  SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2017,2022 IBM Corp.
+# Copyright 2017,2023 IBM Corp.
 # Copyright 2013 NEC Corporation.
 # Copyright 2011 OpenStack Foundation.
 #
@@ -866,7 +866,7 @@ def expand_fcp_list(fcp_list):
 
     Example 2:
     if fcp_list is empty string: '',
-    then the function will return an empty set: {}
+    then the function will return an empty dict: {}
 
     ATTENTION: To support multipath, we expect fcp_list should be like
     "0011-0014;0021-0024", "0011-0014" should have been on same physical


### PR DESCRIPTION
The command zvmsdk-getpchid does the following:
- generates a log in /var/log/zvmsdk/
- returns the PCHIDs and FCP devices from all FCP multipath templates.
- for example:
```json
    {
        "cpc_sn": "0000000000082F57",
        "cpc_name": "M54",
        "hypervisor_hostname": "BOEM5401",
        "lpar": "ZVM4OCP1",
        "pchids": [
            {
                "pchid": "021C",
                "fcp_devices": "1B16 - 1B17",
                "fcp_devices_count": 2
            },
            {
                "pchid": "0260",
                "fcp_devices": "",   <--- no FCP devices is allocated from this PCHID so far via any FCP multipath template
                "fcp_devices_count": 0
            }
        ]
    }
```