### PR TITLE
fix readthedocs errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.coverage
 .project
 .pydevproject
 .python-version

--- a/doc/source/errcode.csv
+++ b/doc/source/errcode.csv
@@ -20,6 +20,7 @@
 300;10;300;14;Failed to deploy image to userid: '%(userid)s', %(msg)s
 300;10;300;15;Failed to live resize cpus of guest: '%(userid)s', error: enable new defined cpus failed: '%(err)s'.
 300;10;300;16;Failed to start the guest: '%(userid)s', %(msg)s
+300;10;300;17;Failed to live resize memory of guest: '%(userid)s', error: chmem command failed: '%(err)s'.
 **Operation on Network failed**
 300;20;300;1;Database operation failed, error: %(msg)s
 300;20;300;2;ZVMSDK network error: %(msg)s

--- a/doc/source/parameters.yaml
+++ b/doc/source/parameters.yaml
@@ -1567,3 +1567,9 @@ switch:
   in: body
   required: true
   type: string
+port_id:
+  description: |
+    The ID of the port.
+  in: body
+  required: true
+  type: string

--- a/doc/source/zvmsdk.conf.sample
+++ b/doc/source/zvmsdk.conf.sample
@@ -485,7 +485,7 @@
 # The default maximum size of memory the user can define.
 # This value is used as the default value for maximum memory size when
 # create a guest with no max_mem specified.
-# The value can be specified by 1-4 digits suffixed by either
+# The value can be specified by 1-4 bits of number suffixed by either
 # M (Megabytes) or G (Gigabytes) and the number must be a whole number,
 # values such as 4096.8M or 32.5G are not supported.
 # 
@@ -499,7 +499,7 @@
 # The default maximum size of reserved memory in a vm's direct entry.
 # This value is used as the default value for maximum reserved memory
 # size for a guest.
-# The value can be specified by 1-4 digits suffixed by either
+# The value can be specified by 1-4 bits of number suffixed by either
 # M (Megabytes) or G (Gigabytes) and the number must be a whole number,
 # values such as 4096.8M or 32.5G are not supported.
 # 


### PR DESCRIPTION
Fixed by import sphinx.util.logging to log info and warnings

Error:
```
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/envs/latest/lib/python3.6/site-packages/sphinx/cmd/build.py", line 281, in build_main
    app.build(args.force_all, args.filenames)
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/envs/latest/lib/python3.6/site-packages/sphinx/application.py", line 347, in build
    self.builder.build_update()
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/envs/latest/lib/python3.6/site-packages/sphinx/builders/__init__.py", line 312, in build_update
    len(to_build))
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/envs/latest/lib/python3.6/site-packages/sphinx/builders/__init__.py", line 326, in build
    updated_docnames = set(self.read())
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/envs/latest/lib/python3.6/site-packages/sphinx/builders/__init__.py", line 433, in read
    self._read_serial(docnames)
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/envs/latest/lib/python3.6/site-packages/sphinx/builders/__init__.py", line 454, in _read_serial
    self.read_doc(docname)
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/envs/latest/lib/python3.6/site-packages/sphinx/builders/__init__.py", line 510, in read_doc
    publisher.publish()
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/envs/latest/lib/python3.6/site-packages/docutils/core.py", line 218, in publish
    self.settings)
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/envs/latest/lib/python3.6/site-packages/sphinx/io.py", line 104, in read
    self.parse()
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/envs/latest/lib/python3.6/site-packages/docutils/readers/__init__.py", line 78, in parse
    self.parser.parse(self.input, document)
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/envs/latest/lib/python3.6/site-packages/sphinx/parsers.py", line 78, in parse
    self.statemachine.run(inputlines, document, inliner=self.inliner)
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/envs/latest/lib/python3.6/site-packages/docutils/parsers/rst/states.py", line 171, in run
    input_source=document['source'])
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/envs/latest/lib/python3.6/site-packages/docutils/statemachine.py", line 241, in run
    context, state, transitions)
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/envs/latest/lib/python3.6/site-packages/docutils/statemachine.py", line 452, in check_line
    return method(match, context, next_state)
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/envs/latest/lib/python3.6/site-packages/docutils/parsers/rst/states.py", line 2779, in underline
    self.section(title, source, style, lineno - 1, messages)
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/envs/latest/lib/python3.6/site-packages/docutils/parsers/rst/states.py", line 327, in section
    self.new_subsection(title, lineno, messages)
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/envs/latest/lib/python3.6/site-packages/docutils/parsers/rst/states.py", line 395, in new_subsection
    node=section_node, match_titles=True)
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/envs/latest/lib/python3.6/site-packages/docutils/parsers/rst/states.py", line 282, in nested_parse
    node=node, match_titles=match_titles)
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/envs/latest/lib/python3.6/site-packages/docutils/parsers/rst/states.py", line 196, in run
    results = StateMachineWS.run(self, input_lines, input_offset)
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/envs/latest/lib/python3.6/site-packages/docutils/statemachine.py", line 241, in run
    context, state, transitions)
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/envs/latest/lib/python3.6/site-packages/docutils/statemachine.py", line 452, in check_line
    return method(match, context, next_state)
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/envs/latest/lib/python3.6/site-packages/docutils/parsers/rst/states.py", line 2779, in underline
    self.section(title, source, style, lineno - 1, messages)
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/envs/latest/lib/python3.6/site-packages/docutils/parsers/rst/states.py", line 327, in section
    self.new_subsection(title, lineno, messages)
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/envs/latest/lib/python3.6/site-packages/docutils/parsers/rst/states.py", line 395, in new_subsection
    node=section_node, match_titles=True)
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/envs/latest/lib/python3.6/site-packages/docutils/parsers/rst/states.py", line 282, in nested_parse
    node=node, match_titles=match_titles)
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/envs/latest/lib/python3.6/site-packages/docutils/parsers/rst/states.py", line 196, in run
    results = StateMachineWS.run(self, input_lines, input_offset)
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/envs/latest/lib/python3.6/site-packages/docutils/statemachine.py", line 241, in run
    context, state, transitions)
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/envs/latest/lib/python3.6/site-packages/docutils/statemachine.py", line 452, in check_line
    return method(match, context, next_state)
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/envs/latest/lib/python3.6/site-packages/docutils/parsers/rst/states.py", line 2779, in underline
    self.section(title, source, style, lineno - 1, messages)
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/envs/latest/lib/python3.6/site-packages/docutils/parsers/rst/states.py", line 327, in section
    self.new_subsection(title, lineno, messages)
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/envs/latest/lib/python3.6/site-packages/docutils/parsers/rst/states.py", line 395, in new_subsection
    node=section_node, match_titles=True)
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/envs/latest/lib/python3.6/site-packages/docutils/parsers/rst/states.py", line 282, in nested_parse
    node=node, match_titles=match_titles)
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/envs/latest/lib/python3.6/site-packages/docutils/parsers/rst/states.py", line 196, in run
    results = StateMachineWS.run(self, input_lines, input_offset)
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/envs/latest/lib/python3.6/site-packages/docutils/statemachine.py", line 241, in run
    context, state, transitions)
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/envs/latest/lib/python3.6/site-packages/docutils/statemachine.py", line 452, in check_line
    return method(match, context, next_state)
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/envs/latest/lib/python3.6/site-packages/docutils/parsers/rst/states.py", line 2352, in explicit_markup
    nodelist, blank_finish = self.explicit_construct(match)
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/envs/latest/lib/python3.6/site-packages/docutils/parsers/rst/states.py", line 2364, in explicit_construct
    return method(self, expmatch)
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/envs/latest/lib/python3.6/site-packages/docutils/parsers/rst/states.py", line 2102, in directive
    directive_class, match, type_name, option_presets)
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/envs/latest/lib/python3.6/site-packages/docutils/parsers/rst/states.py", line 2151, in run_directive
    result = directive_instance.run()
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/checkouts/latest/doc/ext/restapi_parameters.py", line 145, in run
    self.yaml_from_file(self.yaml_file)
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/checkouts/latest/doc/ext/restapi_parameters.py", line 107, in yaml_from_file
    self.app.warn(
AttributeError: 'Sphinx' object has no attribute 'warn'

Exception occurred:
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudlib4zvm/checkouts/latest/doc/ext/restapi_parameters.py", line 107, in yaml_from_file
    self.app.warn(
AttributeError: 'Sphinx' object has no attribute 'warn'
```