### PR TITLE
Fix issue: when the fcp count is different in differnt paths, raise IndexError

### DIFF
--- a/zvmsdk/database.py
+++ b/zvmsdk/database.py
@@ -1038,7 +1038,7 @@ class FCPDbOperator(object):
         #   3 : [('1a03', ...)]}
         #
         # The FCP count of 1st path
-        for i in range(count_per_path[0]):
+        for i in range(count_per_path[count_per_path.index(min(count_per_path))]):
             (fcp_no, connections, path, pchid, reserved,
              state, wwpn_npiv, wwpn_phy) = fcps[i]
             if connections == reserved == 0 and state == 'free':


### PR DESCRIPTION
For example, when the fcp template has 2 paths, and the first path has 2 FCP devices and the second has 1. When enable get_fcp_pair_with_same_index, will raise IndexError.
This PR is to fix this issue.