### PR TITLE
Doc: Add content for "Get Guests interface stats" and "Get Guest stats including cpu and memory"

### DIFF
--- a/doc/source/parameters.yaml
+++ b/doc/source/parameters.yaml
@@ -356,7 +356,8 @@ userid_list_guest:
   type: string
 stats_guest:
   description: |
-    cpu and memory statics of guest
+    CPU and memory statistics of guests, as a dictionary where the
+    key is the userid and the value is the CPU and memory statistics.
   in: body
   required: true
   type: dict
@@ -1377,6 +1378,90 @@ healthy:
   in: body
   required: true
   type: boolean
+guest_cpus:
+  description: |
+    The count of virtual CPUs for the guest.
+  in: body
+  required: true
+  type: integer
+used_cpu_time_us:
+  description: |
+    The CPU time used in microseconds.
+  in: body
+  required: true
+  type: integer
+elapsed_cpu_time_us:
+  description: |
+    The CPU time elapsed in microseconds.
+  in: body
+  required: true
+  type: integer
+min_cpu_count:
+  description: |
+    The minimal count of virtual CPUs allowed.
+  in: body
+  required: true
+  type: integer
+max_cpu_limit:
+  description: |
+    The maximal count of virtual CPUs allowed.
+  in: body
+  required: true
+  type: integer
+samples_cpu_in_use:
+  description: |
+    Samples CPU in use.
+  in: body
+  required: true
+  type: integer
+samples_cpu_delay:
+  description: |
+    Samples CPU delay.
+  in: body
+  required: true
+  type: integer
+used_mem_kb:
+  description: |
+    Memory size used by the guest, in KBytes.
+  in: body
+  required: true
+  type: integer
+max_mem_kb:
+  description: |
+    The maximum memory in KBytes that can be allocated for this guest.
+  in: body
+  required: true
+  type: integer
+min_mem_kb:
+  description: |
+    The maximum memory in KBytes that can be allocated for this guest.
+  in: body
+  required: true
+  type: integer
+shared_mem_kb:
+  description: |
+    Shared memory in KBytes.
+  in: body
+  required: true
+  type: integer
+total_memory:
+  description: |
+    Total memory.
+  in: body
+  required: true
+  type: integer
+available_memory:
+  description: |
+    Available memory.
+  in: body
+  required: true
+  type: integer
+free_memory:
+  description: |
+    Free memory.
+  in: body
+  required: true
+  type: integer
 nic_fr_rx:
   description: |
     Number of received frames.

--- a/doc/source/parameters.yaml
+++ b/doc/source/parameters.yaml
@@ -154,7 +154,8 @@ guest_memory_kb_max:
   type: integer
 guest_vnics:
   description: |
-    vNICs statistics of one guest.
+    vNIC statistics of guests, as a dictionary where the key is
+    the userid and the value is a list of vNIC statistics.
   in: body
   required: true
   type: dict
@@ -1376,3 +1377,51 @@ healthy:
   in: body
   required: true
   type: boolean
+nic_fr_rx:
+  description: |
+    Number of received frames.
+  in: body
+  required: true
+  type: integer
+nic_fr_tx:
+  description: |
+    Number of transmitted frames.
+  in: body
+  required: true
+  type: integer
+nic_fr_rx_dsc:
+  description: |
+    Number of received frames that have been discarded.
+  in: body
+  required: true
+  type: integer
+nic_fr_tx_dsc:
+  description: |
+    Number of transmitted frames that have been discarded.
+  in: body
+  required: true
+  type: integer
+nic_fr_rx_err:
+  description: |
+    Number of received frames that were in error.
+  in: body
+  required: true
+  type: integer
+nic_fr_tx_err:
+  description: |
+    Number of transmitted frames that were in error.
+  in: body
+  required: true
+  type: integer
+nic_rx:
+  description: |
+    Number of received bytes.
+  in: body
+  required: true
+  type: integer
+nic_tx:
+  description: |
+    Number of transmitted bytes.
+  in: body
+  required: true
+  type: integer

--- a/doc/source/restapi.rst
+++ b/doc/source/restapi.rst
@@ -522,6 +522,20 @@ Get guests cpu, memory information.
 .. restapi_parameters:: parameters.yaml
 
   - output: stats_guest
+  - guest_cpus: guest_cpus
+  - used_cpu_time_us: used_cpu_time_us
+  - elapsed_cpu_time_us: elapsed_cpu_time_us
+  - min_cpu_count: min_cpu_count
+  - max_cpu_limit: max_cpu_limit
+  - samples_cpu_in_use: samples_cpu_in_use
+  - samples_cpu_delay: samples_cpu_delay
+  - used_mem_kb: used_mem_kb
+  - max_mem_kb: max_mem_kb
+  - min_mem_kb: min_mem_kb
+  - shared_mem_kb: shared_mem_kb
+  - total_memory: total_memory
+  - available_memory: available_memory
+  - free_memory: free_memory
 
 * Response sample:
 

--- a/doc/source/restapi.rst
+++ b/doc/source/restapi.rst
@@ -550,6 +550,16 @@ Get guests network interface statistics.
 .. restapi_parameters:: parameters.yaml
 
   - output: guest_vnics
+  - vswitch_name: vswitch_name_opt
+  - nic_vdev: nic_interface
+  - nic_fr_rx: nic_fr_rx
+  - nic_fr_tx: nic_fr_tx
+  - nic_fr_rx_dsc: nic_fr_rx_dsc
+  - nic_fr_tx_dsc: nic_fr_tx_dsc
+  - nic_fr_rx_err: nic_fr_rx_err
+  - nic_fr_tx_err: nic_fr_tx_err
+  - nic_rx: nic_rx
+  - nic_tx: nic_tx
 
 * Response sample:
 

--- a/zvmsdk/tests/fvt/api_templates/test_guests_get_interface_stats.tpl
+++ b/zvmsdk/tests/fvt/api_templates/test_guests_get_interface_stats.tpl
@@ -4,5 +4,20 @@
     "modID": null,
     "rc": 0,
     "errmsg": "",
-    "output": {}
+    "output": {
+        "MYGUEST": [
+            {
+                "vswitch_name": "MYSWITCH",
+                "nic_vdev": "1000",
+                "nic_fr_rx": 116686,
+                "nic_fr_tx": 14892,
+                "nic_fr_rx_dsc": 0,
+                "nic_fr_tx_dsc": 0,
+                "nic_fr_rx_err": 0,
+                "nic_fr_tx_err": 0,
+                "nic_rx": 6131168,
+                "nic_tx": 1367740
+            }
+        ]
+    }
 }

--- a/zvmsdk/tests/fvt/api_templates/test_guests_get_stats.tpl
+++ b/zvmsdk/tests/fvt/api_templates/test_guests_get_stats.tpl
@@ -4,5 +4,22 @@
     "modID": null,
     "rc": 0,
     "errmsg": "",
-    "output": {}
+    "output": {
+        "MYGUEST": {
+            "guest_cpus": 2,
+            "used_cpu_time_us": 509530870,
+            "elapsed_cpu_time_us": 260788896874,
+            "min_cpu_count": 2,
+            "max_cpu_limit": 10000,
+            "samples_cpu_in_use": 335,
+            "samples_cpu_delay": 116,
+            "used_mem_kb": 396232,
+            "max_mem_kb": 2097152,
+            "min_mem_kb": 0,
+            "shared_mem_kb": 396232,
+            "total_memory": 2030428,
+            "available_memory": 892136,
+            "free_memory": 791368
+        }
+    }
 }


### PR DESCRIPTION
Current documentation at https://cloudlib4zvm.readthedocs.io/en/latest/restapi.html#get-guests-interface-stats and at https://cloudlib4zvm.readthedocs.io/en/latest/restapi.html#get-guests-stats-including-cpu-and-memory
has no detailed field description nor complete example.

This PR fixes that.