### PR TITLE
[master]support create swap device with vdisk

### DIFF
--- a/doc/source/zvmsdk.conf.sample
+++ b/doc/source/zvmsdk.conf.sample
@@ -449,11 +449,22 @@
 
 
 # 
-# For swap disk to create from mdisk instead of vdisk.
-# In boot from volume case, there might be no disk pool at all, then
+# If configure the dasd group, the user can configure `swap_default_with_mdisk`
+# to create swap device with MDISK or VDISK, the default value `True` means create
+# the swap device with MDISK, if `False`, create the swap device with VDISK.
+# 
+# This param is optional
+#swap_default_with_mdisk=True
+
+
+# 
+# For swap disk to create from mdisk instead of vdisk only for the below boot from
+# volume case. In boot from volume case, there might be no disk pool at all, then
 # the only choice is to use vdisk (or using FCP LUN which is complicated),
 # if customer doesn't want vdisk, then set this value to `True` so
-# VDISK will not be used and in turn it will fail check.
+# VDISK will not be used and in turn it will fail check. If the customer wants
+# to use MDISK to create swap device, he need configure dasd group and set
+# `swap_default_with_mdisk` to `True` which is the default value.
 # 
 # This param is optional
 #swap_force_mdisk=False

--- a/zvmsdk/config.py
+++ b/zvmsdk/config.py
@@ -251,12 +251,24 @@ The length of namelist must no longer than 64.
     Opt('swap_force_mdisk',
         section='zvm',
         default=False,
+        opt_type='bool',
         help='''
-For swap disk to create from mdisk instead of vdisk.
-In boot from volume case, there might be no disk pool at all, then
+For swap disk to create from mdisk instead of vdisk only for the below boot from
+volume case. In boot from volume case, there might be no disk pool at all, then
 the only choice is to use vdisk (or using FCP LUN which is complicated),
 if customer doesn't want vdisk, then set this value to `True` so
-VDISK will not be used and in turn it will fail check.
+VDISK will not be used and in turn it will fail check. If the customer wants
+to use MDISK to create swap device, he need configure dasd group and set
+`swap_default_with_mdisk` to `True` which is the default value.
+'''),
+    Opt('swap_default_with_mdisk',
+        section='zvm',
+        default=True,
+        opt_type='bool',
+        help='''
+If configure the dasd group, the user can configure `swap_default_with_mdisk`
+to create swap device with MDISK or VDISK, the default value `True` means create
+the swap device with MDISK, if `False`, create the swap device with VDISK.
 '''),
     Opt('remotehost_sshd_port',
         section='zvm',
@@ -716,6 +728,9 @@ class ConfigOpts(object):
                 # Convert type
                 if v2['type'] == 'int':
                     v2['default'] = int(v2['default'])
+                if v2['type'] == 'bool':
+                    if isinstance(v2['default'], str):
+                        v2['default'] = (v2['default'].lower() == 'true')
                 # Check format
                 if (k2 == "disk_pool") and (v2['default'] is not None):
                     self._check_zvm_disk_pool(v2['default'])


### PR DESCRIPTION
https://github.ibm.com/zvc/planning/issues/10607

previous config:
swap_force_mdisk: False only works for swap only case( disk_pool is None, bfv + swap)

new config:
swap_default_with_mdisk: True   applies for all the cases when disk_pool is not None (including bfv+swap), if True, create swap with mdisk, if False, create swap device with vdisk