### PR TITLE
Doc: There is no "check info result"

### DIFF
--- a/doc/source/parameters.yaml
+++ b/doc/source/parameters.yaml
@@ -184,7 +184,7 @@ user_profile_guest:
   type: string
 user_direct_guest:
   description: |
-    Dictionary describing user direct and check info result
+    Dictionary with only one entry describing user directory.
   in: body
   required: true
   type: dict


### PR DESCRIPTION
`Show Guest definition` and `Get Guest user direct` API calls return only `user_direct`.

They could also return as "checked info"  a boolean `nic_coupled` if they were coded to call `VMOps.get_definition_info()` in a certain manner, but as far as I can see, they aren't.

This PR removes mention of checked info result from the doc.
