### PR TITLE
[master]Change userid pattern to only support letters and numbers

### DIFF
--- a/zvmsdk/sdkwsgi/validation/parameter_types.py
+++ b/zvmsdk/sdkwsgi/validation/parameter_types.py
@@ -261,7 +261,7 @@ userid = {
     'type': ['string'],
     'minLength': 1,
     'maxLength': 8,
-    'pattern': '^(\w{,8})$'
+    'pattern': '^[a-zA-Z0-9]{1,8}$'
 }
 
 
@@ -301,7 +301,7 @@ userid_or_None = {
     'oneOf': [
         {'type': 'null'},
         {'type': ['string'], 'minLength': 1,
-         'maxLength': 8, 'pattern': '^(\w{,8})$'}
+         'maxLength': 8, 'pattern': '^[a-zA-Z0-9]{1,8}$'}
     ]
 }
 
@@ -334,14 +334,14 @@ cidr = {
 userid_list = {
     'type': ['string'],
     # TODO:validate userid_list in inspect APIs
-    'pattern': '^(\s*\w{1,8}\s*)(,\s*\w{1,8}\s*){0,}$'
+    'pattern': '^(\s*[a-zA-Z0-9]{1,8}\s*)(,\s*[a-zA-Z0-9]{1,8}\s*){0,}$'
 }
 
 userid_list_array = {
     'items': {
         'type': ['string'],
         'minLength': 1,
-        'pattern': '^(\s*\w{1,8}\s*)(,\s*\w{1,8}\s*){0,}$'
+        'pattern': '^(\s*[a-zA-Z0-9]{1,8}\s*)(,\s*[a-zA-Z0-9]{1,8}\s*){0,}$'
 
     },
     'type': 'array'

--- a/zvmsdk/tests/unit/sdkwsgi/handlers/test_guest.py
+++ b/zvmsdk/tests/unit/sdkwsgi/handlers/test_guest.py
@@ -581,10 +581,64 @@ class HandlersGuestTest(SDKWSGITest):
                                             1, 1, user_profile="profile1")
 
     def test_guest_create_invalid_userid(self):
+        body_str = '{"guest": {"userid": "name_1", "vcpus": 1, "memory": 1}}'
+        self.req.body = body_str
+
+        self.assertRaises(exception.ValidationError, guest.guest_create,
+                          self.req)
+
+        body_str = '{"guest": {"userid": "name@1", "vcpus": 1, "memory": 1}}'
+        self.req.body = body_str
+        self.assertRaises(exception.ValidationError, guest.guest_create,
+                          self.req)
         body_str = '{"guest": {"userid": ""}}'
         self.req.body = body_str
 
         self.assertRaises(exception.ValidationError, guest.guest_create,
+                          self.req)
+
+    @mock.patch('zvmsdk.sdkwsgi.handlers.guest._get_userid_list')
+    def test_guest_get_stats_with_invalid_array_useridlist(self, mock_useridlist):
+        # Test invalie userid list
+        fake_userid_list = {'userid': ['name_1', 'name2']}
+        mock_useridlist.reture_value = fake_userid_list
+        self.req.environ = {'wsgiorg.routing_args': [False, fake_userid_list]}
+        self.assertRaises(exception.ValidationError, guest.guest_get_stats,
+                          self.req)
+
+        mock_useridlist.reset()
+        fake_userid_list = {'userid': ['name@1', 'name2']}
+        mock_useridlist.return_value = fake_userid_list
+        self.req.environ = {'wsgiorg.routing_args': [False, fake_userid_list]}
+        self.assertRaises(exception.ValidationError, guest.guest_get_stats,
+                          self.req)
+
+        mock_useridlist.reset()
+        fake_userid_list = {'userid': ['name12345', 'name2']}
+        mock_useridlist.reture_value = fake_userid_list
+        self.req.environ = {'wsgiorg.routing_args': [False, fake_userid_list]}
+        self.assertRaises(exception.ValidationError, guest.guest_get_stats,
+                          self.req)
+
+    @mock.patch.object(util, 'wsgi_path_item')
+    def test_guest_get_power_state_with_invalid_useridlist(self, mock_wsig_item):
+        fake_userid_list = {'userid': 'name_1, name2'}
+        mock_wsig_item.return_value = fake_userid_list
+        self.req.environ = {'wsgiorg.routing_args': [False, fake_userid_list]}
+        self.assertRaises(exception.ValidationError, guest.guest_get_power_state,
+                          self.req)
+
+        mock_wsig_item.reset()
+        fake_userid_list = {'userid': 'name@1, name2'}
+        mock_wsig_item.return_value = fake_userid_list
+        self.req.environ = {'wsgiorg.routing_args': [False, fake_userid_list]}
+        self.assertRaises(exception.ValidationError, guest.guest_get_power_state,
+                          self.req)
+
+        fake_userid_list = {'userid': 'name12345, name2'}
+        mock_wsig_item.return_value = fake_userid_list
+        self.req.environ = {'wsgiorg.routing_args': [False, fake_userid_list]}
+        self.assertRaises(exception.ValidationError, guest.guest_get_power_state,
                           self.req)
 
     @mock.patch('zvmconnector.connector.ZVMConnector.send_request')


### PR DESCRIPTION
The character underline(_) is not supported by smapi, so remove it and only support letters and numbers.