### PR TITLE
Multipath is a boolean, not a string

### DIFF
--- a/zvmsdk/tests/unit/test_volumeop.py
+++ b/zvmsdk/tests/unit/test_volumeop.py
@@ -2103,7 +2103,7 @@ class TestFCPVolumeManager(base.SDKTestCase):
         connection_info = {'platform': 'x86_64',
                            'ip': '1.2.3.4',
                            'os_version': 'rhel7',
-                           'multipath': 'false',
+                           'multipath': False,
                            'target_wwpn': ['20076D8500005182',
                                            '20076D8500005183'],
                            'target_lun': '2222',
@@ -2166,7 +2166,7 @@ class TestFCPVolumeManager(base.SDKTestCase):
         connection_info = {'platform': 'x86_64',
                            'ip': '1.2.3.4',
                            'os_version': 'rhel7',
-                           'multipath': 'false',
+                           'multipath': False,
                            'target_wwpn': ['20076D8500005182'],
                            'target_lun': '2222',
                            'zvm_fcp': ['E83C', 'D83C'],
@@ -2194,7 +2194,7 @@ class TestFCPVolumeManager(base.SDKTestCase):
         connection_info = {'platform': 's390x',
                            'ip': '1.2.3.4',
                            'os_version': 'rhel7',
-                           'multipath': 'false',
+                           'multipath': False,
                            'target_wwpn': ['20076D8500005182',
                                            '20076D8500005183'],
                            'target_lun': '2222',
@@ -2258,7 +2258,7 @@ class TestFCPVolumeManager(base.SDKTestCase):
         connection_info = {'platform': 'x86_64',
                            'ip': '1.2.3.4',
                            'os_version': 'rhel7',
-                           'multipath': 'false',
+                           'multipath': False,
                            'target_wwpn': ['20076D8500005182',
                                            '20076D8500005183'],
                            'target_lun': '2222',
@@ -2313,7 +2313,7 @@ class TestFCPVolumeManager(base.SDKTestCase):
         connection_info = {'platform': 'x86_64',
                            'ip': '1.2.3.4',
                            'os_version': 'rhel7',
-                           'multipath': 'True',
+                           'multipath': True,
                            'target_wwpn': ['20076d8500005182',
                                            '20076d8500005183'],
                            'target_lun': '2222',
@@ -2323,14 +2323,13 @@ class TestFCPVolumeManager(base.SDKTestCase):
                            'fcp_template_id': 'tmpl_id',
                            'is_root_volume': False}
         mock_check_userid.return_value = True
-        multipath = True
         # case1: do_rollback as False
         connection_info['do_rollback'] = False
         self.volumeops.attach(connection_info)
         mock_do_attach.assert_called_once_with(
             connection_info['zvm_fcp'], connection_info['assigner_id'].upper(),
             connection_info['target_wwpn'], connection_info['target_lun'],
-            multipath, connection_info['os_version'],
+            connection_info['multipath'], connection_info['os_version'],
             connection_info['mount_point'], connection_info['is_root_volume'],
             connection_info['fcp_template_id'], do_rollback=False
         )
@@ -2341,7 +2340,7 @@ class TestFCPVolumeManager(base.SDKTestCase):
         mock_do_attach.assert_called_once_with(
             connection_info['zvm_fcp'], connection_info['assigner_id'].upper(),
             connection_info['target_wwpn'], connection_info['target_lun'],
-            multipath, connection_info['os_version'],
+            connection_info['multipath'], connection_info['os_version'],
             connection_info['mount_point'], connection_info['is_root_volume'],
             connection_info['fcp_template_id'], do_rollback=True
         )
@@ -2357,7 +2356,7 @@ class TestFCPVolumeManager(base.SDKTestCase):
         connection_info = {'platform': 'x86_64',
                            'ip': '1.2.3.4',
                            'os_version': 'rhel7',
-                           'multipath': 'false',
+                           'multipath': False,
                            'target_wwpn': ['20076D8500005182',
                                            '20076D8500005183'],
                            'target_lun': '2222',
@@ -2401,7 +2400,7 @@ class TestFCPVolumeManager(base.SDKTestCase):
         connection_info = {'platform': 'x86_64',
                            'ip': '1.2.3.4',
                            'os_version': 'rhel7',
-                           'multipath': 'false',
+                           'multipath': False,
                            'target_wwpn': ['20076D8500005182',
                                            '20076D8500005183'],
                            'target_lun': '2222',
@@ -2462,7 +2461,7 @@ class TestFCPVolumeManager(base.SDKTestCase):
         connection_info = {'platform': 'x86_64',
                            'ip': '1.2.3.4',
                            'os_version': 'rhel7',
-                           'multipath': 'false',
+                           'multipath': False,
                            'target_wwpn': ['20076D8500005182',
                                            '20076D8500005183'],
                            'target_lun': '2222',
@@ -2524,7 +2523,7 @@ class TestFCPVolumeManager(base.SDKTestCase):
         connection_info = {'platform': 'x86_64',
                            'ip': '1.2.3.4',
                            'os_version': 'rhel7',
-                           'multipath': 'True',
+                           'multipath': True,
                            'target_wwpn': ['20076D8500005182',
                                            '20076D8500005183'],
                            'target_lun': '2222',
@@ -2588,7 +2587,7 @@ class TestFCPVolumeManager(base.SDKTestCase):
         connection_info = {'platform': 'x86_64',
                            'ip': '1.2.3.4',
                            'os_version': 'rhel7',
-                           'multipath': 'false',
+                           'multipath': False,
                            'target_wwpn': ['20076D8500005182',
                                            '20076D8500005183'],
                            'target_lun': '2222',
@@ -2650,7 +2649,7 @@ class TestFCPVolumeManager(base.SDKTestCase):
         connection_info = {'platform': 'x86_64',
                            'ip': '1.2.3.4',
                            'os_version': 'rhel7',
-                           'multipath': 'False',
+                           'multipath': False,
                            'target_wwpn': ['20076D8500005181',
                                            '20076D8500005182'],
                            'target_lun': '2222',
@@ -2723,7 +2722,7 @@ class TestFCPVolumeManager(base.SDKTestCase):
         connection_info = {'platform': 'x86_64',
                            'ip': '1.2.3.4',
                            'os_version': 'rhel7',
-                           'multipath': 'True',
+                           'multipath': True,
                            'target_wwpn': ['20076D8500005182',
                                            '20076D8500005183'],
                            'target_lun': '2222',
@@ -2784,7 +2783,7 @@ class TestFCPVolumeManager(base.SDKTestCase):
         connection_info = {'platform': 'x86_64',
                            'ip': '1.2.3.4',
                            'os_version': 'rhel7',
-                           'multipath': 'True',
+                           'multipath': True,
                            'target_wwpn': ['20076d8500005182',
                                            '20076d8500005183'],
                            'target_lun': '2222',
@@ -2795,12 +2794,11 @@ class TestFCPVolumeManager(base.SDKTestCase):
         connection_info['do_rollback'] = False
         connection_info['is_root_volume'] = False
         connection_info['update_connections_only'] = False
-        multipath = True
         self.volumeops.detach(connection_info)
         mock_do_detach.assert_called_once_with(
             connection_info['zvm_fcp'], connection_info['assigner_id'].upper(),
             connection_info['target_wwpn'], connection_info['target_lun'],
-            multipath, connection_info['os_version'],
+            connection_info['multipath'], connection_info['os_version'],
             connection_info['mount_point'], connection_info['is_root_volume'],
             connection_info['update_connections_only'], do_rollback=False
         )
@@ -2811,7 +2809,7 @@ class TestFCPVolumeManager(base.SDKTestCase):
         mock_do_detach.assert_called_once_with(
             connection_info['zvm_fcp'], connection_info['assigner_id'].upper(),
             connection_info['target_wwpn'], connection_info['target_lun'],
-            multipath, connection_info['os_version'],
+            connection_info['multipath'], connection_info['os_version'],
             connection_info['mount_point'], connection_info['is_root_volume'],
             connection_info['update_connections_only'], do_rollback=True
         )
@@ -2827,7 +2825,7 @@ class TestFCPVolumeManager(base.SDKTestCase):
         connection_info = {'platform': 's390x',
                            'ip': '1.2.3.4',
                            'os_version': 'rhel7',
-                           'multipath': 'True',
+                           'multipath': True,
                            'target_wwpn': ['20076D8500005182',
                                            '20076D8500005183'],
                            'target_lun': '2222',
@@ -2878,7 +2876,7 @@ class TestFCPVolumeManager(base.SDKTestCase):
         connection_info = {'platform': 's390x',
                            'ip': '1.2.3.4',
                            'os_version': 'rhel7',
-                           'multipath': 'True',
+                           'multipath': True,
                            'target_wwpn': ['20076D8500005182',
                                            '20076D8500005183'],
                            'target_lun': '2222',
@@ -2928,7 +2926,7 @@ class TestFCPVolumeManager(base.SDKTestCase):
         connection_info = {'platform': 'x86_64',
                            'ip': '1.2.3.4',
                            'os_version': 'rhel7',
-                           'multipath': 'False',
+                           'multipath': False,
                            'target_wwpn': ['1111'],
                            'target_lun': '2222',
                            'zvm_fcp': ['283c'],

--- a/zvmsdk/volumeop.py
+++ b/zvmsdk/volumeop.py
@@ -2307,11 +2307,7 @@ class FCPVolumeManager(object):
         wwpns = connection_info['target_wwpn']
         target_lun = connection_info['target_lun']
         assigner_id = connection_info['assigner_id'].upper()
-        multipath = connection_info['multipath'].lower()
-        if multipath == 'true':
-            multipath = True
-        else:
-            multipath = False
+        multipath = connection_info.get('multipath', False)
         os_version = connection_info['os_version']
         mount_point = connection_info['mount_point']
         is_root_volume = connection_info.get('is_root_volume', False)
@@ -2497,14 +2493,9 @@ class FCPVolumeManager(object):
         wwpns = connection_info['target_wwpn']
         target_lun = connection_info['target_lun']
         assigner_id = connection_info['assigner_id'].upper()
-        multipath = connection_info['multipath'].lower()
+        multipath = connection_info.get('multipath', False)
         os_version = connection_info['os_version']
         mount_point = connection_info['mount_point']
-        if multipath == 'true':
-            multipath = True
-        else:
-            multipath = False
-
         is_root_volume = connection_info.get('is_root_volume', False)
         update_connections_only = connection_info.get(
                 'update_connections_only', False)


### PR DESCRIPTION
When one tries to run the example at https://cloudlib4zvm.readthedocs.io/en/latest/restapi.html#attach-volume

i.e.
```
{
  "info":
  {
      "connection":
      {
        "assigner_id": "username",
        "zvm_fcp": "1fc5",
        "target_wwpn": "0x50050763050b073d",
        "target_lun": "0x4020400100000000",
        "os_version": "redhat7",
        "multipath": True,
        "mount_point": "/dev/sdz",
        "is_root_volume": False
      }
  }
}
```

the following exception is thrown:
```
HTTP status: 500, body: {"overallRC": 500, "modID": 100, "rc": 500, "rs": 1, "errmsg":
 "Unexpected internal error in ZVM SDK, error: (127.0.0.1:46170) SDK server got unexpected exception:
 AttributeError(\"'bool' object has no attribute 'lower'\")", "output": ""}
```

This PR fixes this problem.
