### PR TITLE
Avoid the duplicated granting userid to vswitch

### DIFF
--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -1,7 +1,7 @@
 #  Copyright Contributors to the Feilong Project.
 #  SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2017,2022 IBM Corp.
+# Copyright 2017,2024 IBM Corp.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -1479,6 +1479,17 @@ class SMTClient(object):
 
     def grant_user_to_vswitch(self, vswitch_name, userid):
         """Set vswitch to grant user."""
+        # Check if the userid has already been granted for the vswitch,
+        # if yes, then do nothing. Otherwise, it will cause the existing
+        # NICs in the VM down on the vswitch.
+        vsw_info = self.query_vswitch(vswitch_name)
+        if (userid in vsw_info['authorized_users'] or
+            userid.lower() in vsw_info['authorized_users'] or
+            userid.upper() in vsw_info['authorized_users']):
+            LOG.info("The userid %s has already been granted to "
+                     "vswitch %s. Do nothing." % (userid, vswitch_name))
+            return
+
         smt_userid = zvmutils.get_smt_userid()
         requestData = ' '.join((
             'SMAPI %s API Virtual_Network_Vswitch_Set_Extended' % smt_userid,

--- a/zvmsdk/tests/unit/test_smtclient.py
+++ b/zvmsdk/tests/unit/test_smtclient.py
@@ -1393,8 +1393,10 @@ class SDKSMTClientTestCases(base.SDKTestCase):
 
     @mock.patch.object(zvmutils, 'get_smt_userid')
     @mock.patch.object(smtclient.SMTClient, '_request')
-    def test_grant_user_to_vswitch(self, request, userid):
+    @mock.patch.object(smtclient.SMTClient, 'query_vswitch')
+    def test_grant_user_to_vswitch(self, qvsw, request, userid):
         userid.return_value = 'FakeHostID'
+        qvsw.return_value = {'authorized_users': {'FakeID': 'fake data'}}
         vswitch_name = 'FakeVs'
         userid = 'FakeID'
         requestData = ' '.join((
@@ -1404,6 +1406,12 @@ class SDKSMTClientTestCases(base.SDKTestCase):
             "-k grant_userid=FakeID",
             "-k persist=YES"))
         self._smtclient.grant_user_to_vswitch(vswitch_name, userid)
+        qvsw.assert_called_once_with(vswitch_name)
+        request.assert_not_called()
+        qvsw.reset_mock()
+        qvsw.return_value = {'authorized_users': {'FakeABC': 'fake data'}}
+        self._smtclient.grant_user_to_vswitch(vswitch_name, userid)
+        qvsw.assert_called_once_with(vswitch_name)
         request.assert_called_once_with(requestData)
 
     @mock.patch.object(zvmutils, 'get_smt_userid')


### PR DESCRIPTION
Check if the userid has already been granted for the vswitch, if yes, then do nothing. Otherwise, it will cause the existing NICs in the VM down on the vswitch.