### PR TITLE
Fix auth mechanism 2/3

### DIFF
--- a/zvmsdk/sdkwsgi/handlers/tokens.py
+++ b/zvmsdk/sdkwsgi/handlers/tokens.py
@@ -1,7 +1,7 @@
 #  Copyright Contributors to the Feilong Project.
 #  SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2017 IBM Corp.
+# Copyright 2017-2023 IBM Corp.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -102,7 +102,7 @@ def validate(function):
         token_file_path = CONF.wsgi.token_path
         admin_token = get_admin_token(token_file_path)
         try:
-            jwt.decode(req.headers['X-Auth-Token'], admin_token)
+            jwt.decode(req.headers['X-Auth-Token'], admin_token, algorithms="HS256")
         except jwt.ExpiredSignatureError:
             LOG.debug('token validation failed because it is expired')
             raise exception.ZVMUnauthorized()


### PR DESCRIPTION
When running the command 
```
$ curl http://localhost/ -H "Content-Type:application/json" -H 'X-Auth-Token:<user token>'
```
with the user token provided by the `CreateToken()` function, one systematically gets:
```
HTTP status: 401, body: {"overallRC": 400, "rc": 400, "rs": 401, "modID": 120, "output": "", "errmsg": "This server could not verify that you are authorized to access the document you requested. Either you supplied the wrong credentials (e.g., bad password), or your browser does not understand how to supply the credentials required."}
```

The logs in DEBUG mode show the message:
```
[2023-12-12 22:16:57] [DEBUG] token not valid
```

After debugging, it appears that the function `jwt.decode()` now needs a third argument with the decoding algorithms, as shown by this small python program:
```python
import jwt

key = "zvX2mFxuj8HcrYkAacLReV0RTQ0K5IIEighOR9F8AG"
encoded = jwt.encode({ "exp": 1702422356 }, key)
print(encoded)
# BAD:
jwt.decode(encoded, key)
# GOOD:
# jwt.decode(encoded, key, algorithms="HS256")
```

This PR prevents that decoding exception when using authentication tokens, by adding this missing parameter.
