### PR TITLE
SSC: tolerate the empty max cpu number in MACHINE ESA

### DIFF
--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -3669,7 +3669,19 @@ class SMTClient(object):
                 cpu_addr_long = ent.split()[3].strip().upper()
                 defined_addrs_long.append(cpu_addr_long)
             if ent.startswith("MACHINE ESA"):
-                max_cpus = int(ent.split()[2].strip())
+                # If defined the maximum number of virtual processors
+                # the user can define, update max_cpus value.
+                if len(ent.split()) > 2:
+                    max_cpus = int(ent.split()[2].strip())
+
+        # If empty max cpu number in MACHINE ESA, max_cpus should be set to default.
+        # The default max_cpus value is either 1 or the number of CPU statements
+        # for this user, whichever is greater.
+        if max_cpus == 0:
+            if len(defined_addrs) > 1 or len(defined_addrs_long) > 1:
+                max_cpus = max(len(defined_addrs), len(defined_addrs_long))
+            else:
+                max_cpus = 1
 
         return (max_cpus, defined_addrs, defined_addrs_long)
 

--- a/zvmsdk/tests/unit/test_smtclient.py
+++ b/zvmsdk/tests/unit/test_smtclient.py
@@ -4150,6 +4150,23 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         self.assertEqual(defined_addrs_long, ['00', '01'])
 
     @mock.patch.object(smtclient.SMTClient, 'get_user_direct')
+    def test_private_get_defined_cpu_addrs_default_max_cpu(self, get_user_direct):
+        get_user_direct.return_value = ['USER TESTUID LBYONLY 1024m 64G G',
+                                        'INCLUDE OSDFLT',
+                                        'IPL 0100',
+                                        'MACHINE ESA',
+                                        'NICDEF 1000 TYPE QDIO LAN '
+                                        'SYSTEM XCATVSW2 DEVICES 3',
+                                        'MDISK 0100 3390 52509 1100 OMB1AB MR',
+                                        '']
+        (max_cpus, defined_addrs, defined_addrs_long) = \
+            self._smtclient._get_defined_cpu_addrs('TESTUID')
+        get_user_direct.assert_called_once_with('TESTUID')
+        self.assertEqual(max_cpus, 1)
+        self.assertEqual(defined_addrs, [])
+        self.assertEqual(defined_addrs_long, [])
+
+    @mock.patch.object(smtclient.SMTClient, 'get_user_direct')
     def test_private_get_defined_cpu_addrs_no_max_cpu(self, get_user_direct):
         get_user_direct.return_value = ['USER TESTUID LBYONLY 1024m 64G G',
                                         'INCLUDE OSDFLT',
@@ -4163,7 +4180,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         (max_cpus, defined_addrs, defined_addrs_long) = \
             self._smtclient._get_defined_cpu_addrs('TESTUID')
         get_user_direct.assert_called_once_with('TESTUID')
-        self.assertEqual(max_cpus, 0)
+        self.assertEqual(max_cpus, 2)
         self.assertEqual(defined_addrs, ['00', '0A'])
         self.assertEqual(defined_addrs_long, [])
 


### PR DESCRIPTION
* Set maximum number of virtual processors to its default value if empty max cpu number defined in `MACHINE ESA`
* The default `max_cpus` value is either 1 or the number of CPU statements for this user, whichever is greater.
* Update UT for default `max_cpus`