### PR TITLE
Fix auth mechanism 1/3

### DIFF
--- a/zvmsdk/sdkwsgi/requestlog.py
+++ b/zvmsdk/sdkwsgi/requestlog.py
@@ -1,7 +1,7 @@
 #  Copyright Contributors to the Feilong Project.
 #  SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2017 IBM Corp.
+# Copyright 2017-2023 IBM Corp.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -54,8 +54,9 @@ class RequestLog(object):
                     size = value
             for index, value in enumerate(headers):
                 if value[0] == 'X-Auth-Token':
-                    headers[index] = ('X-Auth-Token', value[1].decode('utf-8'))
-                    break
+                    if isinstance(value[1], bytes):
+                        headers[index] = ('X-Auth-Token', value[1].decode('utf-8'))
+                        break
 
             self._write_log(environ, req_uri, status, size, headers,
                             exc_info)


### PR DESCRIPTION
When trying to create an authentication token:
```
$ curl http://localhost/token -X POST -i -H "Content-Type:application/json" -H "X-Admin-Token:zvX2mFxuj8HcrYkAacLReV0RTQ0K5IIEighOR9F8AG"
```
a "502 bad gateway" is returned:
```
HTTP/1.1 502 Bad Gateway 
Server: nginx/1.18.0 (Ubuntu) 
Date: Mon, 11 Dec 2023 21:17:48 GMT 
Content-Type: text/html 
Content-Length: 166 
Connection: keep-alive 
 
<html> 
<head><title>502 Bad Gateway</title></head> 
<body> 
<center><h1>502 Bad Gateway</h1></center> 
<hr><center>nginx/1.18.0 (Ubuntu)</center> 
</body> 
</html>
```

Log file `/var/log/nginx/error.log` contains
```
2023/12/11 21:32:02 [error] 665#665: *15 upstream prematurely closed connection while reading response header from upstream, client: 127.0.0.1, server: _, request: "POST /token HTTP/1.1", upstream: "uwsgi://unix:///tmp/zvmsdk-wsgi.socket:", host: "localhost"
```

Log file `/var/log/zvmsdk/uwsgi.log` contains:
```
Traceback (most recent call last): 
 File "/usr/local/lib/python3.10/dist-packages/zVMCloudConnector-1.6.6-py3.10.egg/zvmsdk/sdkwsgi/requestlog.py", line 45, in __call__ 
   return self._log_and_call(environ, start_response) 
 File "/usr/local/lib/python3.10/dist-packages/zVMCloudConnector-1.6.6-py3.10.egg/zvmsdk/sdkwsgi/requestlog.py", line 64, in _log_and_call 
   return self.application(environ, _local_response) 
 File "/usr/local/lib/python3.10/dist-packages/WebOb-1.8.7-py3.10.egg/webob/dec.py", line 143, in __call__ 
   return resp(environ, start_response) 
 File "/usr/local/lib/python3.10/dist-packages/WebOb-1.8.7-py3.10.egg/webob/response.py", line 1312, in __call__ 
   start_response(self.status, headerlist) 
 File "/usr/local/lib/python3.10/dist-packages/zVMCloudConnector-1.6.6-py3.10.egg/zvmsdk/sdkwsgi/requestlog.py", line 57, in _local_response 
   headers[index] = ('X-Auth-Token', value[1].decode('utf-8')) 
AttributeError: 'str' object has no attribute 'decode'. Did you mean: 'encode'?
```

Removing the `.decode('utf-8')` in `zvmsdk/sdkwsgi/requestlog.py` resolves the issue.

This was introduced by this commit:
```diff
commit be8a31a9fa6535cceb11c34d9b739bbdab23e54e
Author: SharpRazor <bjcb@cn.ibm.com>
Date:   Fri Jul 10 10:09:41 2020 +0800

    type error reported when sending requests to WSGI in zcc
    
    this is because the data type of X-Auth-Token in headers is bytes
    but start_response expect unicode type.
    so change the type hardly, still need finding the root cause.
    
    Signed-off-by: SharpRazor <bjcb@cn.ibm.com>

diff --git a/zvmsdk/sdkwsgi/requestlog.py b/zvmsdk/sdkwsgi/requestlog.py
index 0107380e..a8db025d 100644
--- a/zvmsdk/sdkwsgi/requestlog.py
+++ b/zvmsdk/sdkwsgi/requestlog.py
@@ -49,6 +49,10 @@ class RequestLog(object):
             for name, value in headers:
                 if name.lower() == 'content-length':
                     size = value
+            for index, value in enumerate(headers):
+                if value[0] == 'X-Auth-Token':
+                    headers[index] = ('X-Auth-Token', value[1].decode('utf-8'))
+                    break
 
             self._write_log(environ, req_uri, status, size, headers,
                             exc_info)
```
