### PR TITLE
get_volume_connector_based_on_pchid_info

### DIFF
--- a/zvmsdk/api.py
+++ b/zvmsdk/api.py
@@ -1,7 +1,7 @@
 #  Copyright Contributors to the Feilong Project.
 #  SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2017,2022 IBM Corp.
+# Copyright 2017,2023 IBM Corp.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -1618,19 +1618,24 @@ class SDKAPI(object):
         self._networkops.delete_vswitch(vswitch_name, persist)
 
     def get_volume_connector(self, userid, reserve=False,
-                             fcp_template_id=None, sp_name=None, pchid_info=None):
-        """Get connector information of the guest for attaching volumes.
+                             fcp_template_id=None, sp_name=None, pchid_info=dict()):
+        """Get connector information of the instance for attaching or detaching volumes.
         This API is for Openstack Cinder driver only now.
 
         @param userid: (str) instance userid in z/VM
         @param reserve: (bool) True for attach-volume process, False for detach-volume
         @param fcp_template_id: (str) FCP multipath template ID
         @param sp_name: (str) storage provider hostname
-        @param pchid_info: (dict) PCHID as key
+        @param pchid_info: (dict) it is only needed when reserve is True.
+            PCHID as key,
+            'allocated' means the count of allocated FCP devices from the PCHID
+            'max' means the maximum allowable count of FCP devices that can be allocated from the PCHID
             example:
-            { 'AAAA': { 'total_allocate': 126, 'instance_allocate': 120, 'max': 128},
-              'BBBB': { 'total_allocate': 104, 'instance_allocate': 102, 'max': 110},
-              'CCCC': { 'total_allocate': 100, 'instance_allocate': 100, 'max': 90}}
+            {'AAAA': {'allocated': 126, 'max': 128},
+             'BBBB': {'allocated': 109, 'max': 110},
+             'CCCC': {'allocated': 111, 'max': 128},
+             'DDDD': {'allocated': 113, 'max': 110},
+             'EEEE': {'allocated': 70,  'max': 90}}
         @return: (dict)
             example:
             {

--- a/zvmsdk/database.py
+++ b/zvmsdk/database.py
@@ -24,6 +24,7 @@ import sqlite3
 import threading
 import uuid
 import json
+import itertools
 
 from zvmsdk import config
 from zvmsdk import constants as const
@@ -352,6 +353,12 @@ class FCPDbOperator(object):
         #       note: SQLite recognizes the keywords "TRUE" and "FALSE",
         #       those keywords are saved in SQLite
         #       as integer 1 and 0 respectively
+        #   min_fcp_paths_count:
+        #       the mimimum path count allowed when selecting
+        #       available FCP devices from the template,
+        #       one FCP device per path.
+        #       -1 means the count is the same as the path count of
+        #       the template defined in table template_fcp_mapping
         fcp_info_tables['template'] = (
             "CREATE TABLE IF NOT EXISTS template("
             "id                   varchar(32)  NOT NULL COLLATE NOCASE,"
@@ -826,15 +833,15 @@ class FCPDbOperator(object):
         with get_fcp_conn() as conn:
             result = conn.execute(
                 "SELECT "
-                "fcp.fcp_id, fcp.wwpn_npiv, fcp.wwpn_phy "
-                "FROM template_fcp_mapping "
+                "fcp.fcp_id, fcp.wwpn_npiv, fcp.wwpn_phy, tf.path, fcp.pchid "
+                "FROM template_fcp_mapping AS tf "
                 "INNER JOIN fcp "
-                "ON template_fcp_mapping.fcp_id=fcp.fcp_id "
-                "WHERE template_fcp_mapping.tmpl_id=? "
+                "ON tf.fcp_id=fcp.fcp_id "
+                "WHERE tf.tmpl_id=? "
                 "AND fcp.assigner_id=? "
                 "AND (fcp.connections<>0 OR fcp.reserved<>0) "
                 "AND fcp.tmpl_id=? "
-                "ORDER BY template_fcp_mapping.fcp_id ASC",
+                "ORDER BY tf.fcp_id ASC",
                 (fcp_template_id, assigner_id, fcp_template_id))
             fcp_list = result.fetchall()
 
@@ -844,15 +851,15 @@ class FCPDbOperator(object):
         with get_fcp_conn() as conn:
             result = conn.execute(
                 "SELECT fcp.fcp_id, fcp.wwpn_npiv, "
-                "fcp.wwpn_phy, fcp.connections "
-                "FROM template_fcp_mapping "
+                "fcp.wwpn_phy, fcp.connections, tf.path, fcp.pchid "
+                "FROM template_fcp_mapping AS tf "
                 "INNER JOIN fcp "
-                "ON template_fcp_mapping.fcp_id=fcp.fcp_id "
-                "WHERE template_fcp_mapping.tmpl_id=? "
+                "ON tf.fcp_id=fcp.fcp_id "
+                "WHERE tf.tmpl_id=? "
                 "AND fcp.assigner_id=? "
                 "AND fcp.reserved<>0 "
                 "AND fcp.tmpl_id=? "
-                "ORDER BY template_fcp_mapping.fcp_id ASC",
+                "ORDER BY tf.fcp_id ASC",
                 (fcp_template_id, assigner_id, fcp_template_id))
             fcp_list = result.fetchall()
 
@@ -927,7 +934,7 @@ class FCPDbOperator(object):
                 return fcp_list
             '''
             fcps 2 paths example:
-               fcp  conn reserved
+               fcp  conn reserved state
               ------------------
             [('1a00', 1, 1, 'active'),
              ('1a01', 0, 0, 'free'),
@@ -943,30 +950,29 @@ class FCPDbOperator(object):
              ...           ]
             '''
             result = conn.execute(
-                "SELECT fcp.fcp_id, fcp.connections, "
+                "SELECT fcp.fcp_id, fcp.connections, tf.path, fcp.pchid, "
                 "fcp.reserved, fcp.state, fcp.wwpn_npiv, fcp.wwpn_phy "
                 "FROM fcp "
-                "INNER JOIN template_fcp_mapping "
-                "ON template_fcp_mapping.fcp_id=fcp.fcp_id "
-                "WHERE template_fcp_mapping.tmpl_id=? "
-                "ORDER BY template_fcp_mapping.path, "
-                "template_fcp_mapping.fcp_id", (fcp_template_id,))
+                "INNER JOIN template_fcp_mapping AS tf"
+                "ON tf.fcp_id=fcp.fcp_id "
+                "WHERE tf.tmpl_id=? "
+                "ORDER BY tf.path, tf.fcp_id", (fcp_template_id,))
             fcps = result.fetchall()
         '''
         get all free fcps from 1st path
         fcp_pair_map example:
          idx    fcp_pair
          ----------------
-        { 1 : [('1a01', 'c05076de330003a3', '', 1)],
+        { 1 : [('1a01', 'c0507...', 'c0604...', 0, 'AAAA')],
           2 : ['1a02'],
           3 : ['1a03']}
         '''
         # The FCP count of 1st path
         for i in range(count_per_path[0]):
-            (fcp_no, connections, reserved,
+            (fcp_no, connections, path, pchid, reserved,
              state, wwpn_npiv, wwpn_phy) = fcps[i]
             if connections == reserved == 0 and state == 'free':
-                fcp_pair_map[i] = [(fcp_no, wwpn_npiv, wwpn_phy)]
+                fcp_pair_map[i] = [(fcp_no, wwpn_npiv, wwpn_phy, path, pchid)]
         '''
         select out pairs if member count == path count
         fcp_pair_map example:
@@ -980,13 +986,13 @@ class FCPDbOperator(object):
             for i, c in enumerate(count_per_path[:-1]):
                 s += c
                 # avoid index out of range for per path in fcps[]
-                (fcp_no, connections, reserved,
+                (fcp_no, connections, path, pchid, reserved,
                  state, wwpn_npiv, wwpn_phy) = fcps[s + idx]
                 if (idx < count_per_path[i + 1] and
                         connections == reserved == 0 and
                         state == 'free'):
                     fcp_pair_map[idx].append(
-                        (fcp_no, wwpn_npiv, wwpn_phy))
+                        (fcp_no, wwpn_npiv, wwpn_phy, path, pchid))
                 else:
                     fcp_pair_map.pop(idx)
                     break
@@ -998,75 +1004,351 @@ class FCPDbOperator(object):
         LOG.info("Print at most 5 available FCP groups: {}".format(
             list(fcp_pair_map.values())[:5]))
         if fcp_pair_map:
-            fcp_list = random.choice(sorted(fcp_pair_map.values()))
+            # tmp_list ex:
+            # [(fcp_no, wwpn_npiv, wwpn_phy, path, pchid)
+            #  ('1a03', '.......', '......', 0,   'AAAA'),
+            #  ('1b03', '.......', '......', 1,   'BBBB')]
+            tmp_list = random.choice(sorted(fcp_pair_map.values()))
+            # fcp_list ex:
+            # [{'fcp_id':'1A03', 'path':0, 'pchid':'AAAA', 'wwpn_npiv':'aa', 'wwpn_phy':'xx'},
+            #  {'fcp_id':'1B03', 'path':1, 'pchid':'BBBB', 'wwpn_npiv':'cc', 'wwpn_phy':'zz'}]
+            for fcp in tmp_list:
+                item = {
+                    'fcp_id': fcp[0].upper(),
+                    'wwpn_npiv': fcp[1],
+                    'wwpn_phy': fcp[2],
+                    'path': fcp[3],
+                    'pchid': fcp[4].upper()
+                }
+                fcp_list.append(item)
         else:
             LOG.error("Not eligible FCP group found in FCP DB.")
         return fcp_list
 
-    def get_fcp_devices(self, fcp_template_id):
+    def get_fcp_devices(self, fcp_template_id, pchid_info):
         """ Get a group of available FCPs,
-            which satisfy the following conditions:
-            a. connections = 0
-            b. reserved = 0
-            c. state = free
+        which satisfy the following conditions:
+        a. connections = 0
+        b. reserved = 0
+        c. state = free
+        d. wwpn_npiv IS NOT ''
+        e. wwpn_phy IS NOT ''
+
+        @param fcp_template_id: FCP multipath template ID
+        @param pchid_info:
+          example:
+          { 'AAAA': { 'total_allocate': 128, 'instance_allocate': 106, 'max': 128},
+            'BBBB': { 'total_allocate': 109, 'instance_allocate': 93,  'max': 110},
+            'CCCC': { 'total_allocate': 111, 'instance_allocate': 103, 'max': 128},
+            'DDDD': { 'total_allocate': 113, 'instance_allocate': 102, 'max': 110},
+            'EEEE': { 'total_allocate': 70,  'instance_allocate': 70,  'max': 90}}
+        @return:
+          example:
+          [{'fcp_id':'1B02', 'path':1, 'pchid':'BBBB', 'wwpn_npiv':'aa', 'wwpn_phy':'xx'},
+           {'fcp_id':'1C04', 'path':4, 'pchid':'CCCC', 'wwpn_npiv':'bb', 'wwpn_phy':'yy'},
+           {'fcp_id':'1E05', 'path':5, 'pchid':'EEEE', 'wwpn_npiv':'cc', 'wwpn_phy':'zz'}]
         """
+
+        def _calculate_instance_count(pchid_info ,pchids_per_path_combinations):
+            """ Calculate to-be-created instance count based on PCHID info """
+
+            # free_fcp_count_per_pchid:
+            # PCHID as key, free-FCP-device-count as value. Ex:
+            # {'AAAA': 0, 'BBBB': 1, 'CCCC': 17, 'DDDD': -3, 'EEEE': 20}
+            free_fcp_count_per_pchid = dict()
+            for pchid in pchid_info:
+                free_fcp_count = (pchid_info[pchid]['max'] -
+                                  pchid_info[pchid]['total_allocate'])
+                free_fcp_count_per_pchid[pchid] = free_fcp_count
+            # comb:
+            # path as key, PCHID as value. Ex:
+            # {3: 'CCCC', 4: 'CCCC', 5: 'EEEE'}
+            for comb in pchids_per_path_combinations:
+                # comb_fcp_count_per_pchid:
+                # PCHID as key, occurance-count-in-comb as value. Ex:
+                # {'EEEE': 1, 'CCCC': 2}
+                comb_fcp_count_per_pchid = {
+                    pchid: (list(comb.values()).count(pchid))
+                    for pchid in set(comb.values())}
+                # instance_count:
+                # indicates how many instances can be created if choosing this comb.
+                # take PCHIDs 'EEEE' and 'CCCC' as example:
+                # min(20/1, 17/2) -> min(20, 8.5) -> 8.5
+                instance_count = min(
+                    free_fcp_count_per_pchid[p] / comb_fcp_count_per_pchid[p]
+                    for p in comb_fcp_count_per_pchid)
+                # comb ex:
+                # {3: 'CCCC', 4: 'CCCC', 5: 'EEEE', 'instance_count': 8.5}
+                comb['instance_count'] = instance_count
+            # log
+            LOG.info(
+                'after _calculate_instance_count, pchids_per_path_combinations: '
+                '{}'.format(pchids_per_path_combinations))
+
+        def _remove_invalid_instance_count(pchids_per_path_combinations):
+            """remove the combinations whose instance_count is less than 1"""
+            for comb in pchids_per_path_combinations.copy():
+                if comb['instance_count'] < 1:
+                    pchids_per_path_combinations.remove(comb)
+            # log
+            LOG.info(
+                'after _remove_invalid_instance_count, pchids_per_path_combinations: '
+                '{}'.format(pchids_per_path_combinations))
+
+        def _select_max_instance_count(pchids_per_path_combinations):
+            """ keep only the combinations with max instance count """
+            # max_instance_count ex: 8.5
+            max_instance_count = max(
+                p['instance_count'] for p in pchids_per_path_combinations)
+            # keep only the combinations with max instance count
+            for comb in pchids_per_path_combinations.copy():
+                if comb['instance_count'] != max_instance_count:
+                    pchids_per_path_combinations.remove(comb)
+            # log
+            LOG.info(
+                'after _select_max_instance_count, pchids_per_path_combinations: '
+                '{}'.format(pchids_per_path_combinations))
+
+        def _select_most_distributed_pchids(pchids_per_path_combinations):
+            """ keep only the combinations with most distributed PCHIDs """
+            # pop the instance_count
+            for comb in pchids_per_path_combinations:
+                comb.pop('instance_count')
+            # max_pchid_count ex:
+            # max(3,3,2)
+            max_pchid_count = max(
+                len(set(p.values())) for p in pchids_per_path_combinations)
+            # keep only the combinations with most distributed PCHIDs
+            for comb in pchids_per_path_combinations.copy():
+                if len(set(comb.values())) != max_pchid_count:
+                    pchids_per_path_combinations.remove(comb)
+            # log
+            LOG.info(
+                'after _select_most_distributed_pchids, pchids_per_path_combinations: '
+                '{}'.format(pchids_per_path_combinations))
+
+        def _get_one_random_fcp_combinations(fcp_template_id,
+                                             final_pchid_per_path):
+            """ randomly choose one FCP device per path
+            @param fcp_template_id:
+            @param final_pchid_per_path:
+                ex: {1: 'BBBB', 4: 'CCCC', 5: 'EEEE'}
+            @return: None
+            """
+            LOG.info('final_pchid_per_path: {}'.format(final_pchid_per_path))
+            # pchid_path_filter ex:
+            # (path=1 AND pchid='BBBB') OR (path=4 AND pchid='CCCC')
+            pchid_path_filter = ' OR '.join(
+                "(tf.path={} AND fcp.pchid='{}')"
+                "".format(path, final_pchid_per_path[path])
+                for path in final_pchid_per_path)
+            sql = (
+                "SELECT fcp.fcp_id, fcp.wwpn_npiv, fcp.wwpn_phy, tf.path, fcp.pchid "
+                "FROM template_fcp_mapping as tf "
+                "INNER JOIN fcp "
+                "ON tf.fcp_id=fcp.fcp_id "
+                "WHERE tf.tmpl_id='{}' "
+                "AND fcp.connections=0 "
+                "AND fcp.reserved=0 "
+                "AND fcp.state='free' "
+                "AND fcp.wwpn_npiv IS NOT '' "
+                "AND fcp.wwpn_phy IS NOT '' "
+                "AND ({}) "
+                "ORDER BY tf.path, fcp.pchid, fcp.fcp_id").format(
+                fcp_template_id, pchid_path_filter)
+            with get_fcp_conn() as conn:
+                query_sql = conn.execute(sql)
+                fcps = query_sql.fetchall()
+            # tmp_dict:
+            # path as key, list of FCP devices as value. Ex:
+            # { 1: [{'fcp_id': '1B02', ...}, {'fcp_id': '1B05', ...}, ...],
+            #   4: [{'fcp_id': '1C04', ...}, {'fcp_id': '1C02', ...}, ...],
+            #   5: [{'fcp_id': '1E05', ...}, {'fcp_id': '1E02', ...}, ...]}
+            tmp_dict = {path:[] for path in final_pchid_per_path}
+            for f in fcps:
+                item = {
+                    'fcp_id': f['fcp_id'].upper(),
+                    'wwpn_npiv': f['wwpn_npiv'],
+                    'wwpn_phy': f['wwpn_phy'],
+                    'path': f['path'],
+                    'pchid': f['pchid'].upper()
+                }
+                tmp_dict[f['path']].append(item)
+            # randomly choose one FCP device per path
+            # fcp_comb ex:
+            # [{'fcp_id': '1B02', ...},
+            #  {'fcp_id': '1C04', ...},
+            #  {'fcp_id': '1E05', ...}]
+            fcp_comb = [random.choice(tmp_dict[path]) for path in tmp_dict]
+            # log
+            LOG.info(
+                'after _get_one_random_fcp_combinations, '
+                'fcp_list: {}'.format(fcp_comb))
+            return fcp_comb
+        def _log_for_path_count_comparison():
+            """log for total path, min path, allocated path"""
+            allocated_paths = len(fcp_list)
+            total_path_count = self.get_path_count(fcp_template_id)
+            if allocated_paths < total_path_count:
+                LOG.info("Not all paths of FCP Multipath Template (id={}) "
+                         "have available FCP devices. "
+                         "The count of minimum FCP device path is {}. "
+                         "The count of total paths is {}. "
+                         "The count of paths with available FCP devices is {}, "
+                         "which is less than the total path count."
+                         .format(fcp_template_id, min_path_count,
+                                 total_path_count, allocated_paths))
+                if allocated_paths >= min_path_count:
+                    LOG.warning("The count of paths with available FCP devices "
+                                "is less than that of total path, but not less "
+                                "than that of minimum FCP device path. "
+                                "Return the FCP devices {} from the available "
+                                "paths to continue.".format(fcp_list))
+                else:
+                    LOG.error("The count of paths with available FCP devices "
+                              "must not be less than that of minimum FCP device "
+                              "path, return empty list to abort the volume attachment.")
+
         fcp_list = []
-        with get_fcp_conn() as conn:
-            min_fcp_paths_count = self.get_min_fcp_paths_count(fcp_template_id)
-            # Get distinct path list in DB
-            result = conn.execute("SELECT DISTINCT path "
-                                  "FROM template_fcp_mapping "
-                                  "WHERE tmpl_id=?", (fcp_template_id,))
-            path_list = result.fetchall()
-            # Get fcp_list of every path
-            for no in path_list:
-                result = conn.execute(
-                    "SELECT fcp.fcp_id, fcp.wwpn_npiv, fcp.wwpn_phy "
-                    "FROM template_fcp_mapping "
-                    "INNER JOIN fcp "
-                    "ON template_fcp_mapping.fcp_id=fcp.fcp_id "
-                    "WHERE template_fcp_mapping.tmpl_id=? "
-                    "AND fcp.connections=0 "
-                    "AND fcp.reserved=0 "
-                    "AND fcp.state='free' "
-                    "AND template_fcp_mapping.path=? "
-                    "AND fcp.wwpn_npiv IS NOT '' "
-                    "AND fcp.wwpn_phy IS NOT '' "
-                    "ORDER BY template_fcp_mapping.path",
-                    (fcp_template_id, no[0]))
-                fcps = result.fetchall()
-                if not fcps:
-                    # continue to find whether
-                    # other paths has available FCP
-                    continue
-                index = random.randint(0, len(fcps) - 1)
-                fcp_list.append(fcps[index])
-        # Start to check whether the available count >= min_fcp_paths_count
-        allocated_paths = len(fcp_list)
-        total_paths = len(path_list)
-        if allocated_paths < total_paths:
-            LOG.info("Not all paths of FCP Multipath Template (id={}) "
-                     "have available FCP devices. "
-                     "The count of minimum FCP device path is {}. "
-                     "The count of total paths is {}. "
-                     "The count of paths with available FCP devices is {}, "
-                     "which is less than the total path count."
-                     .format(fcp_template_id, min_fcp_paths_count,
-                             total_paths, allocated_paths))
-            if allocated_paths >= min_fcp_paths_count:
-                LOG.warning("The count of paths with available FCP devices "
-                            "is less than that of total path, but not less "
-                            "than that of minimum FCP device path. "
-                            "Return the FCP devices {} from the available "
-                            "paths to continue.".format(fcp_list))
-                return fcp_list
-            else:
-                LOG.error("The count of paths with available FCP devices "
-                          "must not be less than that of minimum FCP device "
-                          "path, return empty list to abort the volume attachment.")
-                return []
-        else:
-            return fcp_list
+        with get_fcp_conn():
+            # min_path_count ex: 2
+            min_path_count = self.db.get_min_fcp_paths_count(fcp_template_id)
+            # free_pchids_per_path:
+            # path as key, PCHID (that have free FCP devices) as value. Ex:
+            #   { 1: ['AAAA', 'BBBB'],
+            #     3: ['CCCC'],
+            #     4: ['CCCC', 'DDDD'],
+            #     5: ['EEEE']}
+            # In the example,
+            # both path-3 and path-4 have free FCP devices from PCHID 'CCCC',
+            # but the FCP devices in path-3 must differ from that in path-4,
+            # because, for each template, one FCP device can only belong to one path.
+            free_pchids_per_path = self.db.get_free_pchids_by_fcp_template(fcp_template_id)
+            # free_path_count ex: 4
+            free_path_count = len(free_pchids_per_path)
+            # free_path_idx ex: [1, 3, 4, 5]
+            free_path_idx = sorted(list(free_pchids_per_path))
+            # path_count_choices:
+            # if min_path_count > free_path_count:
+            #   []
+            # otherwise for example:
+            #   [4, 3, 2] rather than [2, 3, 4]
+            #   because we want to select FCP devices on as more paths as possible
+            path_count_choices = reversed(range(min_path_count, free_path_count + 1))
+            # loop for each possible path count, bigest first,
+            # because we want to select FCP devices on as more paths as possible
+            for path_cnt in path_count_choices:
+                # path_cnt      path_idx_combinations
+                # -----------------------------------
+                # 4             [(1, 3, 4, 5)]
+                # 3             [(1, 3, 4), (1, 3, 5), (1, 4, 5), (3, 4, 5)]
+                # 2             ...
+                path_idx_combinations = list(
+                    itertools.combinations(free_path_idx, path_cnt))
+                # pchids_per_path_combinations:
+                # a list of dicts with path as key and PCHID as value
+                # path_cnt      pchids_per_path_combinations
+                # -----------------------------------
+                # 3            [{1: 'AAAA', 3: 'CCCC', 4: 'CCCC'},
+                #               {1: 'AAAA', 3: 'CCCC', 4: 'DDDD'},
+                #               {1: 'BBBB', 3: 'CCCC', 4: 'CCCC'},
+                #               {1: 'BBBB', 3: 'CCCC', 4: 'DDDD'},
+                #               {1: 'AAAA', 3: 'CCCC', 5: 'EEEE'},
+                #               {1: 'BBBB', 3: 'CCCC', 5: 'EEEE'},
+                #               {1: 'AAAA', 4: 'CCCC', 5: 'EEEE'},
+                #               {1: 'AAAA', 4: 'DDDD', 5: 'EEEE'},
+                #               {1: 'BBBB', 4: 'CCCC', 5: 'EEEE'},
+                #               {1: 'BBBB', 4: 'DDDD', 5: 'EEEE'},
+                #               {3: 'CCCC', 4: 'CCCC', 5: 'EEEE'},
+                #               {3: 'CCCC', 4: 'DDDD', 5: 'EEEE'}]
+                pchids_per_path_combinations = list()
+                for path_idx_comb in path_idx_combinations:
+                    # path_idx_comb  pchids_per_path_comb
+                    # -------------------------------
+                    # (1, 3, 4)      [['AAAA', 'BBBB'],
+                    #                 ['CCCC'],
+                    #                 ['CCCC', 'DDDD']]
+                    pchids_per_path_comb = [free_pchids_per_path[idx]
+                                            for idx in path_idx_comb]
+                    # path_idx_comb     tmp_pchid_comb
+                    # -------------------------------
+                    # (1, 3, 4)         [('AAAA', 'CCCC', 'CCCC'),
+                    #                    ('AAAA', 'CCCC', 'DDDD'),
+                    #                    ('BBBB', 'CCCC', 'CCCC'),
+                    #                    ('BBBB', 'CCCC', 'DDDD')]
+                    tmp_pchid_comb = list(itertools.product(*pchids_per_path_comb))
+                    # tmp_pchid_comb_with_path:
+                    # a list of dicts with path as key and PCHID as value
+                    # path_idx_comb     tmp_pchid_comb_with_path
+                    # -------------------------------
+                    # (1, 3, 4)         [{1: 'AAAA', 3: 'CCCC', 4: 'CCCC'},
+                    #                    {1: 'AAAA', 3: 'CCCC', 4: 'DDDD'},
+                    #                    {1: 'BBBB', 3: 'CCCC', 4: 'CCCC'},
+                    #                    {1: 'BBBB', 3: 'CCCC', 4: 'DDDD'}]
+                    tmp_pchid_comb_with_path = [
+                        dict(zip(path_idx_comb, comb)) for comb in tmp_pchid_comb]
+                    pchids_per_path_combinations.extend(tmp_pchid_comb_with_path)
+                # calculate to-be-created instance count for each combination,
+                # afterwards, instance_count is added, ex:
+                # path_cnt pchids_per_path_combinations
+                # -----------------------------------
+                # 3        [{1: 'AAAA', 3: 'CCCC', 4: 'CCCC', 'instance_count': 0.0},
+                #           {1: 'AAAA', 3: 'CCCC', 4: 'DDDD', 'instance_count': -3.0},
+                #           {1: 'BBBB', 3: 'CCCC', 4: 'CCCC', 'instance_count': 1.0},
+                #           {1: 'BBBB', 3: 'CCCC', 4: 'DDDD', 'instance_count': -3.0},
+                #           {1: 'AAAA', 3: 'CCCC', 5: 'EEEE', 'instance_count': 8.5},
+                #           {1: 'BBBB', 3: 'CCCC', 5: 'EEEE', 'instance_count': 1.0},
+                #           {1: 'AAAA', 4: 'CCCC', 5: 'EEEE', 'instance_count': 0.0},
+                #           {1: 'AAAA', 4: 'DDDD', 5: 'EEEE', 'instance_count': -3.0},
+                #           {1: 'BBBB', 4: 'CCCC', 5: 'EEEE', 'instance_count': 8.5},
+                #           {1: 'BBBB', 4: 'DDDD', 5: 'EEEE', 'instance_count': -3.0},
+                #           {3: 'CCCC', 4: 'CCCC', 5: 'EEEE', 'instance_count': 8.5},
+                #           {3: 'CCCC', 4: 'DDDD', 5: 'EEEE', 'instance_count': -3.0}]
+                _calculate_instance_count(pchid_info, pchids_per_path_combinations)
+                # remove the combinations
+                # whose instance_count is less than 1, ex:
+                # path_cnt pchids_per_path_combinations
+                # -----------------------------------
+                # 3        [{1: 'BBBB', 3: 'CCCC', 4: 'CCCC', 'instance_count': 1.0},
+                #           {1: 'AAAA', 3: 'CCCC', 5: 'EEEE', 'instance_count': 8.5},
+                #           {1: 'BBBB', 3: 'CCCC', 5: 'EEEE', 'instance_count': 1.0},
+                #           {1: 'BBBB', 4: 'CCCC', 5: 'EEEE', 'instance_count': 8.5},
+                #           {3: 'CCCC', 4: 'CCCC', 5: 'EEEE', 'instance_count': 8.5}]
+                _remove_invalid_instance_count(pchids_per_path_combinations)
+                # _select_max_instance_count must be called before
+                # _select_most_distributed_pchids, because we treat
+                # _select_max_instance_count with higher priority
+                if pchids_per_path_combinations:
+                    # keep only the combinations with max instance count
+                    # path_cnt pchids_per_path_combinations
+                    # -----------------------------------
+                    # 3        [{1: 'BBBB', 4: 'CCCC', 5: 'EEEE', 'instance_count': 8.5},
+                    #           {1: 'AAAA', 3: 'CCCC', 5: 'EEEE', 'instance_count': 8.5},
+                    #           {3: 'CCCC', 4: 'CCCC', 5: 'EEEE', 'instance_count': 8.5}]
+                    _select_max_instance_count(pchids_per_path_combinations)
+                    # keep only the combinations with most distributed PCHIDs
+                    # path_cnt pchids_per_path_combinations
+                    # -----------------------------------
+                    # 3        [{1: 'BBBB', 4: 'CCCC', 5: 'EEEE'},
+                    #           {1: 'AAAA', 3: 'CCCC', 5: 'EEEE'}]
+                    _select_most_distributed_pchids(pchids_per_path_combinations)
+                    # random select one from the final candidate combinations
+                    # path_cnt final_pchid_per_path
+                    # -----------------------------------
+                    # 3        {1: 'BBBB', 4: 'CCCC', 5: 'EEEE'}
+                    final_pchid_per_path = random.choice(pchids_per_path_combinations)
+                    # randomly choose one FCP device per path
+                    # fcp_list ex:
+                    # [{'fcp_id':'1B02', 'path':1, 'pchid':'BBBB', 'wwpn_npiv':'aa', 'wwpn_phy':'xx'},
+                    #  {'fcp_id':'1C04', 'path':4, 'pchid':'CCCC', 'wwpn_npiv':'bb', 'wwpn_phy':'yy'},
+                    #  {'fcp_id':'1E05', 'path':5, 'pchid':'EEEE', 'wwpn_npiv':'cc', 'wwpn_phy':'zz'}]
+                    fcp_list = _get_one_random_fcp_combinations(
+                        fcp_template_id, final_pchid_per_path)
+                    break
+            # Log for different path count comparison
+            _log_for_path_count_comparison()
+        # return
+        return fcp_list
 
     def create_fcp_template(self, fcp_template_id, name, description,
                             fcp_devices_by_path, host_default,
@@ -1133,7 +1415,7 @@ class FCPDbOperator(object):
             if host_default is True:
                 conn.execute("UPDATE template SET is_default=?", (False,))
             # 2. insert a new record in template table
-            #    if min_fcp_paths_count is None, will not insert it to db
+            #    if min_fcp_paths_count is None, -1 will be used as the default
             if not min_fcp_paths_count:
                 tmpl_basics = (fcp_template_id, name, description, host_default)
                 sql = ("INSERT INTO template (id, name, description, "
@@ -1184,8 +1466,13 @@ class FCPDbOperator(object):
                 raise exception.SDKConflictError(modID=self._module_id, rs=23, msg=msg)
 
     def get_min_fcp_paths_count(self, fcp_template_id):
-        """ Get min_fcp_paths_count, query template table first, if it is -1, then return the
-            value of fcp devices path count from template_fcp_mapping table. If it is None, raise error.
+        """ Get min_fcp_paths_count from FCP multipath template
+
+        @param fcp_template_id: (str) id of FCP multipath template
+        @return: (integer)
+            If it is -1, return path count of the template from template_fcp_mapping table.
+            otherwise, return the min_fcp_paths_count from template table.
+            If it is None, raise error.
         """
         if not fcp_template_id:
             min_fcp_paths_count = None
@@ -1495,7 +1782,7 @@ class FCPDbOperator(object):
                 "ORDER BY pchid")
             # already ORDER BY pchid in SQL
             # inuse_fcp_devices ex:
-            # [ each item is a sqlite3.Row object, dict-style
+            # [ each item is a sqlite3.Row object in dict-style
             #   {'pchid': '02E0',  'fcp_id': '1A01'},
             #   {'pchid': '02E0',  'fcp_id': '1A02'},
             #   {'pchid': '02E0',  'fcp_id': '1A03'},
@@ -1570,6 +1857,45 @@ class FCPDbOperator(object):
             raw = result.fetchall()
             for item in raw:
                 pchids.append(item['pchid'].upper())
+        return pchids
+
+    def get_free_pchids_by_fcp_template(self, fcp_template_id):
+        """Get PCHIDs that have free FCP devices per path of the template
+
+        :param fcp_template_id: (str) id of FCP Multipath Template
+
+        :return pchids: (dict) path number as key, PCHIDs as value
+            for example:
+            {'1': ['01E0', '02A0'],
+             '3': ['02A0', '03FC']}
+        """
+        pchids = dict()
+        with get_fcp_conn() as conn:
+            result = conn.execute(
+                "SELECT DISTINCT path, pchid "
+                "FROM template_fcp_mapping AS tf "
+                "INNER JOIN fcp "
+                "ON tf.fcp_id=fcp.fcp_id "
+                "WHERE tf.tmpl_id=? "
+                "AND fcp.connections=0 "
+                "AND fcp.reserved=0 "
+                "AND fcp.state='free' "
+                "AND fcp.wwpn_npiv IS NOT '' "
+                "AND fcp.wwpn_phy IS NOT '' "
+                "ORDER BY path, pchid", (fcp_template_id,))
+
+            # free_pchids_per_path ex:
+            # [ each item is a sqlite3.Row object in dict-style
+            #   {'pchid': '01E0',  'path': '1'},
+            #   {'pchid': '02A0',  'path': '1'},
+            #   {'pchid': '02A0',  'path': '3'},
+            #   {'pchid': '03FC',  'path': '3'} ]
+            free_pchids_per_path = result.fetchall()
+            for item in free_pchids_per_path:
+                if item['path'] in pchids:
+                    pchids[item['path']].append(item['pchid'].upper())
+                else:
+                    pchids[item['path']] = []
         return pchids
 
     def get_host_default_fcp_template(self, host_default=True):

--- a/zvmsdk/sdkwsgi/schemas/volume.py
+++ b/zvmsdk/sdkwsgi/schemas/volume.py
@@ -1,7 +1,7 @@
 #  Copyright Contributors to the Feilong Project.
 #  SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2017,2022 IBM Corp.
+# Copyright 2017,2023 IBM Corp.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -124,7 +124,8 @@ get_volume_connector = {
             'properties': {
                 'reserve': parameter_types.boolean,
                 'fcp_template_id': parameter_types.fcp_template_id,
-                'storage_provider': parameter_types.name
+                'storage_provider': parameter_types.name,
+                'pchid_info': {'type': 'object'}
             },
             'required': ['info'],
             'additionalProperties': False,

--- a/zvmsdk/tests/unit/sdkwsgi/handlers/test_volume.py
+++ b/zvmsdk/tests/unit/sdkwsgi/handlers/test_volume.py
@@ -191,14 +191,16 @@ class HandlersVolumeTest(unittest.TestCase):
         mock_send_request.return_value = {'overallRC': 0}
         mock_path_item.return_value = 'fakeuser'
         info = {'reserve': True,
-                'fcp_template_id': 'faketmpl'}
+                'fcp_template_id': 'faketmpl',
+                'pchid_info': dict()}
         body_str = {"info": info}
         self.req.body = json.dumps(body_str)
         # to pass validataion.query_schema
         self.req.environ['wsgiorg.routing_args'] = (
             (), {'userid': 'fakeuser'})
         volume.get_volume_connector(self.req)
-        mock_send_request.assert_called_once_with('get_volume_connector', 'fakeuser', True, 'faketmpl', None)
+        mock_send_request.assert_called_once_with(
+            'get_volume_connector', 'fakeuser', True, 'faketmpl', None, dict())
 
     @mock.patch.object(util, 'wsgi_path_item')
     @mock.patch('zvmconnector.connector.ZVMConnector.send_request')

--- a/zvmsdk/tests/unit/sdkwsgi/test_handler.py
+++ b/zvmsdk/tests/unit/sdkwsgi/test_handler.py
@@ -794,7 +794,7 @@ class VolumeHandlerTest(unittest.TestCase):
         with mock.patch(function) as get_volume_connector:
             get_volume_connector.return_value = {'overallRC': 0}
             h(self.env, dummy)
-            get_volume_connector.assert_called_once_with(mock.ANY, 'test0001', True, None, None)
+            get_volume_connector.assert_called_once_with(mock.ANY, 'test0001', True, None, None, {})
 
     @mock.patch('zvmsdk.sdkwsgi.util.extract_json')
     @mock.patch.object(tokens, 'validate')

--- a/zvmsdk/volumeop.py
+++ b/zvmsdk/volumeop.py
@@ -102,10 +102,10 @@ class VolumeOperatorAPI(object):
                                             fcp_template_id=fcp_template_id)
 
     def get_volume_connector(self, assigner_id, reserve,
-                             fcp_template_id=None, sp_name=None):
+                             fcp_template_id=None, sp_name=None, pchid_info=None):
         return self._volume_manager.get_volume_connector(
             assigner_id, reserve, fcp_template_id=fcp_template_id,
-            sp_name=sp_name)
+            sp_name=sp_name, pchid_info=pchid_info)
 
     def check_fcp_exist_in_db(self, fcp, raise_exec=True):
         return self._volume_manager.check_fcp_exist_in_db(fcp, raise_exec)
@@ -624,27 +624,37 @@ class FCPManager(object):
         """
         self.db.unreserve_fcps(fcp_list)
 
-    def allocate_fcp_devices(self, assigner_id, fcp_template_id, sp_name):
-        """
-        Allocate and reserve FCP devices by assigner_id and fcp_template_id. In this method:
+    def allocate_fcp_devices(self, assigner_id, fcp_template_id,
+                                        sp_name, pchid_info):
+        """ Allocate and reserve FCP devices by assigner_id and fcp_template_id
+        In this method:
         1. If fcp_template_id is specified, then use it. If not, get the sp
            default FCP Multipath Template, if no sp default template, use host default
            FCP Multipath Template.
            If host default template is not found, then raise error.
         2. Get FCP list from db by assigner and fcp_template whose reserve=1
         3. If fcp_list is not empty, just to use them.
-        4. If fcp_list is empty, get one from each path,
+        4. If fcp_list is empty, get one from each path based on pchid_info,
            then update 'reserved' and 'tmpl_id' in fcp table.
 
-        Returns: fcp_list and fcp_template_id.
-                 The fcp list data structure: [(fcp_id, wwpn_npiv, wwpn_phy)].
-                 An example of fcp_list:
-                 [('1c10', 'c12345abcdefg1', 'c1234abcd33002641'),
-                 ('1d10', 'c12345abcdefg2', 'c1234abcd33002641')]
+        @param assigner_id: instance userid
+        @param fcp_template_id: FCP multipath template ID
+        @param sp_name: storage provider hostname
+        @param pchid_info:
+            example:
+            { 'AAAA': { 'total_allocate': 126, 'instance_allocate': 120, 'max': 128},
+              'BBBB': { 'total_allocate': 104, 'instance_allocate': 102, 'max': 110},
+              'CCCC': { 'total_allocate': 100, 'instance_allocate': 100, 'max': 90}}
+        @return: is_reserved_changed, fcp_list and fcp_template_id.
+            An example of fcp_list:
+            [{'fcp_id':'1B02', 'path':1, 'pchid':'BBBB', 'wwpn_npiv':'aa', 'wwpn_phy':'xx'},
+             {'fcp_id':'1C04', 'path':4, 'pchid':'CCCC', 'wwpn_npiv':'bb', 'wwpn_phy':'yy'},
+             {'fcp_id':'1E05', 'path':5, 'pchid':'EEEE', 'wwpn_npiv':'cc', 'wwpn_phy':'zz'}]
         """
+        is_reserved_changed = False
         with database.get_fcp_conn():
-            fcp_tmpl_id = fcp_template_id
-            if not fcp_tmpl_id:
+
+            if not fcp_template_id:
                 LOG.info("FCP Multipath Template id is not specified when reserving FCP "
                          "devices for assigner %s." % assigner_id)
                 if sp_name:
@@ -658,8 +668,8 @@ class FCPManager(object):
                                                               assigner_id))
                     default_tmpl = self.db.get_host_default_fcp_template()
                 if default_tmpl:
-                    fcp_tmpl_id = default_tmpl[0][0]
-                    LOG.info("The default FCP Multipath Template id is %s." % fcp_tmpl_id)
+                    fcp_template_id = default_tmpl[0][0]
+                    LOG.info("The default FCP Multipath Template id is %s." % fcp_template_id)
                 else:
                     errmsg = ("No FCP Multipath Template is specified and "
                               "no default FCP Multipath Template is found.")
@@ -669,67 +679,69 @@ class FCPManager(object):
                                                             msg=errmsg)
 
             try:
-                # go here, means try to attach volumes
-                # first check whether this userid already has a FCP device
-                # get the FCP devices belongs to assigner_id
+                # get the FCP devices allocated to the userid if any
                 fcp_list = self.db.get_allocated_fcps_from_assigner(
-                    assigner_id, fcp_tmpl_id)
-                LOG.info("Previously allocated records %s for "
+                    assigner_id, fcp_template_id)
+                LOG.info("Previously allocated FCP devices %s for "
                          "instance %s in FCP Multipath Template %s." %
                          ([f['fcp_id'] for f in fcp_list],
-                          assigner_id, fcp_tmpl_id))
+                          assigner_id, fcp_template_id))
                 if not fcp_list:
                     # Sync DB to update FCP state,
                     # so that allocating new FCPs is based on the latest FCP state
                     self._sync_db_with_zvm()
                     # allocate new ones if fcp_list is empty
-                    LOG.info("There is no allocated FCP devices for virtual machine %s, "
+                    LOG.info("There is no previously allocated FCP devices for the instance %s, "
                              "allocating new ones." % assigner_id)
                     if CONF.volume.get_fcp_pair_with_same_index:
                         '''
                         If use get_fcp_pair_with_same_index,
-                        then fcp pair is randomly selected from below combinations.
+                        then FCP devices are randomly selected from below combinations,
+                        one FCP device per path, ex:
                         [fa00,fb00],[fa01,fb01],[fa02,fb02]
                         '''
-                        free_unreserved = self.db.get_fcp_devices_with_same_index(
-                            fcp_tmpl_id)
+                        fcp_list = self.db.get_fcp_devices_with_same_index(
+                            fcp_template_id)
                     else:
                         '''
                         If use get_fcp_pair,
-                        then fcp pair is randomly selected from below combinations.
+                        then FCP devices are randomly selected from below combinations,
+                        one FCP device per path, ex:
                         [fa00,fb00],[fa01,fb00],[fa02,fb00]
                         [fa00,fb01],[fa01,fb01],[fa02,fb01]
                         [fa00,fb02],[fa01,fb02],[fa02,fb02]
                         '''
-                        free_unreserved = self.db.get_fcp_devices(fcp_tmpl_id)
-                    if not free_unreserved:
-                        return [], fcp_tmpl_id
-                    available_list = free_unreserved
-                    fcp_ids = [fcp[0] for fcp in free_unreserved]
+                        fcp_list = self.db.get_fcp_devices(fcp_template_id, pchid_info)
+                    # process empty fcp_list
+                    if not fcp_list:
+                        return is_reserved_changed, [], fcp_template_id
                     # record the assigner id in the fcp DB so that
                     # when the vm provision with both root and data volumes
                     # the root and data volume would get the same FCP devices
                     # with the get_volume_connector call.
+                    fcp_ids = [fcp['fcp_id'] for fcp in fcp_list]
                     assigner_id = assigner_id.upper()
-                    self.db.reserve_fcps(fcp_ids, assigner_id, fcp_tmpl_id)
-                    LOG.info("Newly allocated %s fcp for %s assigner "
+                    self.db.reserve_fcps(fcp_ids, assigner_id, fcp_template_id)
+                    is_reserved_changed = True
+                    LOG.info("Newly allocated %s FCP devices for instance %s "
                              "and FCP Multipath Template %s" %
-                             (fcp_ids, assigner_id, fcp_tmpl_id))
+                             (fcp_ids, assigner_id, fcp_template_id))
                 else:
                     # reuse the old ones if fcp_list is not empty
-                    LOG.info("Found allocated fcps %s for %s in FCP Multipath Template %s, "
+                    LOG.info("Found previously allocated FCP devices %s "
+                             "for instance %s in FCP Multipath Template %s, "
                              "will reuse them."
                              % ([f['fcp_id'] for f in fcp_list],
-                                assigner_id, fcp_tmpl_id))
-                    path_count = self.db.get_path_count(fcp_tmpl_id)
+                                assigner_id, fcp_template_id))
+                    path_count = self.db.get_path_count(fcp_template_id)
                     if len(fcp_list) != path_count:
-                        LOG.warning("FCPs previously assigned to %s includes %s, "
-                                    "it is not equal to the path count: %s." %
+                        LOG.warning("FCP devices previously allocated to instance %s are %s, "
+                                    "it is not equal to the total path count (%s) "
+                                    "of the FCP Multipath Template." %
                                     (assigner_id, fcp_list, path_count))
                     self._valid_fcp_devcie_wwpn(fcp_list, assigner_id)
-                    # we got it from db, let's reuse it
-                    available_list = fcp_list
-                return available_list, fcp_tmpl_id
+                # return
+                return is_reserved_changed, fcp_list, fcp_template_id
             except Exception as err:
                 errmsg = ("Failed to reserve FCP devices "
                           "for assigner %s by FCP Multipath Template %s error: %s"
@@ -750,13 +762,15 @@ class FCPManager(object):
            and then set reserved=0 in fcp table in db
         3. If fcp_list is empty, return empty list
 
-        Returns: The fcp list data structure:
-           [(fcp_id, wwpn_npiv, wwpn_phy, connections)].
+        Returns: is_reserved_changed and fcp_list
+            The fcp list data structure:
+                [(fcp_id, wwpn_npiv, wwpn_phy, connections, path, pchid), ...].
             An example of fcp_list:
-            [('1c10', 'c12345abcdefg1', 'c1234abcd33002641', 1),
-             ('1d10', 'c12345abcdefg2', 'c1234abcd33002641', 0)]
-            If no fcp can be gotten from db, return empty list.
+                [('1c10', 'c12345abcdefg1', 'c1234abcd33002641', 1, 0, 'AAAA'),
+                 ('1d10', 'c12345abcdefg2', 'c1234abcd33002641', 0, 0, 'BBBB')]
+                If no fcp can be gotten from db, return empty list.
         """
+        is_reserved_changed = False
         with database.get_fcp_conn():
             try:
                 if fcp_template_id is None:
@@ -771,17 +785,19 @@ class FCPManager(object):
                 if fcp_list:
                     self._valid_fcp_devcie_wwpn(fcp_list, assigner_id)
                     # the data structure of fcp_list is
-                    # [(fcp_id, wwpn_npiv, wwpn_phy, connections)]
+                    # [(fcp_id, wwpn_npiv, wwpn_phy, connections, path, pchid)]
                     # only unreserve the fcp with connections=0
                     fcp_ids = [fcp['fcp_id'] for fcp in fcp_list
                                if fcp['connections'] == 0]
                     if fcp_ids:
                         self.db.unreserve_fcps(fcp_ids)
+                        is_reserved_changed = True
                         LOG.info("Unreserve fcp device %s from "
                                  "instance %s and FCP Multipath Template %s."
                                  % (fcp_ids, assigner_id, fcp_template_id))
-                    return fcp_list
-                return []
+                    return is_reserved_changed, fcp_list
+                else:
+                    return is_reserved_changed, []
             except Exception as err:
                 errmsg = ("Failed to unreserve FCP devices for "
                           "assigner %s by FCP Multipath Template %s. Error: %s"
@@ -2470,98 +2486,154 @@ class FCPVolumeManager(object):
 
     @utils.synchronized('volumeAttachOrDetach-{assigner_id}')
     def get_volume_connector(self, assigner_id, reserve,
-                             fcp_template_id=None, sp_name=None):
-        """Get connector information of the instance for attaching to volumes.
+                             fcp_template_id=None, sp_name=None, pchid_info=None):
+        """Get connector information of the instance for attaching volumes.
 
-        Connector information is a dictionary representing the Fibre
-        Channel(FC) port(s) that will be making the connection.
-        The properties of FC port(s) are as follows::
-        {
-            'zvm_fcp': [fcp1, fcp2]
-            'wwpns': [npiv_wwpn1, npiv_wwpn2]
-            'phy_to_virt_initiators':{
-                npiv_wwpn1: phy_wwpn1,
-                npiv_wwpn2: phy_wwpn2,
+        @param assigner_id: (str) instance userid in z/VM
+        @param reserve: (bool) True for attach-volume process, False for detach-volume
+        @param fcp_template_id: (str) FCP multipath template ID
+        @param sp_name: (str) storage provider hostname
+        @param pchid_info: (dict) PCHID as key
+            example:
+            { 'AAAA': { 'total_allocate': 126, 'instance_allocate': 120, 'max': 128},
+              'BBBB': { 'total_allocate': 104, 'instance_allocate': 102, 'max': 110},
+              'CCCC': { 'total_allocate': 100, 'instance_allocate': 100, 'max': 90}}
+        @return: (dict)
+            example:
+            {
+                'zvm_fcp': [fcp1, fcp2, fcp3]
+                'wwpns': [npiv_wwpn1, npiv_wwpn2, npiv_wwpn3]
+                'phy_to_virt_initiators':{
+                    npiv_wwpn1: phy_wwpn1,
+                    npiv_wwpn2: phy_wwpn2,
+                    npiv_wwpn3: phy_wwpn3
+                }
+                'host': LPARname_VMuserid, # the name to be used by storage provider
+                'fcp_paths': 3,            # the count of fcp paths
+                'fcp_template_id': '123',  # if user doesn't specify it,
+                                             it is either the SP default or the host
+                                             default template id
+                'cpc_sn': '8257',
+                'cpc_name': 'M54',
+                'lpar': 'ZVM4OCP1',
+                "hypervisor_hostname": "BOEM5401",
+                'pchid_fcp_map': {
+                    'A': [fcp1, fcp2],
+                    'B': [fcp3]
+                },
+                'is_reserved_changed': True  # True for either attaching 1st volume to
+                                               or detaching last volume from
+                                               the VM (assigner_id)
+                                               through this template (fcp_template_id)
             }
-            'host': LPARname_VMuserid,
-            'fcp_paths': 2,            # the count of fcp paths
-            'fcp_template_id': fcp_template_id # if user doesn't specify it,
-                               it is either the SP default or the host
-                               default template id
-        }
         """
-        with database.get_fcp_conn():
-            if fcp_template_id and \
-                    not self.db.fcp_template_exist_in_db(fcp_template_id):
+
+        LOG.info("pchid_info: {}".format(pchid_info))
+
+        def _precheck():
+            # verify z/VM hypervisor name of the userid
+            zvm_host = zvmutils.get_zvm_name()
+            if not zvm_host:
+                errmsg = "failed to get z/VM hypervisor name."
+                LOG.error(errmsg)
+                raise exception.SDKVolumeOperationError(
+                    rs=11, userid=assigner_id, msg=errmsg)
+            # verify fcp_template_id:
+            # DB operation fcp_template_exist_in_db() must be inside the with-block,
+            # because it is related with other DB operations:
+            # allocate_fcp_devices() and release_fcp_devices()
+            if fcp_template_id and not self.db.fcp_template_exist_in_db(fcp_template_id):
                 errmsg = ("FCP Multipath Template (id: %s) does not exist." % fcp_template_id)
                 LOG.error(errmsg)
                 raise exception.SDKVolumeOperationError(
                     rs=11, userid=assigner_id, msg=errmsg)
 
-            # get z/VM name of the userid,
-            # if no host name got, raise exception
-            zvm_host = zvmutils.get_zvm_name()
-            if zvm_host == '':
-                errmsg = "failed to get z/VM LPAR name."
-                LOG.error(errmsg)
-                raise exception.SDKVolumeOperationError(
-                    rs=11, userid=assigner_id, msg=errmsg)
+        with database.get_fcp_conn():
+            zvm_host = None
+            # precheck
+            _precheck()
             """
             Reserve or unreserve FCP device
             according to assigner id and FCP Multipath Template id.
             """
             if reserve:
                 LOG.info("get_volume_connector: Enter allocate_fcp_devices.")
-                # The data structure of fcp_list is:
-                # [(fcp_id, wwpn_npiv, wwpn_phy)]
-                fcp_list, fcp_template_id = self.fcp_mgr.allocate_fcp_devices(
-                    assigner_id, fcp_template_id, sp_name)
+                # fcp_list is a list of python built-in dict objects, ex:
+                # [{'fcp_id':'1B02', 'path':1, 'pchid':'BBBB', 'wwpn_npiv':'aa', 'wwpn_phy':'xx'},
+                #  {'fcp_id':'1C04', 'path':4, 'pchid':'CCCC', 'wwpn_npiv':'bb', 'wwpn_phy':'yy'},
+                #  {'fcp_id':'1E05', 'path':5, 'pchid':'EEEE', 'wwpn_npiv':'cc', 'wwpn_phy':'zz'}]
+                is_reserved_changed, fcp_list, fcp_template_id = self.fcp_mgr.allocate_fcp_devices(
+                    assigner_id, fcp_template_id, sp_name, pchid_info)
                 LOG.info("get_volume_connector: Exit allocate_fcp_devices {}".format(
                     [f['fcp_id'] for f in fcp_list]))
             else:
                 LOG.info("get_volume_connector: Enter release_fcp_devices.")
-                # The data structure of fcp_list is:
-                # [(fcp_id, wwpn_npiv, wwpn_phy, connections)]
-                # An example of fcp_list:
-                # [('1c10', 'c12345abcdefg1', 'c1234abcd33002641', 1),
-                #  ('1d10', 'c12345abcdefg2', 'c1234abcd33002641', 0)]
-                fcp_list = self.fcp_mgr.release_fcp_devices(
+                # fcp_list is a list of sqlite3.Row objects, it is similar as the example below:
+                # [{'fcp_id':'1B02', 'path':1, 'pchid':'BBBB', 'wwpn_npiv':'aa', 'wwpn_phy':'xx'},
+                #  {'fcp_id':'1C04', 'path':4, 'pchid':'CCCC', 'wwpn_npiv':'bb', 'wwpn_phy':'yy'},
+                #  {'fcp_id':'1E05', 'path':5, 'pchid':'EEEE', 'wwpn_npiv':'cc', 'wwpn_phy':'zz'}]
+                is_reserved_changed, fcp_list = self.fcp_mgr.release_fcp_devices(
                     assigner_id, fcp_template_id)
                 LOG.info("get_volume_connector: Exit release_fcp_devices {}".format(
                     [f['fcp_id'] for f in fcp_list]))
 
-        empty_connector = {'zvm_fcp': [],
-                           'wwpns': [],
-                           'host': '',
-                           'phy_to_virt_initiators': {},
-                           'fcp_paths': 0,
-                           'fcp_template_id': fcp_template_id}
+        # get zhypinfo
+        zhypinfo = utils.get_zhypinfo()
+        cpc_sn = utils.get_cpc_sn(zhypinfo=zhypinfo)
+        cpc_name = utils.get_cpc_name(zhypinfo=zhypinfo)
+        lpar = utils.get_lpar_name(zhypinfo=zhypinfo)
+        hypervisor_hostname = utils.get_zvm_name()
+        # process empty fcp_list
         if not fcp_list:
             errmsg = ("Not enough available FCP devices found from "
                       "FCP Multipath Template(id={})".format(fcp_template_id))
             LOG.error(errmsg)
+            empty_connector = {'zvm_fcp': [],
+                               'wwpns': [],
+                               'host': '',
+                               'phy_to_virt_initiators': {},
+                               'fcp_paths': 0,
+                               'fcp_template_id': fcp_template_id,
+                               'cpc_sn': cpc_sn,
+                               'cpc_name': cpc_name,
+                               'lpar': lpar,
+                               'hypervisor_hostname': hypervisor_hostname,
+                               'pchid_fcp_map': {},
+                               'is_reserved_changed': False}
             return empty_connector
-
         # get wwpns of fcp devices
         wwpns = []
-        phy_virt_wwpn_map = {}
         fcp_ids = []
+        pchid_fcp_map = {}
+        phy_virt_wwpn_map = {}
         for fcp in fcp_list:
-            wwpn_npiv = fcp[1]
-            fcp_ids.append(fcp[0])
+            wwpn_npiv = fcp['wwpn_npiv']
+            fcp_ids.append(fcp['fcp_id'])
             wwpns.append(wwpn_npiv)
-            phy_virt_wwpn_map[wwpn_npiv] = fcp[2]
+            phy_virt_wwpn_map[wwpn_npiv] = fcp['wwpn_phy']
+            # populate pchid_fcp_map
+            if fcp['pchid'] not in pchid_fcp_map:
+                pchid_fcp_map[fcp['pchid']] = []
+            pchid_fcp_map[fcp['pchid']].append(fcp['fcp_id'])
 
-        # return the LPARname+VMuserid as host
+        # return the LPARname+VMuserid
+        # as host to be used by storage provider
         ret_host = zvm_host + '_' + assigner_id
         connector = {'zvm_fcp': fcp_ids,
                      'wwpns': wwpns,
                      'phy_to_virt_initiators': phy_virt_wwpn_map,
                      'host': ret_host,
                      'fcp_paths': len(fcp_list),
-                     'fcp_template_id': fcp_template_id}
+                     'fcp_template_id': fcp_template_id,
+                     'cpc_sn': cpc_sn,
+                     'cpc_name': cpc_name,
+                     'lpar': lpar,
+                     'hypervisor_hostname': hypervisor_hostname,
+                     'pchid_fcp_map': pchid_fcp_map,
+                     'is_reserved_changed': is_reserved_changed
+                     }
         LOG.info('get_volume_connector returns %s for '
-                 'assigner %s and FCP Multipath Template %s'
+                 'instance %s and FCP Multipath Template %s'
                  % (connector, assigner_id, fcp_template_id))
         return connector
 


### PR DESCRIPTION
- API interface change:
  - PCHID usage info will be passed in
  - return more info:
    - the PCHID of each allocated FCP,
    - whether new FCP devices are allocated or reused, whether FCP devices are released.

- When allocating new FCP devices to VM, take the PCHID free capacity into consideration
  - PCHID load balance. (select the most free PCHIDs as possible)
  - real multipath from PCHID layer. (select different PCHIDs for different paths as possbile)
  
  
### modification summary 
#### zvmsdk/volumeop.py
```python
def get_volume_connector(self, assigner_id, reserve,
                         fcp_template_id=None, sp_name=None, pchid_info=None):

    if reserve:
        
        # add is_reserved_changed
        is_reserved_changed, fcp_list, fcp_template_id = 
        
            self.fcp_mgr.allocate_fcp_devices(assigner_id, fcp_template_id,
                                              sp_name, pchid_info)
            
    else:
        
        # add is_reserved_changed
        is_reserved_changed, fcp_list = 
        
            self.fcp_mgr.release_fcp_devices(assigner_id, fcp_template_id)

    # more info added in connector 
    connector = {'zvm_fcp': fcp_ids,
                 'wwpns': wwpns,
                 'phy_to_virt_initiators': phy_virt_wwpn_map,
                 'host': ret_host,
                 'fcp_paths': len(fcp_list),
                 'fcp_template_id': fcp_template_id,
                 'cpc_sn': cpc_sn,                          --| 
                 'cpc_name': cpc_name,                        |
                 'lpar': lpar,                                |- new added
                 'hypervisor_hostname': hypervisor_hostname,  |
                 'pchid_fcp_map': pchid_fcp_map,              |
                 'is_reserved_changed': is_reserved_changed --|
                 }
    return connector


def allocate_fcp_devices(self, assigner_id, fcp_template_id,
                         sp_name, pchid_info):

    # add is_reserved_changed
    is_reserved_changed = False

    # add pchid and path in fcp_list
    fcp_list = self.db.get_allocated_fcps_from_assigner(
                        assigner_id, fcp_template_id)
                
    if not fcp_list:
        
        _sync_db_with_zvm()
        
        if CONF.volume.get_fcp_pair_with_same_index:
            
            # add pchid and path in fcp_list
            fcp_list = self.db.get_fcp_devices_with_same_index(
                            fcp_template_id)
                
        else:
            
            # add pchid and path in fcp_list
            fcp_list = self.db.get_fcp_devices(fcp_template_id, pchid_info)
            
        # reserve_fcps
        fcp_ids = [fcp['fcp_id'] for fcp in fcp_list]
        self.db.reserve_fcps(fcp_ids, assigner_id, fcp_template_id)
        
        # is_reserved_changed
        is_reserved_changed = True
        
    return is_reserved_changed, fcp_list, fcp_template_id
```

#### zvmsdk/database.py
![get_fcp_devices_with_pchid](https://media.github.ibm.com/user/22006/files/46670558-0267-40eb-9ec9-45eb4a59be07)

------------


### Tests: call ZCC API directly
### Cases for reserve=True
#### case1: 1st time, reserve=True for a userid

```python
>>> pf = {'02e4': {'allocated': 126, 'max': 128},
...       '021C': {'allocated': 104, 'max': 110},
...       '0264': {'allocated': 126, 'max': 128},
...       'CCCC': {'allocated': 100, 'max': 90}}
>>>
... tid = '5129ba98-3b34-11ee-82df-0201012eebe3';
>>> pp(conn.send_request('get_volume_connector', 'JACKTEST', reserve=True, fcp_template_id=tid, pchid_info=pf))

{'errmsg': '',
 'modID': None,
 'output': {'cpc_name': 'M54',
            'cpc_sn': '0000000000082F57',
            'fcp_paths': 2,
            'fcp_template_id': '5129ba98-3b34-11ee-82df-0201012eebe3',
            'host': 'BOEM5401_JACKTEST',
            'hypervisor_hostname': 'BOEM5401',
            'is_reserved_changed': True,         <-------
            'lpar': 'ZVM4OCP1',
            'pchid_fcp_map': {'0264': ['1C17'], '02E4': ['1D17']},
            'phy_to_virt_initiators': {'c05076de33000363': 'c05076de33002e41',
                                       'c05076de3300036a': 'c05076de33002641'},
            'wwpns': ['c05076de3300036a', 'c05076de33000363'],
            'zvm_fcp': ['1c17', '1d17']},
 'overallRC': 0,
 'rc': 0,
 'rs': 0}
```
- log
```shell
[2023-08-30 04:18:38] [INFO] synchronized: acquiring lock volumeAttachOrDetach-JACKTEST, concurrent thread count 1, current thread: Thread-57
[2023-08-30 04:18:38] [INFO] synchronized: acquired lock volumeAttachOrDetach-JACKTEST, waited 0.00 seconds, current thread: Thread-57
[2023-08-30 04:18:38] [INFO] pchid_info: 

    {'02E4': {'allocated': 126, 'max': 128}, 
     '021C': {'allocated': 104, 'max': 110}, 
     '0264': {'allocated': 126, 'max': 128}, 
     'CCCC': {'allocated': 100, 'max': 90}}
     
[2023-08-30 04:18:38] [INFO] get_volume_connector: Enter allocate_fcp_devices.
[2023-08-30 04:18:38] [INFO] Previously allocated FCP devices [] for instance JACKTEST in FCP Multipath Template 5129ba98-3b34-11ee-82df-0201012eebe3.
[2023-08-30 04:18:38] [INFO] Enter: Sync FCP DB with FCP info queried from z/VM.
[2023-08-30 04:18:38] [INFO] Querying FCP status on z/VM.
[2023-08-30 04:18:41] [INFO] New FCP devices found on z/VM: set()
[2023-08-30 04:18:41] [INFO] FCP devices exist in FCP table but not in z/VM any more: set()
[2023-08-30 04:18:41] [INFO] FCP devices removed from FCP table: set()
[2023-08-30 04:18:41] [INFO] FCP devices exist in both FCP table and z/VM: {'1b0a', '1d1c', '1c18', '1a1c', '1c07', '1c14', '1d01', '1d11', '1d19', '1d1b', '1a13', '1b05', '1b1c', '1c0e', '1d17', '1a10', '1a1a', '1d13', '1c03', '1d0b', '1d12', '1d06', '1d18', '1b1a', '1a16', '1a17', '1c02', '1b13', '1c05', '1b04', '1b06', '1b19', '1d04', '1b17', '1d15', '1d1a', '1a15', '1a0e', '1d08', '1d02', '1b1b', '1a18', '1c0d', '1d0d', '1c17', '1d10', '1c13', '1a00', '1d0e', '1b01', '1b15', '1b1e', '1a1f', '000e', '1b11', '1a03', '1a0a', '1b07', '1d05', '1a14', '1b0f', '1a19', '1c1d', '1b0e', '1b0d', '1c1c', '1c09', '1d1d', '1c00', '1a02', '1b0b', '1c04', '1b03', '1c1b', '1d03', '1a0c', '1c11', '1b02', '1c15', '1a04', '1c0f', '1a1d', '1d0f', '1b09', '1c1e', '1c1f', '1a09', '1b16', '1b1f', '1c0c', '1c01', '1b10', '1d14', '1a1e', '1d09', '1a0f', '1d16', '1c16', '1a12', '1c0a', '1d0a', '1b08', '1a0b', '1c12', '1c10', '1c0b', '1b18', '1c1a', '1c08', '1a08', '1d0c', '1a06', '1a1b', '1a0d', '1b12', '1a07', '1d1f', '1b00', '1c06', '1a11', '1c19', '1b0c', '1b1d', '1a05', '1b14', '1d00', '1d07', '1d1e'}
[2023-08-30 04:18:41] [INFO] FCP devices need to update records in fcp table: []
[2023-08-30 04:18:41] [INFO] Exit: Sync FCP DB with FCP info queried from z/VM.
[2023-08-30 04:18:41] [INFO] There is no previously allocated FCP devices for the instance JACKTEST, allocating new ones.
[2023-08-30 04:18:41] [INFO] free_pchids_per_path: 

    {0: ['0264', '02E4'], 
     1: ['021C', '02E4']}
    
[2023-08-30 04:18:41] [INFO] free_count_in_pchid_info: 

    {'02E4': 2, 
     '021C': 6, 
     '0264': 2, 
     'CCCC': -10}
     
[2023-08-30 04:18:41] [INFO] after _calculate_weight, pchids_per_path_combinations: 
    
    [{0: '0264', 1: '021C', 'weight': 2.0}, 
     {0: '0264', 1: '02E4', 'weight': 2.0}, 
     {0: '02E4', 1: '021C', 'weight': 2.0}, 
     {0: '02E4', 1: '02E4', 'weight': 1.0}]
     
[2023-08-30 04:18:41] [INFO] after _remove_invalid_weight, pchids_per_path_combinations: 
 
    [{0: '0264', 1: '021C', 'weight': 2.0}, 
     {0: '0264', 1: '02E4', 'weight': 2.0}, 
     {0: '02E4', 1: '021C', 'weight': 2.0}, 
     {0: '02E4', 1: '02E4', 'weight': 1.0}]
     
[2023-08-30 04:18:41] [INFO] after _select_max_weight, pchids_per_path_combinations: 

    [{0: '0264', 1: '021C', 'weight': 2.0}, 
     {0: '0264', 1: '02E4', 'weight': 2.0}, 
     {0: '02E4', 1: '021C', 'weight': 2.0}]
     
[2023-08-30 04:18:41] [INFO] after _select_most_distributed_pchids, pchids_per_path_combinations: 

    [{0: '0264', 1: '021C'}, 
     {0: '0264', 1: '02E4'}, 
     {0: '02E4', 1: '021C'}]
     
[2023-08-30 04:18:41] [INFO] final_pchid_per_path: 

    {0: '0264', 1: '02E4'}
    
[2023-08-30 04:18:41] [INFO] after _get_one_random_fcp_combinations, fcp_list: 

    [{'fcp_id': '1C17', 'wwpn_npiv': 'c05076de3300036a', 'wwpn_phy': 'c05076de33002641', 'path': 0, 'pchid': '0264'}, 
     {'fcp_id': '1D17', 'wwpn_npiv': 'c05076de33000363', 'wwpn_phy': 'c05076de33002e41', 'path': 1, 'pchid': '02E4'}]
     
[2023-08-30 04:18:41] [INFO] Newly allocated ['1C17', '1D17'] FCP devices for instance JACKTEST and FCP Multipath Template 5129ba98-3b34-11ee-82df-0201012eebe3
[2023-08-30 04:18:41] [INFO] get_volume_connector: Exit allocate_fcp_devices ['1C17', '1D17']
[2023-08-30 04:18:41] [INFO] get_volume_connector returns 

    {'zvm_fcp': ['1c17', '1d17'], 
     'wwpns': ['c05076de3300036a', 'c05076de33000363'], 
     'phy_to_virt_initiators': {'c05076de3300036a': 'c05076de33002641', 'c05076de33000363': 'c05076de33002e41'}, 
     'host': 'BOEM5401_JACKTEST', 
     'fcp_paths': 2, 
     'fcp_template_id': '5129ba98-3b34-11ee-82df-0201012eebe3', 
     'cpc_sn': '0000000000082F57', 
     'cpc_name': 'M54', 
     'lpar': 'ZVM4OCP1', 
     'hypervisor_hostname': 'BOEM5401', 
     'pchid_fcp_map': {'0264': ['1C17'], '02E4': ['1D17']}, 
     'is_reserved_changed': True} for instance JACKTEST and FCP Multipath Template 5129ba98-3b34-11ee-82df-0201012eebe3
     
     
[2023-08-30 04:18:41] [INFO] synchronized: released lock volumeAttachOrDetach-JACKTEST, held 2.32 seconds, current thread: Thread-57
[2023-08-30 04:18:41] [INFO] synchronized: after releasing lock volumeAttachOrDetach-JACKTEST, concurrent thread count 0, current thread: Thread-57
```
- sqlite FCP DB
```shell
sqlite> SELECT fcp.fcp_id, path, pchid, assigner_id, reserved, tf.tmpl_id FROM template_fcp_mapping as tf INNER JOIN fcp ON tf.fcp_id=fcp.fcp_id WHERE tf.tmpl_id='5129ba98-3b34-11ee-82df-0201012eebe3' AND reserved = 1 ORDER BY path, pchid, fcp.fcp_id;
fcp_id      path        pchid       assigner_id  reserved    tmpl_id
----------  ----------  ----------  -----------  ----------  ------------------------------------
1c17        0           0264        JACKTEST     1           5129ba98-3b34-11ee-82df-0201012eebe3
1a18        0           02e4        JACK0002     1           5129ba98-3b34-11ee-82df-0201012eebe3
1b17        1           021c        JACK0002     1           5129ba98-3b34-11ee-82df-0201012eebe3
1d17        1           02e4        JACKTEST     1           5129ba98-3b34-11ee-82df-0201012eebe3
```

#### case2: 2nd time, reserve=True for a userid

```python
>>> pp(conn.send_request('get_volume_connector', 'JACKTEST', reserve=True, fcp_template_id=tid, pchid_info=pf))
{'errmsg': '',
 'modID': None,
 'output': {'cpc_name': 'M54',
            'cpc_sn': '0000000000082F57',
            'fcp_paths': 2,
            'fcp_template_id': '5129ba98-3b34-11ee-82df-0201012eebe3',
            'host': 'BOEM5401_JACKTEST',
            'hypervisor_hostname': 'BOEM5401',
            'is_reserved_changed': False,        <-------
            'lpar': 'ZVM4OCP1',
            'pchid_fcp_map': {'0264': ['1C17'], '02E4': ['1D17']},
            'phy_to_virt_initiators': {'c05076de33000363': 'c05076de33002e41',
                                       'c05076de3300036a': 'c05076de33002641'},
            'wwpns': ['c05076de3300036a', 'c05076de33000363'],
            'zvm_fcp': ['1c17', '1d17']},
 'overallRC': 0,
 'rc': 0,
 'rs': 0}
```
- log
```shell
[2023-09-03 09:48:53] [INFO] synchronized: acquiring lock volumeAttachOrDetach-JACKTEST, concurrent thread count 1, current thread: Thread-52
[2023-09-03 09:48:53] [INFO] synchronized: acquired lock volumeAttachOrDetach-JACKTEST, waited 0.00 seconds, current thread: Thread-52
[2023-09-03 09:48:53] [INFO] pchid_info: {'02E4': {'allocated': 126, 'max': 128}, '021C': {'allocated': 104, 'max': 110}, '0264': {'allocated': 126, 'max': 128}, 'CCCC': {'allocated': 100, 'max': 90}}
[2023-09-03 09:48:53] [INFO] get_volume_connector: Enter allocate_fcp_devices.
[2023-09-03 09:48:53] [INFO] Previously allocated FCP devices ['1c17', '1d17'] for instance JACKTEST in FCP Multipath Template 5129ba98-3b34-11ee-82df-0201012eebe3.
[2023-09-03 09:48:53] [INFO] Found previously allocated FCP devices ['1c17', '1d17'] for instance JACKTEST in FCP Multipath Template 5129ba98-3b34-11ee-82df-0201012eebe3, will reuse them.
[2023-09-03 09:48:53] [INFO] get_volume_connector: Exit allocate_fcp_devices ['1c17', '1d17']
[2023-09-03 09:48:53] [INFO] get_volume_connector returns {'zvm_fcp': ['1c17', '1d17'], 'wwpns': ['c05076de3300036a', 'c05076de33000363'], 'phy_to_virt_initiators': {'c05076de3300036a': 'c05076de33002641', 'c05076de33000363': 'c05076de33002e41'}, 'host': 'BOEM5401_JACKTEST', 'fcp_paths': 2, 'fcp_template_id': '5129ba98-3b34-11ee-82df-0201012eebe3', 'cpc_sn': '0000000000082F57', 'cpc_name': 'M54', 'lpar': 'ZVM4OCP1', 'hypervisor_hostname': 'BOEM5401', 'pchid_fcp_map': {'0264': ['1C17'], '02E4': ['1D17']}, 'is_reserved_changed': False} for instance JACKTEST and FCP Multipath Template 5129ba98-3b34-11ee-82df-0201012eebe3
[2023-09-03 09:48:53] [INFO] synchronized: released lock volumeAttachOrDetach-JACKTEST, held 0.06 seconds, current thread: Thread-52
[2023-09-03 09:48:53] [INFO] synchronized: after releasing lock volumeAttachOrDetach-JACKTEST, concurrent thread count 0, current thread: Thread-52
```

#### case3: reserve=True without passing pchid_info : raise Exception as expected

```python
>>> pp(conn.send_request('get_volume_connector', 'JACKTEST', reserve=True, fcp_template_id=tid))
{'errmsg':
 'Failed to get volume connector of JACKTEST because The PCHIDs '
           "['021C', '0264', '02E4'] are missing in the pchid_info {}, though "
           'are included in the FCP multipath template '
           '(id=5129ba98-3b34-11ee-82df-0201012eebe3).',
 'modID': 30,
 'output': '',
 'overallRC': 300,
 'rc': 300,
 'rs': 11}
```

- log
```shell
[2023-09-03 09:50:14] [INFO] synchronized: acquiring lock volumeAttachOrDetach-JACKTEST, concurrent thread count 1, current thread: Thread-70
[2023-09-03 09:50:14] [INFO] synchronized: acquired lock volumeAttachOrDetach-JACKTEST, waited 0.00 seconds, current thread: Thread-70
[2023-09-03 09:50:14] [INFO] pchid_info: {}
[2023-09-03 09:50:14] [ERROR] The PCHIDs ['021C', '0264', '02E4'] are missing in the pchid_info {}, though are included in the FCP multipath template (id=5129ba98-3b34-11ee-82df-0201012eebe3).
[2023-09-03 09:50:14] [ERROR] Got SDK exception in FCP DB operation: Failed to get volume connector of JACKTEST because The PCHIDs ['021C', '0264', '02E4'] are missing in the pchid_info {}, though are included in the FCP multipath template (id=5129ba98-3b34-11ee-82df-0201012eebe3).
[2023-09-03 09:50:14] [INFO] synchronized: released lock volumeAttachOrDetach-JACKTEST, held 0.05 seconds, current thread: Thread-70
[2023-09-03 09:50:14] [INFO] synchronized: after releasing lock volumeAttachOrDetach-JACKTEST, concurrent thread count 0, current thread: Thread-70
[2023-09-03 09:50:14] [ERROR] [Thread-70] (127.0.0.1:43086) Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/zvmsdk/sdkserver.py", line 153, in serve_API
    return_data = api_func(*api_args, **api_kwargs)
  File "/usr/lib/python3.6/site-packages/zvmsdk/api.py", line 1670, in get_volume_connector
    fcp_template_id=fcp_template_id, sp_name=sp_name, pchid_info=pchid_info)
  File "/usr/lib/python3.6/site-packages/zvmsdk/volumeop.py", line 108, in get_volume_connector
    sp_name=sp_name, pchid_info=pchid_info)
  File "/usr/lib/python3.6/site-packages/zvmsdk/utils.py", line 431, in _wrapper
    return func(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/zvmsdk/volumeop.py", line 2593, in get_volume_connector
    _precheck()
  File "/usr/lib/python3.6/site-packages/zvmsdk/volumeop.py", line 2589, in _precheck
    rs=11, userid=assigner_id, msg=errmsg)
zvmsdk.exception.SDKVolumeOperationError: Failed to get volume connector of JACKTEST because The PCHIDs ['021C', '0264', '02E4'] are missing in the pchid_info {}, though are included in the FCP multipath template (id=5129ba98-3b34-11ee-82df-0201012eebe3).

[2023-09-03 09:50:14] [INFO] The msg <{'overallRC': 300, 'modID': 30, 'rc': 300, 'rs': 11, 'errmsg': "Failed to get volume connector of JACKTEST because The PCHIDs ['021C', '0264', '02E4'] are missing in the pchid_info {}, though are included in the FCP multipath template (id=5129ba98-3b34-11ee-82df-0201012eebe3).", 'output': ''}> lead to return internal error
```

#### case4: reserve=True for a userid, when
- some path of the template does NOT have free FCP devices

```python
>>> pp(conn.send_request('get_volume_connector', 'JACKTEST', reserve=True, fcp_template_id=tid, pchid_info=pf))
{'errmsg': '',
 'modID': None,
 'output': {'cpc_name': 'M54',
            'cpc_sn': '0000000000082F57',
            'fcp_paths': 0,
            'fcp_template_id': '5129ba98-3b34-11ee-82df-0201012eebe3',
            'host': '',
            'hypervisor_hostname': 'BOEM5401',
            'is_reserved_changed': False,        <-------
            'lpar': 'ZVM4OCP1',
            'pchid_fcp_map': {},
            'phy_to_virt_initiators': {},
            'wwpns': [],
            'zvm_fcp': []},
 'overallRC': 0,
 'rc': 0,
 'rs': 0}
```

- log
```shell
[2023-08-31 00:38:15] [INFO] synchronized: acquiring lock volumeAttachOrDetach-JACKTEST, concurrent thread count 1, current thread: Thread-1302
[2023-08-31 00:38:15] [INFO] synchronized: acquired lock volumeAttachOrDetach-JACKTEST, waited 0.00 seconds, current thread: Thread-1302
[2023-08-31 00:38:15] [INFO] pchid_info: 

    {'02E4': {'allocated': 126, 'max': 128}, 
     '021C': {'allocated': 104, 'max': 110}, 
     '0264': {'allocated': 126, 'max': 128}, 
     'CCCC': {'allocated': 100, 'max': 90}}
     
[2023-08-31 00:38:15] [INFO] get_volume_connector: Enter allocate_fcp_devices.
[2023-08-31 00:38:15] [INFO] Previously allocated FCP devices [] for instance JACKTEST in FCP Multipath Template 5129ba98-3b34-11ee-82df-0201012eebe3.
[2023-08-31 00:38:15] [INFO] Enter: Sync FCP DB with FCP info queried from z/VM.
[2023-08-31 00:38:15] [INFO] Querying FCP status on z/VM.
[2023-08-31 00:38:18] [INFO] New FCP devices found on z/VM: set()
[2023-08-31 00:38:18] [INFO] FCP devices exist in FCP table but not in z/VM any more: set()
[2023-08-31 00:38:18] [INFO] FCP devices removed from FCP table: set()
[2023-08-31 00:38:18] [INFO] FCP devices exist in both FCP table and z/VM: {'1d1b', '1a0f', '1a09', '1b18', '1b02', '1d0d', '1a15', '1c15', '1b0b', '1a08', '1b0e', '1b01', '1c1a', '1a0a', '1d06', '1c0e', '1a0c', '1c0c', '1a19', '1b09', '1a10', '1c13', '1c0f', '1a1b', '1a04', '1a05', '1d14', '1b12', '1b17', '1a18', '1d00', '1c1d', '1d1c', '1c02', '1c18', '1d05', '1b16', '1c09', '1b13', '1c0d', '1c01', '1b19', '1a1a', '1a06', '1c05', '1d1e', '1c08', '1b11', '1c1b', '1b1c', '1b04', '1a14', '1c11', '1a17', '1d09', '1c14', '1c03', '1a16', '1d08', '1c06', '1d0a', '1b1e', '1a1f', '1b07', '1b0d', '1c19', '1a1d', '1c16', '1d16', '1a11', '1d11', '1d13', '1a0d', '1b1a', '1d1d', '1a0e', '1d17', '1d1a', '1c0b', '1d0e', '1b0c', '1d0b', '1b03', '1c07', '1c04', '1b1d', '1a0b', '1c10', '1b00', '1d12', '1d0c', '1a12', '1c0a', '1a00', '1b0f', '1d19', '1d18', '1a1c', '1b15', '1d03', '1b1f', '1c1e', '1c1c', '000e', '1a07', '1b10', '1b06', '1c1f', '1d02', '1d15', '1d10', '1b14', '1d07', '1d1f', '1b0a', '1c12', '1a13', '1b1b', '1a02', '1a1e', '1d0f', '1b08', '1c00', '1d04', '1a03', '1c17', '1d01', '1b05'}
[2023-08-31 00:38:18] [INFO] FCP devices need to update records in fcp table: []
[2023-08-31 00:38:18] [INFO] Exit: Sync FCP DB with FCP info queried from z/VM.
[2023-08-31 00:38:18] [INFO] There is no previously allocated FCP devices for the instance JACKTEST, allocating new ones.
[2023-08-31 00:38:18] [INFO] free_pchids_per_path: 

     {1: ['021C', '02E4']}
 
[2023-08-31 00:38:18] [INFO] 

    Not all paths of FCP Multipath Template (id=5129ba98-3b34-11ee-82df-0201012eebe3) have available FCP devices. 
    The count of minimum FCP device path is 2. 
    The count of total paths is 2. 
    The count of paths with available FCP devices is 1, 
    which is less than the total path count.
    
[2023-08-31 00:38:18] [ERROR] 

    The count of paths with available FCP devices must not be less than that of minimum FCP device path, 
    return empty list to abort the volume attachment.
    
[2023-08-31 00:38:18] [INFO] get_volume_connector: Exit allocate_fcp_devices []
[2023-08-31 00:38:18] [ERROR] 

    Not enough available FCP devices found from FCP Multipath Template(id=5129ba98-3b34-11ee-82df-0201012eebe3)
    
[2023-08-31 00:38:18] [INFO] synchronized: released lock volumeAttachOrDetach-JACKTEST, held 2.64 seconds, current thread: Thread-1302
[2023-08-31 00:38:18] [INFO] synchronized: after releasing lock volumeAttachOrDetach-JACKTEST, concurrent thread count 0, current thread: Thread-1302
```

### Cases for reserve=False (no need to pass pchid_info)
#### case1: reserve=False for a userid, when
- connections != 0
- without passing pchid_info
```python
>>> pp(conn.send_request('get_volume_connector', 'JACKTEST', reserve=False, fcp_template_id=tid))
{'errmsg': '',
 'modID': None,
 'output': {'cpc_name': 'M54',
            'cpc_sn': '0000000000082F57',
            'fcp_paths': 2,
            'fcp_template_id': '5129ba98-3b34-11ee-82df-0201012eebe3',
            'host': 'BOEM5401_JACKTEST',
            'hypervisor_hostname': 'BOEM5401',
            'is_reserved_changed': False,        <-------
            'lpar': 'ZVM4OCP1',
            'pchid_fcp_map': {'0264': ['1C17'], '02E4': ['1D17']},
            'phy_to_virt_initiators': {'c05076de33000363': 'c05076de33002e41',
                                       'c05076de3300036a': 'c05076de33002641'},
            'wwpns': ['c05076de3300036a', 'c05076de33000363'],
            'zvm_fcp': ['1c17', '1d17']},
 'overallRC': 0,
 'rc': 0,
 'rs': 0}
```

#### case2: reserve=False for a userid, when
- connections != 0
- with passing pchid_info   <--- 
```python
### same result as case1

>>> pp(conn.send_request('get_volume_connector', 'JACKTEST', reserve=False, fcp_template_id=tid, pchid_info=pf))
{'errmsg': '',
 'modID': None,
 'output': {'cpc_name': 'M54',
            'cpc_sn': '0000000000082F57',
            'fcp_paths': 2,
            'fcp_template_id': '5129ba98-3b34-11ee-82df-0201012eebe3',
            'host': 'BOEM5401_JACKTEST',
            'hypervisor_hostname': 'BOEM5401',
            'is_reserved_changed': False,        <-------
            'lpar': 'ZVM4OCP1',
            'pchid_fcp_map': {'0264': ['1C17'], '02E4': ['1D17']},
            'phy_to_virt_initiators': {'c05076de33000363': 'c05076de33002e41',
                                       'c05076de3300036a': 'c05076de33002641'},
            'wwpns': ['c05076de3300036a', 'c05076de33000363'],
            'zvm_fcp': ['1c17', '1d17']},
 'overallRC': 0,
 'rc': 0,
 'rs': 0}
```

#### case3: reserve=False for a userid, when
- connections = 0
- without passing pchid_info
```python
>>> pp(conn.send_request('get_volume_connector', 'JACKTEST', reserve=False, fcp_template_id=tid))
{'errmsg': '',
 'modID': None,
 'output': {'cpc_name': 'M54',
            'cpc_sn': '0000000000082F57',
            'fcp_paths': 2,
            'fcp_template_id': '5129ba98-3b34-11ee-82df-0201012eebe3',
            'host': 'BOEM5401_JACKTEST',
            'hypervisor_hostname': 'BOEM5401',
            'is_reserved_changed': True,        <-------
            'lpar': 'ZVM4OCP1',
            'pchid_fcp_map': {'0264': ['1C17'], '02E4': ['1D17']},
            'phy_to_virt_initiators': {'c05076de33000363': 'c05076de33002e41',
                                       'c05076de3300036a': 'c05076de33002641'},
            'wwpns': ['c05076de3300036a', 'c05076de33000363'],
            'zvm_fcp': ['1c17', '1d17']},
 'overallRC': 0,
 'rc': 0,
 'rs': 0}
```

#### case4: reserve=False for a userid, when
- no FCP devices allocated to the userid

```python
>>> pp(conn.send_request('get_volume_connector', 'JACKTEST', reserve=False, fcp_template_id=tid))
{'errmsg': '',
 'modID': None,
 'output': {'cpc_name': 'M54',
            'cpc_sn': '0000000000082F57',
            'fcp_paths': 0,
            'fcp_template_id': '5129ba98-3b34-11ee-82df-0201012eebe3',
            'host': '',
            'hypervisor_hostname': 'BOEM5401',
            'is_reserved_changed': False,        <-------
            'lpar': 'ZVM4OCP1',
            'pchid_fcp_map': {},
            'phy_to_virt_initiators': {},
            'wwpns': [],
            'zvm_fcp': []},
 'overallRC': 0,
 'rc': 0,
 'rs': 0}
```