### PR TITLE
Doc: Missing parameter for "Create network interface"

### DIFF
--- a/doc/source/parameters.yaml
+++ b/doc/source/parameters.yaml
@@ -1063,6 +1063,7 @@ guest_networks_list:
     - ``mac_addr``: mac address
     - ``nic_id``: nic identifier
     - ``osa_device``: OSA device number, 1- to 4- hexadecimal digits
+    - ``hostname``: host name
   in: body
   required: true
   type: list


### PR DESCRIPTION
One missing parameter found when comparing to source code.