### PR TITLE
Support more DEF STOR statment format when resizing zvm guest memory

### DIFF
--- a/zvmsdk/constants.py
+++ b/zvmsdk/constants.py
@@ -148,3 +148,5 @@ SDK_DATA_PATH = '/var/lib/zvmsdk/'
 IUCV_AUTH_USERID_PATH = '/etc/zvmsdk/iucv_authorized_userid'
 
 HYPERVISOR_HOSTNAME_SUFFIX_FILE = '.zvmsdk_hypervisor_hostname_suffix'
+
+RESERVED_STOR_PATTERN = 'COMMAND DEF(I|IN|INE)? ST(O|OR|ORA|ORAG|ORAGE)? RESERVED .+'

--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -4238,7 +4238,7 @@ class SMTClient(object):
                             new_ent += (str(size) + 'M ')
                     # remove the last space
                     new_ent = new_ent.strip()
-                elif ent.startswith("COMMAND DEF STOR RESERVED"):
+                elif re.match(const.RESERVED_STOR_PATTERN, ent):
                     new_ent = ("COMMAND DEF STOR INITIAL STANDBY REMAINDER")
                 else:
                     new_ent = ent
@@ -4351,7 +4351,7 @@ class SMTClient(object):
             # If the user direct include DEF STOR RESERVED statement,
             # then need define standby storage
             # Step1: Define new standby storage
-            if any(ent.startswith("COMMAND DEF STOR RESERVED") for ent in user_direct):
+            if any(re.match(const.RESERVED_STOR_PATTERN, ent) for ent in user_direct):
                 # 'DEF STOR RESERVED' statement in Legacy user direct is replace to
                 # 'COMMAND DEFINE STORAGE INITIAL STANDBY REMAINDER', so here def all
                 # reserved memory to standby
@@ -4393,7 +4393,7 @@ class SMTClient(object):
                 LOG.error(msg1)
                 # Start to do rollback
                 LOG.info("Start to do revert.")
-                if any(ent.startswith("COMMAND DEF STOR RESERVED") for ent in user_direct):
+                if any(re.match(const.RESERVED_STOR_PATTERN, ent) for ent in user_direct):
                     LOG.debug("Reverting the standby memory.")
                     try:
                         self.execute_cmd(userid, "vmcp def storage standby 0M")

--- a/zvmsdk/tests/unit/test_smtclient.py
+++ b/zvmsdk/tests/unit/test_smtclient.py
@@ -4596,7 +4596,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         size = '4g'
         sample_definition = [u'USER TESTUID LBYONLY 4096M 64G G',
                              u'INCLUDE OSDFLT',
-                             u'COMMAND DEF STOR RESERVED 61440M',
+                             u'COMMAND DEFINE STORAG RESERVED 61440M',
                              u'CPU 00 BASE',
                              u'IPL 0100',
                              u'MDISK 0100 3390 5501 5500 OMB1BA MR',
@@ -4615,7 +4615,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         size = '10240M'
         sample_definition = [u'USER TESTUID LBYONLY 4096M 64G G',
                              u'INCLUDE OSDFLT',
-                             u'COMMAND DEF STOR RESERVED 61440M',
+                             u'COMMAND DEFINE STORAGE RESERVED 61440M',
                              u'CPU 00 BASE',
                              u'IPL 0100',
                              u'MDISK 0100 3390 5501 5500 OMB1BA MR',
@@ -4642,7 +4642,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         size = '2g'
         sample_definition = [u'USER TESTUID LBYONLY 4096M 64G G',
                              u'INCLUDE OSDFLT',
-                             u'COMMAND DEF STOR RESERVED 61440M',
+                             u'COMMAND DEFIN ST RESERVED 61440M',
                              u'CPU 00 BASE',
                              u'IPL 0100',
                              u'MDISK 0100 3390 5501 5500 OMB1BA MR',
@@ -4672,7 +4672,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         base.set_conf('zvm', 'user_default_max_reserved_memory', '64G')
         sample_definition = [u'USER TESTUID LBYONLY 65536M 128G G',
                              u'INCLUDE OSDFLT',
-                             u'COMMAND DEF STOR RESERVED 65536M',
+                             u'COMMAND DEFINE STOR RESERVED 65536M',
                              u'CPU 00 BASE',
                              u'IPL 0100',
                              u'MDISK 0100 3390 5501 5500 OMB1BA MR',
@@ -4702,7 +4702,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         base.set_conf('zvm', 'user_default_max_reserved_memory', '65536M')
         sample_definition = [u'USER TESTUID LBYONLY 65536M 128G G',
                              u'INCLUDE OSDFLT',
-                             u'COMMAND DEF STOR RESERVED 65536M',
+                             u'COMMAND DEFINE STORAGE RESERVED 65536M',
                              u'CPU 00 BASE',
                              u'IPL 0100',
                              u'MDISK 0100 3390 5501 5500 OMB1BA MR',
@@ -4732,7 +4732,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         base.set_conf('zvm', 'user_default_max_reserved_memory', '128G')
         sample_definition = [u'USER TESTUID LBYONLY 1024M 256G G',
                              u'INCLUDE OSDFLT',
-                             u'COMMAND DEF STOR RESERVED 131072M',
+                             u'COMMAND DEFI STORAGE RESERVED 131072M',
                              u'CPU 00 BASE',
                              u'IPL 0100',
                              u'MDISK 0100 3390 5501 5500 OMB1BA MR',
@@ -4759,7 +4759,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         size = '2g'
         sample_definition = [u'USER TESTUID LBYONLY 4096M 64G G',
                              u'INCLUDE OSDFLT',
-                             u'COMMAND DEF STOR RESERVED 61440M',
+                             u'COMMAND DEF ST RESERVED 61440M',
                              u'CPU 00 BASE',
                              u'IPL 0100',
                              u'MDISK 0100 3390 5501 5500 OMB1BA MR',
@@ -4781,7 +4781,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         size = '2g'
         sample_definition = [u'USER TESTUID LBYONLY 4096M 64G G',
                              u'INCLUDE OSDFLT',
-                             u'COMMAND DEF STOR RESERVED 61440M',
+                             u'COMMAND DEFINE ST RESERVED 61440M',
                              u'CPU 00 BASE',
                              u'IPL 0100',
                              u'MDISK 0100 3390 5501 5500 OMB1BA MR',
@@ -4838,7 +4838,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         userid = 'testuid'
         sample_definition = [u'USER TESTUID LBYONLY 4096M 64G G 64',
                              u'INCLUDE OSDFLT',
-                             u'COMMAND DEF STOR RESERVED 61440M',
+                             u'COMMAND DEF STORA RESERVED 61440M',
                              u'CPU 00 BASE',
                              u'IPL 0100',
                              u'MDISK 0100 3390 5501 5500 OMB1BA MR',
@@ -4872,7 +4872,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         userid = 'testuid'
         user_entry = [u'USER TESTUID LBYONLY 4096M 64G G',
                      u'INCLUDE OSDFLT',
-                     u'COMMAND DEF STOR RESERVED 61440M',
+                     u'COMMAND DEFI STORA RESERVED 61440M',
                      u'CPU 00 BASE',
                      u'IPL 0100',
                      u'MDISK 0100 3390 5501 5500 OMB1BA MR',


### PR DESCRIPTION
- For resizing a zvm guest memory, when the zvm user direct contains 
  - COMMAND DEF STOR RESERVED xx,
  -  COMMAND DEF STORAGE RESERVED xx, 
  - COMMAND DEFINE STOR RESERVED xx, 
  - COMMAND DEFINE STORAGE RESERVED xx, 
  - COMMAND DEF ST RESERVED xx,
  - COMMAND DEFINE ST RESERVED xx
    replace it with COMMAND DEF STOR INITIAL STANDBY REMAINDER.
- Update UT cases.