### PR TITLE
fix_sqliteRow_indexError_when_running_command_zvmsdk-getpchid

### DIFF
--- a/zvmsdk/database.py
+++ b/zvmsdk/database.py
@@ -1823,16 +1823,13 @@ class FCPDbOperator(object):
             # already ORDER BY pchid in SQL
             # inuse_fcp_devices ex:
             # [ each item is a sqlite3.Row object that can be accessed in dict-style
-            #   {'pchid': '02E0',  'fcp_id': '1A01'},
-            #   {'pchid': '02E0',  'fcp_id': '1A02'},
-            #   {'pchid': '02E0',  'fcp_id': '1A03'},
-            #   {'pchid': '03FC',  'fcp_id': '1B02'},
-            #   {'pchid': '03FC',  'fcp_id': '1B05'} ]
+            #   {'pchid': '02e0',  'fcp_id': '1a01'},
+            #   {'pchid': '02e0',  'fcp_id': '1a02'},
+            #   {'pchid': '02e0',  'fcp_id': '1a03'},
+            #   {'pchid': '03fc',  'fcp_id': '1b02'},
+            #   {'pchid': '03fc',  'fcp_id': '1b05'} ]
             inuse_fcp_devices = result.fetchall()
-        # upper case
-        for item in inuse_fcp_devices:
-            for key in item:
-                item[key] = item[key].upper()
+
         # shrink_fcp_list
         if inuse_fcp_devices:
             # tmp_fcps ex:

--- a/zvmsdk/tests/unit/test_database.py
+++ b/zvmsdk/tests/unit/test_database.py
@@ -1876,18 +1876,20 @@ class FCPDbOperatorTestCase(base.SDKTestCase):
         """test get_pchids_of_all_inuse_fcp_devices"""
         mock_conn.execute().fetchall.side_effect = [
             [],
-            [   # pchid: 02E0
+            [   # all the keys and values must be in lower case,
+                # because sqlite DB query always returns in lower case
+                # pchid: 02E0
                 {'pchid': '02e0', 'fcp_id': '1a0a'},
                 {'pchid': '02e0', 'fcp_id': '1a09'},
                 {'pchid': '02e0', 'fcp_id': '1a0b'},
-                {'pchid': '02e0', 'fcp_id': '1A02'},
-                {'pchid': '02E0', 'fcp_id': '1A11'},
+                {'pchid': '02e0', 'fcp_id': '1a02'},
+                {'pchid': '02e0', 'fcp_id': '1a11'},
                 # pchid: 03FC
                 {'pchid': '03fc', 'fcp_id': '1c03'},
                 {'pchid': '03fc', 'fcp_id': '1c04'},
                 {'pchid': '03fc', 'fcp_id': '1b1f'},
-                {'pchid': '03FC', 'fcp_id': '1B20'},
-                {'pchid': '03FC', 'fcp_id': '1B21'}]
+                {'pchid': '03fc', 'fcp_id': '1b20'},
+                {'pchid': '03fc', 'fcp_id': '1b21'}]
         ]
         # case1: no inuse fcp
         expected = {}


### PR DESCRIPTION
- fix sqliteRow indexError when running command zvmsdk-getpchid
```python
[root@112-cmp-wdl ~]# /usr/bin/zvmsdk-getpchid
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/zvmsdk/database.py", line 118, in get_fcp_conn
    yield _FCP_CONN
  File "/usr/bin/zvmsdk-getpchid", line 119, in get_fcp_devices_per_pchid
    inuse_pchids = fcp_mgr.db.get_pchids_of_all_inuse_fcp_devices()
  File "/usr/lib/python3.6/site-packages/zvmsdk/database.py", line 1835, in get_pchids_of_all_inuse_fcp_devices
    item[key] = item[key].upper()
IndexError: No item with that key
```