### PR TITLE
Update zthin makefile to remove flag

### DIFF
--- a/zthin-parts/Makefile
+++ b/zthin-parts/Makefile
@@ -7,11 +7,7 @@ SRC_DIR = zthin/src/
 INCLUDE_DIR = zthin/include/
 ZTHINLIB = "libzthin.so"
 
-ifeq ($(OS_IS_RHEL8),1)
-	LINK_TIRPC = -ltirpc
-else
-	LINK_TIRPC =
-endif
+LINK_TIRPC = -ltirpc
 
 #-----------------------------------------------------------------------
 # Objects for utils


### PR DESCRIPTION
Removed the `ifeq ($(OS_IS_RHEL8),1)` flag in the zthin-parts makefile to avoid encountering error