### PR TITLE
check_pchid_free_capability_for_get_fcp_pair_with_same_index

### DIFF
--- a/zvmsdk/volumeop.py
+++ b/zvmsdk/volumeop.py
@@ -728,23 +728,19 @@ class FCPManager(object):
                     LOG.info("There is no previously allocated FCP devices for the instance %s, "
                              "allocating new ones." % assigner_id)
                     if CONF.volume.get_fcp_pair_with_same_index:
-                        '''
-                        If use get_fcp_pair_with_same_index,
-                        then FCP devices are randomly selected from below combinations,
-                        one FCP device per path, ex:
-                        [fa00,fb00],[fa01,fb01],[fa02,fb02]
-                        '''
+                        # If use get_fcp_pair_with_same_index,
+                        # then FCP devices are randomly selected from below combinations,
+                        # one FCP device per path, ex:
+                        # [fa00,fb00],[fa01,fb01],[fa02,fb02]
                         fcp_list = self.db.get_fcp_devices_with_same_index(
-                            fcp_template_id)
+                            fcp_template_id, pchid_info)
                     else:
-                        '''
-                        If use get_fcp_pair,
-                        then FCP devices are randomly selected from below combinations,
-                        one FCP device per path, ex:
-                        [fa00,fb00],[fa01,fb00],[fa02,fb00]
-                        [fa00,fb01],[fa01,fb01],[fa02,fb01]
-                        [fa00,fb02],[fa01,fb02],[fa02,fb02]
-                        '''
+                        # If use get_fcp_pair,
+                        # then FCP devices are randomly selected from below combinations,
+                        # one FCP device per path, ex:
+                        # [fa00,fb00],[fa01,fb00],[fa02,fb00]
+                        # [fa00,fb01],[fa01,fb01],[fa02,fb01]
+                        # [fa00,fb02],[fa01,fb02],[fa02,fb02]
                         fcp_list = self.db.get_fcp_devices(fcp_template_id, pchid_info)
                     # process empty fcp_list
                     if not fcp_list:


### PR DESCRIPTION
only select the FCP devices whose PCHIID has free capacity

- Examples:
```python
 free capcity of PCHIDs =  {'A':1, 'B':3, 'C':2, 'D':2}


                                 |--- PCHID ----|   
 FCP combinations                A    B    C    D        weight  valid(>=1)
---------------------------------------------------------------------------
 1a01(A) 1b01(A) 1c01(C)    min( 0.5       2        )  = 0.5     No
 1a02(A) 1b02(B) 1c02(C)    min( 1    3    2        )  = 1       Yes   --|___ random select one
 1a03(A) 1b03(D) 1c03(D)    min( 1              1   )  = 1       Yes   --|
```


Signed-off-by: Da Long Wang <shdlwang@cn.ibm.com>
