### PR TITLE
SMAPI health

### DIFF
--- a/doc/source/parameters.yaml
+++ b/doc/source/parameters.yaml
@@ -110,6 +110,12 @@ sync_with_zvm:
   in: parameter
   required: false
   type: boolean
+smapi_health_report:
+  description: |
+    SMAPI health report
+  in: body
+  required: true
+  type: dict
 guest_list:
   description: |
     Guests list

--- a/doc/source/restapi.rst
+++ b/doc/source/restapi.rst
@@ -98,7 +98,7 @@ SMAPI Health
 Report health of SMAPI
 ----------------------
 
-**GET /smapi-healthy**
+**GET /smapi_health**
 
 Get health status of the SMAPI.
 
@@ -114,7 +114,7 @@ Get health status of the SMAPI.
 
 .. restapi_parameters:: parameters.yaml
 
-  - SMAPI: SMAPI
+  - output: smapi_health_report
   - totalSuccess: totalSuccess
   - totalFail: totalFail
   - lastSuccess: lastSuccess
@@ -126,6 +126,10 @@ Get health status of the SMAPI.
 
 .. literalinclude:: ../../zvmsdk/tests/fvt/api_templates/test_smapi_health.tpl
    :language: javascript
+
+* Note:
+
+  Old API call **GET /smapi-healthy** is deprecated.
 
 Guest(s)
 ========

--- a/doc/source/restapi.rst
+++ b/doc/source/restapi.rst
@@ -2139,9 +2139,9 @@ The Content-Type header contains the application/octet-stream value.
 
 
 Get Switch information based on port id
---------------------
+---------------------------------------
 
-**GET /switch
+**GET /switch**
 
 Get Switch information based on port id.
 
@@ -2149,7 +2149,7 @@ Get Switch information based on port id.
 
 .. restapi_parameters:: parameters.yaml
 
-  - portid: port id
+  - portid: port_id
 
 * Response code:
 

--- a/smtLayer/tests/unit/test_vmStatus.py
+++ b/smtLayer/tests/unit/test_vmStatus.py
@@ -29,7 +29,7 @@ class SMTvmStatusTestCase(base.SMTTestCase):
         s.RecordSuccess()
         s.RecordSuccess()
 
-        ret = s.Get()['SMAPI']
+        ret = s.Get()
         d = ret.pop('lastSuccess', None)
         self.assertIsNotNone(d)
         exp = {'continuousFail': 0,
@@ -44,7 +44,7 @@ class SMTvmStatusTestCase(base.SMTTestCase):
         s.RecordFail()
         s.RecordFail()
 
-        ret = s.Get()['SMAPI']
+        ret = s.Get()
         d = ret.pop('lastFail', None)
         self.assertIsNotNone(d)
         exp = {'continuousFail': 2,
@@ -60,7 +60,7 @@ class SMTvmStatusTestCase(base.SMTTestCase):
         for i in range(40):
             s.RecordFail()
 
-        ret = s.Get()['SMAPI']
+        ret = s.Get()
         d = ret.pop('lastFail', None)
         self.assertIsNotNone(d)
         m = ret.pop('lastSuccess', None)

--- a/smtLayer/vmStatus.py
+++ b/smtLayer/vmStatus.py
@@ -62,13 +62,12 @@ class SMAPIStatus():
         self.lock.release()
 
     def Get(self):
-        status = {'SMAPI':
-                  {'totalSuccess': self.totalSuccess,
+        status = {'totalSuccess': self.totalSuccess,
                   'totalFail': self.totalFail,
                   'lastSuccess': self.lastSuccess,
                   'lastFail': self.lastFail,
                   'continuousFail': self.continueFail,
-                  'healthy': self.IsHealthy()}
+                  'healthy': self.IsHealthy()
                  }
         return status
 

--- a/zvmconnector/restclient.py
+++ b/zvmconnector/restclient.py
@@ -112,6 +112,12 @@ def req_version(start_index, *args, **kwargs):
     return url, body
 
 
+def req_smapi_health(start_index, *args, **kwargs):
+    url = '/smapi_health'
+    body = None
+    return url, body
+
+
 def req_guest_list(start_index, *args, **kwargs):
     url = '/guests'
     body = None
@@ -724,6 +730,11 @@ DATABASE = {
         'args_required': 0,
         'params_path': 0,
         'request': req_version},
+    'smapi_health': {
+        'method': 'GET',
+        'args_required': 0,
+        'params_path': 0,
+        'request': req_smapi_health},
     'guest_create': {
         'method': 'POST',
         'args_required': 3,

--- a/zvmsdk/sdkwsgi/handler.py
+++ b/zvmsdk/sdkwsgi/handler.py
@@ -23,7 +23,8 @@ from zvmsdk import log
 from zvmsdk.sdkwsgi import util
 from zvmsdk.sdkwsgi.handlers import file
 from zvmsdk.sdkwsgi.handlers import guest
-from zvmsdk.sdkwsgi.handlers import healthy
+from zvmsdk.sdkwsgi.handlers import smapi
+from zvmsdk.sdkwsgi.handlers import healthy  # deprecated
 from zvmsdk.sdkwsgi.handlers import host
 from zvmsdk.sdkwsgi.handlers import image
 from zvmsdk.sdkwsgi.handlers import tokens
@@ -118,7 +119,10 @@ ROUTE_LIST = (
         'PUT': guest.guest_config_disks,
         'GET': guest.guest_get_disks_info,
     }),
-    ('/smapi-healthy', {
+    ('/smapi_health', {
+        'GET': smapi.health,
+    }),
+    ('/smapi-healthy', {  # deprecated
         'GET': healthy.healthy,
     }),
     ('/host', {

--- a/zvmsdk/sdkwsgi/handlers/smapi.py
+++ b/zvmsdk/sdkwsgi/handlers/smapi.py
@@ -15,7 +15,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-"""Deprecated handler - See 'smapi.py' instead"""
+"""Handler for SMAPI-related calls"""
 
 import json
 
@@ -27,13 +27,20 @@ from zvmsdk import utils
 
 @util.SdkWsgify
 @tokens.validate
-def healthy(req):
+def health(req):
 
-    s = vmStatus.GetSMAPIStatus()
-    output = {'SMAPI': s.Get()}
-    info_json = json.dumps(output)
+    def _smapi_health(req):
+        status = vmStatus.GetSMAPIStatus()
+        results = {'overallRC': 0, 'modID': None,
+                   'rc': 0, 'rs': 0,
+                   'errmsg': '',
+                   'output': status.Get()}
+        return results
+
+    info = _smapi_health(req)
+
+    info_json = json.dumps(info)
+    req.response.status = 200
     req.response.body = utils.to_utf8(info_json)
     req.response.content_type = 'application/json'
-    req.response.status = 200
-
     return req.response

--- a/zvmsdk/tests/fvt/api_templates/test_smapi_health.tpl
+++ b/zvmsdk/tests/fvt/api_templates/test_smapi_health.tpl
@@ -1,5 +1,10 @@
 {
-    "SMAPI": {
+    "rs": 0,
+    "overallRC": 0,
+    "modID": null,
+    "rc": 0,
+    "errmsg": "",
+    "output": {
         "totalSuccess": 0,
         "totalFail": 0,
         "lastSuccess": "",


### PR DESCRIPTION
This PR adds the missing fields to the output of "Report health of SMAPI" (see issue #774).

It preserves ascending compatibility by introducing a new API call with a slightly different URL:
 **GET /smapi_health**
 instead of **GET /smapi-healthy**.
The old call still exists with the old behaviour, but is documented as "deprecated".

* [x] new call
* [x] documentation
* [x] python client library
* [ ] unit test _?? did not find where to put one_


## Before

```
{
    "SMAPI": {
        "totalSuccess": 0,
        "totalFail": 0,
        "lastSuccess": "",
        "lastFail": "",
        "continuousFail": 0,
        "healthy": True
    }
}
```

## After

```
{
    "rs": 0,
    "overallRC": 0,
    "modID": null,
    "rc": 0,
    "errmsg": "",
    "output": {
        "totalSuccess": 0,
        "totalFail": 0,
        "lastSuccess": "",
        "lastFail": "",
        "continuousFail": 0,
        "healthy": True
    }
}
```