### PR TITLE
Fix[SMT]: Update rs code for error in live_resize_memory

### DIFF
--- a/zvmsdk/returncode.py
+++ b/zvmsdk/returncode.py
@@ -175,7 +175,9 @@ errors = {
                14: ("Failed to deploy image to userid: '%(userid)s', %(msg)s"),
                15: ("Failed to live resize cpus of guest: '%(userid)s', "
                     "error: enable new defined cpus failed: '%(err)s'."),
-               16: ("Failed to start the guest: '%(userid)s', %(msg)s")
+               16: ("Failed to start the guest: '%(userid)s', %(msg)s"),
+               17: ("Failed to live resize memory of guest: '%(userid)s', "
+                    "error: chmem command failed: '%(err)s'.")
                },
               "Operation on Guest failed"
               ],

--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -4460,7 +4460,7 @@ class SMTClient(object):
                     self._revert_user_direct(userid, user_direct)
                 # Finally raise the exception
                 raise exception.SDKGuestOperationError(
-                    rs=7, userid=userid, err=err1.format_message())
+                    rs=17, userid=userid, err=err1.format_message())
 
         LOG.info("Live resize memory for guest: '%s' finished successfully."
                  % userid)


### PR DESCRIPTION
z/VM: Fail to resize memory, but the error message wrongly reports `fail to resize CPU`.

**Changes for fix**:  
change `rs` code for error in `live_resize_memory`: `7` ==> `17`(newly defined for memory error)