### PR TITLE
Doc: update list of supported operating systems

### DIFF
--- a/doc/source/parameters.yaml
+++ b/doc/source/parameters.yaml
@@ -698,10 +698,11 @@ image_export_url:
   type: string
 image_metadata:
   description: |
-    The metadata which describes image, the valid keys are os_version, md5sum and disk_type,
-    os_version is required key, the valid os_version values are: rhel6.x, rhel7.x,
-    sles11.x, sles12.x, ubuntu16.x, rhcos4.X, all case insensitive, please contact with your cloud administrator
-    if you don't know the image's os version. disk_type is required if os_version is rhcos4,
+    The metadata which describes the image, the valid keys are os_version, md5sum and disk_type.
+    os_version is a required key, the valid values are: rhel6.x, rhel7.x, rhel8.x,
+    rhel9.x, sles11.x, sles12.x, sles15.x, ubuntu16.x, ubuntu20.x, ubuntu22.x, rhcos4.x,
+    all case insensitive. Please contact your cloud administrator
+    if you don't know the image's OS version. disk_type is required if os_version is rhcos4,
     the valid disk_type values are: DASD, SCSI.
   in: body
   required: true
@@ -1039,17 +1040,10 @@ network_interface_info:
   type: dict
 guest_os_version:
   description: |
-    Operating system version, the valid os_version values are: rhel6.x, rhel7.x,
-    sles11.x, sles12.x, ubuntu16.x, all case insensitive, please contact with your
-    cloud administrator if you don't know the guest's os version
-  in: body
-  required: true
-  type: string
-guest_os_version_all:
-  description: |
-    Operating system version, the valid os_version values are: rhel6.x, rhel7.x,
-    sles11.x, sles12.x, ubuntu16.x, rhcos4.x, all case insensitive, please contact with your
-    cloud administrator if you don't know the guest's os version
+    Operating system version, the valid alues are: rhel6.x, rhel7.x, rhel8.x,
+    rhel9.x, sles11.x, sles12.x, sles15.x, ubuntu16.x, ubuntu20.x, ubuntu22.x, rhcos4.x,
+    all case insensitive. Please contact your cloud administrator if you don't know
+    the guest's OS version.
   in: body
   required: true
   type: string

--- a/doc/source/restapi.rst
+++ b/doc/source/restapi.rst
@@ -815,7 +815,7 @@ Create one or more network interfaces on giving guest.
 
   - userid: guest_userid
   - interface: network_interface_info
-  - os_version: guest_os_version_all
+  - os_version: guest_os_version
   - guest_networks: guest_networks_list
   - active: active_flag
 
@@ -1684,7 +1684,7 @@ Get the list of image info in image repository.
 
   - output: image_info
   - imagename: image_name
-  - imageosdistro: guest_os_version_all
+  - imageosdistro: guest_os_version
   - md5sum: image_md5sum
   - disk_size_units: root_disk_size_image
   - image_size_in_bytes: physical_disk_size_image


### PR DESCRIPTION
This PR synchronizes the documentation with the code of `get_linux_dist()`:
```
        supported = {'rhel': ['6', '7', '8', '9'],
                     'sles': ['11', '12', '15'],
                     'ubuntu': ['16', '20', '22'],
                     'rhcos': ['4']}
```
`rhel8.x`, `rhel9.x`, `sles15.x`, `ubuntu20.x`, and `ubuntu22.x` were missing in the doc.

These texts are used in:
 * documentation parameter `image_metadata`
      for `Create image`
  * documentation parameter `guest_os_version`
      for `Attach volume`, `Detach volume`, `Delete network interface`, and `Grow root volume of guest`
  * documentation parameter `guest_os_version_all`
     for `Create network interface` and `List images`

I tried to follow all code paths and it seemed to me they all call `get_linux_dist()`. Please double-check as I am new to Feilong's source code, and an error is always possible.
