### PR TITLE
Add API call to get minidisks list

### DIFF
--- a/doc/source/parameters.yaml
+++ b/doc/source/parameters.yaml
@@ -198,6 +198,14 @@ disk_list_guest:
   in: body
   required: false
   type: list
+minidisks_guest:
+  description: |
+    A list of disks info for the guest.
+    Each entry in this list describes a minidisk and is a dictionary
+    that contains some of the below keys.
+  in: body
+  required: false
+  type: list
 add_mdisk_disk_vdev:
   description: |
     when adding mdisk (either add after create or during create guest)
@@ -206,6 +214,12 @@ add_mdisk_disk_vdev:
     direct has something like `MDISK 0123`
   in: body
   required: false
+  type: string
+get_mdisk_disk_vdev:
+  description:
+    the virtual device number of the disk.
+  in: body
+  required: true
   type: string
 guest_ipl_from:
   description: |
@@ -1239,6 +1253,18 @@ vdev_disk:
   in: body
   required: true
   type: string
+rdev_disk:
+  description: |
+    the real device number of the disk.
+  in: body
+  required: true
+  type: string
+access_type:
+  description: |
+    type of access to the disk, either ``R/O`` or ``R/W``.
+  in: body
+  required: true
+  type: string
 disk_pool_output:
   description: |
     disk pool, the format is ``ECKD:eckdpoolname`` or ``FBA:fbapoolname``.
@@ -1249,6 +1275,24 @@ size_output:
   description: |
     size of disk, case insensitive, the unit can be in Megabytes (M),
     Gigabytes (G), for example, please ``512M``, ``1g``.
+  in: body
+  required: true
+  type: string
+size_no_unit:
+  description: |
+    the size of the disk, without unit.
+  in: body
+  required: true
+  type: integer
+device_units:
+  description: |
+    the unit for the size of the disk, for example ``Cylinders``.
+  in: body
+  required: true
+  type: string
+volume_label:
+  description: |
+    the volume label of the disk.
   in: body
   required: true
   type: string

--- a/doc/source/restapi.rst
+++ b/doc/source/restapi.rst
@@ -216,6 +216,39 @@ Create a vm in z/VM
 .. literalinclude:: ../../zvmsdk/tests/fvt/api_templates/test_guest_disk_output.tpl
    :language: javascript
 
+Get guest minidisks info
+------------------------
+
+**GET /guests/{userid}/disks**
+
+List characteristics of all disks of a guest
+
+* Request:
+
+  None
+
+* Response code:
+
+  HTTP status code 200 on success.
+
+* Response contents:
+
+.. restapi_parameters:: parameters.yaml
+
+  - userid: guest_userid
+  - minidisks: minidisks_guest
+  - vdev: get_mdisk_disk_vdev
+  - rdev: rdev_disk
+  - access_type: access_type
+  - device_size: size_no_unit
+  - device_units: device_units
+  - volume_label: volume_label
+
+* Response sample:
+
+.. literalinclude:: ../../zvmsdk/tests/fvt/api_templates/test_guest_disk_info_output.tpl
+   :language: javascript
+
 Guest add disks
 ---------------
 

--- a/zvmconnector/restclient.py
+++ b/zvmconnector/restclient.py
@@ -338,6 +338,12 @@ def req_guest_get_adapters_info(start_index, *args, **kwargs):
     return url, body
 
 
+def req_guest_get_disks_info(start_index, *args, **kwargs):
+    url = '/guests/%s/disks'
+    body = None
+    return url, body
+
+
 def req_guest_create_nic(start_index, *args, **kwargs):
     url = '/guests/%s/nic'
     body = {'nic': {}}
@@ -915,6 +921,11 @@ DATABASE = {
         'args_required': 2,
         'params_path': 1,
         'request': req_guest_config_minidisks},
+    'guest_get_disks_info': {
+        'method': 'GET',
+        'args_required': 1,
+        'params_path': 1,
+        'request': req_guest_get_disks_info},
     'volume_attach': {
         'method': 'POST',
         'args_required': 1,

--- a/zvmsdk/api.py
+++ b/zvmsdk/api.py
@@ -251,6 +251,18 @@ class SDKAPI(object):
         with zvmutils.log_and_reraise_sdkbase_error(action):
             return self._vmops.get_adapters_info(userid)
 
+    def guest_get_disks_info(self, userid):
+        """Get the disks information of a virtual machine.
+
+        :param str userid: the id of the virtual machine
+
+        :returns: Dictionary contains:
+                TODO
+        """
+        action = "get disks info of guest '%s'" % userid
+        with zvmutils.log_and_reraise_sdkbase_error(action):
+            return self._vmops.get_disks_info(userid)
+
     def guest_get_user_direct(self, userid):
         """Get user direct of the specified guest vm
 

--- a/zvmsdk/sdkwsgi/handler.py
+++ b/zvmsdk/sdkwsgi/handler.py
@@ -116,6 +116,7 @@ ROUTE_LIST = (
         'POST': guest.guest_create_disks,
         'DELETE': guest.guest_delete_disks,
         'PUT': guest.guest_config_disks,
+        'GET': guest.guest_get_disks_info,
     }),
     ('/smapi-healthy', {
         'GET': healthy.healthy,

--- a/zvmsdk/sdkwsgi/handlers/guest.py
+++ b/zvmsdk/sdkwsgi/handlers/guest.py
@@ -116,6 +116,11 @@ class VMHandler(object):
         return info
 
     @validation.query_schema(guest.userid_list_query)
+    def get_disks(self, req, userid):
+        info = self.client.send_request('guest_get_disks_info', userid)
+        return info
+
+    @validation.query_schema(guest.userid_list_query)
     def get_definition_info(self, req, userid):
         info = self.client.send_request('guest_get_definition_info', userid)
         return info
@@ -557,6 +562,25 @@ def guest_get_adapters_info(req):
 
     userid = util.wsgi_path_item(req.environ, 'userid')
     info = _guest_get_adapters_info(req, userid)
+
+    info_json = json.dumps(info)
+    req.response.status = util.get_http_code_from_sdk_return(info,
+        additional_handler=util.handle_not_found)
+    req.response.body = utils.to_utf8(info_json)
+    req.response.content_type = 'application/json'
+    return req.response
+
+
+@util.SdkWsgify
+@tokens.validate
+def guest_get_disks_info(req):
+
+    def _guest_get_disks_info(req, userid):
+        action = get_handler()
+        return action.get_disks(req, userid)
+
+    userid = util.wsgi_path_item(req.environ, 'userid')
+    info = _guest_get_disks_info(req, userid)
 
     info_json = json.dumps(info)
     req.response.status = util.get_http_code_from_sdk_return(info,

--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -387,6 +387,41 @@ class SMTClient(object):
                 found_mac = False
         return adapters_info
 
+    def get_disks_info(self, userid):
+        rd = ' '.join((
+            "SMAPI %s API Image_Disk_Query" % userid,
+            "--operands",
+            "-k 'vdasd_id=all'"))
+        results = None
+        action = "get disk info of all disks"
+        with zvmutils.log_and_reraise_smt_request_failed(action):
+            results = self._request(rd)
+            ret = results['response']
+            disks_info = []
+            disk = dict()
+            for line in ret:
+                if line != "":
+                    key = line.split(':')[0].strip()
+                    value = line.split(':')[-1].strip()
+                    if key == 'DASD VDEV':
+                        disk['vdev'] = value
+                    elif key == 'RDEV':
+                        disk['rdev'] = value
+                    elif key == 'Access type':
+                        disk['access_type'] = value
+                    elif key == 'Device type':
+                        disk['device_type'] = value
+                    elif key == 'Device size':
+                        disk['device_size'] = int(value)
+                    elif key == 'Device units':
+                        disk['device_units'] = value
+                    elif key == 'Device volume label':
+                        disk['volume_label'] = value
+                else:
+                    disks_info.append(disk)
+                    disk = dict()
+        return disks_info
+
     def _parse_vswitch_inspect_data(self, rd_list):
         """ Parse the Virtual_Network_Vswitch_Query_Byte_Stats data to get
         inspect data.

--- a/zvmsdk/tests/fvt/api_templates/test_guest_disk_info_output.tpl
+++ b/zvmsdk/tests/fvt/api_templates/test_guest_disk_info_output.tpl
@@ -1,0 +1,17 @@
+{
+    "rs": 0,
+    "overallRC": 0,
+    "modID": null,
+    "rc": 0,
+    "errmsg": "",
+    "output": {
+        "minidisks": [{'vdev': '0100',
+                       'rdev': '6018',
+                       'access_type': 'R/W',
+                       'device_type': '3390',
+                       'device_size': 29128,
+                       'device_units': 'Cylinders',
+                       'volume_label': 'VM6018'}]
+
+    }
+}

--- a/zvmsdk/tests/unit/test_smtclient.py
+++ b/zvmsdk/tests/unit/test_smtclient.py
@@ -1391,6 +1391,49 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         self.assertEqual(ret[1]['mac_ip_version'], '4')
         self.assertEqual(ret[1]['mac_address'], '02:55:36:5D:48:57')
 
+    @mock.patch.object(smtclient.SMTClient, '_request')
+    def test_get_disks_info(self, request):
+        userid = 'FakeID'
+        rd = ' '.join((
+            "SMAPI %s API Image_Disk_Query" % userid,
+            "--operands",
+            "-k 'vdasd_id=all'"))
+        data = [
+            "DASD VDEV: 0100",
+            "  RDEV: 6018",
+            "  Access type: R/W",
+            "  Device type: 3390",
+            "  Device size: 17477",
+            "  Device units: Cylinders",
+            "  Device volume label: VM6018",
+            "",
+            "DASD VDEV: 0190",
+            "  RDEV: 6000",
+            "  Access type: R/O",
+            "  Device type: 3390",
+            "  Device size: 214",
+            "  Device units: Cylinders",
+            "  Device volume label: M01RES",
+            ""]
+        request.return_value = {'response': data}
+        ret = self._smtclient.get_disks_info('FakeID')
+        self.assertEqual(1, request.call_count)
+        request.assert_called_once_with(rd)
+        self.assertEqual(ret[0]['vdev'], '0100')
+        self.assertEqual(ret[0]['rdev'], '6018')
+        self.assertEqual(ret[0]['access_type'], 'R/W')
+        self.assertEqual(ret[0]['device_type'], '3390')
+        self.assertEqual(ret[0]['device_size'], 17477)
+        self.assertEqual(ret[0]['device_units'], 'Cylinders')
+        self.assertEqual(ret[0]['volume_label'], 'VM6018')
+        self.assertEqual(ret[1]['vdev'], '0190')
+        self.assertEqual(ret[1]['rdev'], '6000')
+        self.assertEqual(ret[1]['access_type'], 'R/O')
+        self.assertEqual(ret[1]['device_type'], '3390')
+        self.assertEqual(ret[1]['device_size'], 214)
+        self.assertEqual(ret[1]['device_units'], 'Cylinders')
+        self.assertEqual(ret[1]['volume_label'], 'M01RES')
+
     @mock.patch.object(zvmutils, 'get_smt_userid')
     @mock.patch.object(smtclient.SMTClient, '_request')
     @mock.patch.object(smtclient.SMTClient, 'query_vswitch')

--- a/zvmsdk/tests/unit/test_vmops.py
+++ b/zvmsdk/tests/unit/test_vmops.py
@@ -222,6 +222,21 @@ class SDKVMOpsTestCase(base.SDKTestCase):
         self.assertRaises(exception.ZVMVirtualMachineNotExist,
                           self.vmops.get_info, 'fakeid')
 
+    @mock.patch("zvmsdk.smtclient.SMTClient.get_disks_info")
+    def test_get_disks_info(self, get_disks_info):
+        minidisks = [{'vdev': '0100',
+                      'rdev': '6018',
+                      'access_type': 'R/W',
+                      'device_type': '3390',
+                      'device_size': 29128,
+                      'device_units': 'Cylinders',
+                      'volume_label': 'VM6018'}]
+        get_disks_info.return_value = minidisks
+        ret = self.vmops.get_disks_info('fakeid')
+        first_minidisk = ret['minidisks'][0]
+        self.assertEqual(first_minidisk['device_size'], 29128)
+        self.assertEqual(first_minidisk['device_units'], 'Cylinders')
+
     @mock.patch("zvmsdk.smtclient.SMTClient.get_adapters_info")
     def test_get_adapters_info(self, adapters_info):
         adapters = [{u'lan_owner': u'SYSTEM',

--- a/zvmsdk/vmops.py
+++ b/zvmsdk/vmops.py
@@ -149,6 +149,14 @@ class VMOps(object):
             raise exception.SDKInternalError(msg=msg, modID='guest')
         return {'adapters': adapters_info}
 
+    def get_disks_info(self, userid):
+        disks_info = self._smtclient.get_disks_info(userid)
+        if not disks_info:
+            msg = 'Get disks information failed on: %s' % userid
+            LOG.error(msg)
+            raise exception.SDKInternalError(msg=msg, modID='guest')
+        return {'minidisks': disks_info}
+
     def instance_metadata(self, instance, content, extra_md):
         pass
 


### PR DESCRIPTION
This PR adds missing GET operation for the list of minidisks of a guest:
```
GET /guests/{userid}/disks
```

This PR solves issue #796.

It contains changes to:
 * zvmsdk
 * zvmconnector
 * unit tests
 * documentation