### PR TITLE
Doc: Fix userids that are in body, not in path

### DIFF
--- a/doc/source/parameters.yaml
+++ b/doc/source/parameters.yaml
@@ -931,6 +931,12 @@ vswitch_list:
   in: body
   required: true
   type: list
+grant_userid:
+  description: |
+    Guest userid.
+  in: body
+  required: true
+  type: string
 imagename:
   description: |
     Retrieve the specified image information, if not specified,
@@ -1260,6 +1266,12 @@ fcp_id:
   description: |
     ID of FCP device.
   in: path
+  required: true
+  type: string
+fcp_userid:
+  description: |
+    Guest userid.
+  in: body
   required: true
   type: string
 fcp_usage:

--- a/doc/source/restapi.rst
+++ b/doc/source/restapi.rst
@@ -487,7 +487,7 @@ Set the FCP usage in database for z/VM.
 .. restapi_parameters:: parameters.yaml
 
   - fcp_id: fcp_id
-  - userid: guest_userid
+  - userid: fcp_userid
   - reserved: fcp_reserve
   - connections: fcp_connections
 
@@ -1921,7 +1921,7 @@ Grant an user to access vswitch
 
   - name: vswitch_name
   - vswitch: vswitch_info
-  - grant_userid: guest_userid
+  - grant_userid: grant_userid
 
 * Request sample:
 
@@ -1949,7 +1949,7 @@ Revoke the user access from vswitch
 
   - name: vswitch_name
   - vswitch: vswitch_info
-  - revoke_userid: guest_userid
+  - revoke_userid: grant_userid
 
 * Request sample:
 
@@ -1978,7 +1978,7 @@ Set vlan id for user when connecting to the vswitch
   - name: vswitch_name
   - vswitch: vswitch_info
   - user_vlan_id: user_vlan_id
-  - userid: guest_userid
+  - userid: grant_userid
   - vlanid: vlan_id
 
 * Request sample:


### PR DESCRIPTION
In the API doc, some `userid` parameters are marked as if they were in the `path`, while they are in the `body`.

This PR fixes the 4 cases I have found.


7.5.11. Set FCP Usage
```
  userid path string Guest userid
  ->
  userid body string Guest userid.
```

7.8.4. Grant user to vswitch
```
  grant_userid path string Guest userid
  ->
  grant_userid body string Guest userid.
```

7.8.5. Revoke user from vswitch
```
  revoke_userid path string Guest userid
  ->
  revoke_userid body string Guest userid.
```

7.8.6. Set user VLANID to vswitch
```
  userid path string Guest userid
  ->
  userid body string Guest userid.
```