### PR TITLE
Doc: True is a boolean, not a string

### DIFF
--- a/zvmsdk/tests/fvt/api_templates/test_guest_create_network_interface.tpl
+++ b/zvmsdk/tests/fvt/api_templates/test_guest_create_network_interface.tpl
@@ -21,6 +21,6 @@
           "mac_addr": "02:00:00:12:34:78",
           "nic_id": "444-555-666"
       }],
-      "active": "True"
+      "active": True
   }
 }


### PR DESCRIPTION
`active` field is defined as a boolean, but the example shows it as a string.

This PR fixes the example.