### PR TITLE
move the check of pchids_info to later stage after FCP multipath template is set

### DIFF
--- a/doc/source/errcode.csv
+++ b/doc/source/errcode.csv
@@ -36,7 +36,8 @@
 300;30;300;8;Failed to attach volume to instance %(userid)s with reason %(msg)s
 300;30;300;9;Failed to detach volume from instance %(userid)s with reason %(msg)s
 300;30;300;10;Failed to refresh bootmap for RHCOS: transportfiles are required
-300;30;300;11;Failed to get volume connector of %(userid)s because %(msg)s
+300;30;300;11;Failed to get volume connector of %(userid)s: %(msg)s
+300;30;300;12;PCHIDs info missing: %(msg)s
 **Operation on Image failed**
 300;40;300;1;Database operation failed, error: %(msg)s
 300;40;300;2;No image schema found for %(schema)s

--- a/zvmsdk/returncode.py
+++ b/zvmsdk/returncode.py
@@ -248,8 +248,10 @@ errors = {
                    "%(userid)s with reason %(msg)s",
                 10: "Failed to refresh bootmap for RHCOS: "
                     "transportfiles are required",
-                11: "Failed to get volume connector of %(userid)s "
-                    "because %(msg)s",
+                11: "Failed to get volume connector of %(userid)s: "
+                    "%(msg)s",
+                12: "PCHIDs info missing: "
+                    "%(msg)s",
                 },
                "Operation on Volume failed"
                ],


### PR DESCRIPTION
Before this fix, when calling the get_volume_connector:
if 
1. fcp_multipath_template is not specified which means to use default template, and 
2. some PCHID info is not contained in the pchid_info 

Then the following keyerror would be reported:
`Failed to reserve FCP devices for assigner xj00000e by FCP Multipath Template aee11840-5185-11ee-b8ec-02010d42ff55 error: Database operation failed, error: Execute SQL statements error: '0240'`

This fix makes the following changes:
1. the check of pchids_info to a later stage after the FCP multipath template is selected based on the default rule.
2. Enhance the error msg, avoid printing the whole pchids_info as it will contain all the PCHIDs info of the CPC which can be very long string.