### PR TITLE
Fix the bug of argument active in guest_create_network_interface

### DIFF
--- a/zvmconnector/restclient.py
+++ b/zvmconnector/restclient.py
@@ -1,7 +1,7 @@
 #  Copyright Contributors to the Feilong Project.
 #  SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2017,2022 IBM Corp.
+# Copyright 2017,2024 IBM Corp.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -370,7 +370,8 @@ def req_guest_nic_uncouple_from_vswitch(start_index, *args, **kwargs):
 def req_guest_create_network_interface(start_index, *args, **kwargs):
     url = '/guests/%s/interface'
     body = {'interface': {'os_version': args[start_index],
-                          'guest_networks': args[start_index + 1]}}
+                          'guest_networks': args[start_index + 1],
+                          'active': args[start_index + 2]}}
     fill_kwargs_in_body(body['interface'], **kwargs)
     return url, body
 
@@ -879,7 +880,7 @@ DATABASE = {
         'request': req_guest_nic_uncouple_from_vswitch},
     'guest_create_network_interface': {
         'method': 'POST',
-        'args_required': 3,
+        'args_required': 4,
         'params_path': 1,
         'request': req_guest_create_network_interface},
     'guest_delete_network_interface': {

--- a/zvmsdk/sdkwsgi/schemas/guest.py
+++ b/zvmsdk/sdkwsgi/schemas/guest.py
@@ -1,7 +1,7 @@
 #  Copyright Contributors to the Feilong Project.
 #  SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2017,2018 IBM Corp.
+# Copyright 2017,2024 IBM Corp.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -95,7 +95,7 @@ create_network_interface = {
                 'guest_networks': parameter_types.network_list,
                 'active': parameter_types.boolean,
             },
-            'required': ['os_version', 'guest_networks'],
+            'required': ['os_version', 'guest_networks', 'active'],
             'additionalProperties': False,
         },
         'additionalProperties': False,

--- a/zvmsdk/tests/unit/sdkclientcases/test_restclient.py
+++ b/zvmsdk/tests/unit/sdkclientcases/test_restclient.py
@@ -1,7 +1,7 @@
 #  Copyright Contributors to the Feilong Project.
 #  SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2017, 2022 IBM Corp.
+# Copyright 2017, 2024 IBM Corp.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -652,8 +652,9 @@ class RESTClientTestCase(unittest.TestCase):
         request.return_value = self.response
         get_token.return_value = self._tmp_token()
 
+        # **kwargs accepts the key=val arguments
         self.client.call("guest_create_network_interface", self.fake_userid,
-                         'rhel7.2', networks, active=False)
+                         'rhel7.2', networks, False)
         request.assert_called_with(method, full_uri,
                                    data=body, headers=header,
                                    verify=False)

--- a/zvmsdk/tests/unit/sdkwsgi/handlers/test_guest.py
+++ b/zvmsdk/tests/unit/sdkwsgi/handlers/test_guest.py
@@ -799,7 +799,8 @@ class HandlersGuestTest(SDKWSGITest):
                                       "gateway_addr": "192.168.95.1",
                                       "cidr": "192.168.95.0/24",
                                       "nic_vdev": "1000",
-                                      "mac_addr": "02:00:00:12:34:56"}]}}"""
+                                      "mac_addr": "02:00:00:12:34:56"}],
+                                 "active": "False"}}"""
         self.req.body = bstr
         mock_userid.return_value = FAKE_USERID
         mock_interface.return_value = ''
@@ -832,7 +833,8 @@ class HandlersGuestTest(SDKWSGITest):
                                       "cidr": "192.168.95.0/24",
                                       "nic_vdev": "1000",
                                       "mac_addr": "02:00:00:12:34:56",
-                                      "osa_device": "AABB"}]}}"""
+                                      "osa_device": "AABB"}],
+                                 "active": "True"}}"""
         self.req.body = bstr
         mock_userid.return_value = FAKE_USERID
         mock_interface.return_value = ''
@@ -843,7 +845,7 @@ class HandlersGuestTest(SDKWSGITest):
             FAKE_USERID,
             os_version=os_version,
             guest_networks=guest_networks,
-            active=False)
+            active=True)
 
     @mock.patch.object(util, 'wsgi_path_item')
     @mock.patch('zvmconnector.connector.ZVMConnector.send_request')
@@ -883,7 +885,8 @@ class HandlersGuestTest(SDKWSGITest):
                                       "gateway_addr": "192.168.95.1",
                                       "cidr": "192.168.95.0/24",
                                       "nic_vdev": "1000",
-                                      "mac_addr": "02:00:00:12:34:56"}]}}"""
+                                      "mac_addr": "02:00:00:12:34:56"}],
+                                 "active": "False"}}"""
         self.req.body = bstr
         mock_userid.return_value = FAKE_USERID
         mock_interface.return_value = ''
@@ -915,7 +918,8 @@ class HandlersGuestTest(SDKWSGITest):
                                       "gateway_addr": "192.168.95.1",
                                       "cidr": "192.168.95.0/24",
                                       "nic_vdev": "1000",
-                                      "mac_addr": "02:00:00:12:34:56"}]}}"""
+                                      "mac_addr": "02:00:00:12:34:56"}],
+                                 "active": "False"}}"""
         self.req.body = bstr
         mock_userid.return_value = FAKE_USERID
         mock_interface.return_value = ''
@@ -947,7 +951,8 @@ class HandlersGuestTest(SDKWSGITest):
                                       "gateway_addr": "192.168.95.1",
                                       "cidr": "192.168.95.0/24",
                                       "nic_vdev": "1000",
-                                      "mac_addr": "02:00:00:12:34:56"}]}}"""
+                                      "mac_addr": "02:00:00:12:34:56"}],
+                                 "active": "True"}}"""
         self.req.body = bstr
         mock_userid.return_value = FAKE_USERID
         mock_interface.return_value = ''
@@ -958,7 +963,7 @@ class HandlersGuestTest(SDKWSGITest):
             FAKE_USERID,
             os_version=os_version,
             guest_networks=guest_networks,
-            active=False)
+            active=True)
 
     @mock.patch.object(util, 'wsgi_path_item')
     @mock.patch('zvmconnector.connector.ZVMConnector.send_request')
@@ -979,7 +984,8 @@ class HandlersGuestTest(SDKWSGITest):
                                       "gateway_addr": "192.168.95.1",
                                       "cidr": "192.168.95.0/24",
                                       "nic_vdev": "1000",
-                                      "mac_addr": "02:00:00:12:34:56"}]}}"""
+                                      "mac_addr": "02:00:00:12:34:56"}],
+                                 "active": "False"}}"""
         self.req.body = bstr
         mock_userid.return_value = FAKE_USERID
         mock_interface.return_value = ''
@@ -1011,7 +1017,8 @@ class HandlersGuestTest(SDKWSGITest):
                                       "gateway_addr": "192.168.95.1",
                                       "cidr": "192.168.95.0/24",
                                       "nic_vdev": "1000",
-                                      "mac_addr": "02:00:00:12:34:56"}]}}"""
+                                      "mac_addr": "02:00:00:12:34:56"}],
+                                 "active": "False"}}"""
         self.req.body = bstr
         mock_userid.return_value = FAKE_USERID
         mock_interface.return_value = ''
@@ -1036,7 +1043,8 @@ class HandlersGuestTest(SDKWSGITest):
                                       "gateway_addr": "192.168.95.1",
                                       "cidr": "192.168.95.0/24",
                                       "nic_vdev": "1000",
-                                      "mac_addr": "02:00:00:12:34:56"}]}}"""
+                                      "mac_addr": "02:00:00:12:34:56"}],
+                                 "active": "False"}}"""
         self.req.body = bstr
         mock_userid.return_value = FAKE_USERID
         mock_interface.return_value = ''
@@ -1057,7 +1065,8 @@ class HandlersGuestTest(SDKWSGITest):
                                       "gateway_addr": "192.168.95.1",
                                       "cidr": "192.168.95.0/24",
                                       "nic_vdev": "1000",
-                                      "mac_addr": "02:00:00:12:34:56"}]}}"""
+                                      "mac_addr": "02:00:00:12:34:56"}],
+                                 "active": "False"}}"""
         self.req.body = bstr
         mock_userid.return_value = FAKE_USERID
         mock_interface.return_value = ''
@@ -1078,7 +1087,8 @@ class HandlersGuestTest(SDKWSGITest):
                                       "gateway_addr": "192.168.95.1",
                                       "cidr": "192.168.95.0/24",
                                       "nic_vdev": "1000",
-                                      "mac_addr": "02:00:00:12:34:56"}]}}"""
+                                      "mac_addr": "02:00:00:12:34:56"}],
+                                 "active": "False"}}"""
         self.req.body = bstr
         mock_userid.return_value = FAKE_USERID
         mock_interface.return_value = ''
@@ -1099,7 +1109,8 @@ class HandlersGuestTest(SDKWSGITest):
                                       "gateway_addr": "192.168.95.1",
                                       "cidr": "192.168.95.0/24",
                                       "nic_vdev": "1000",
-                                      "mac_addr": "02:00:00:12:34:56"}]}}"""
+                                      "mac_addr": "02:00:00:12:34:56"}],
+                                 "active": "False"}}"""
         self.req.body = bstr
         mock_userid.return_value = FAKE_USERID
         mock_interface.return_value = ''


### PR DESCRIPTION
This problem wasn't exposed because we always use the default value of False before in the deployment. But it has the problem when we try to pass the "Active=True" in attach_interface.

Signed-off-by: QingFeng Hao <haoqf@linux.vnet.ibm.com>