### PR TITLE
Support SMAPI timeout configuration

### DIFF
--- a/doc/source/zvmsdk.conf.sample
+++ b/doc/source/zvmsdk.conf.sample
@@ -449,6 +449,31 @@
 
 
 # 
+# The timeout value for a long-duration SMAPI socket is specified in seconds.
+# 
+# The default value is 900 seconds.
+# 
+# SMAPIs are socket-based systems management application programming interfaces.
+# If the SMAPI socket connection of a long-duration operation exceeds this timeout,
+# the SMAPI long-duration operation will fail.
+# 
+# This param is optional
+#smapi_socket_long_call_timeout_seconds=900
+
+
+# 
+# The timeout value for a general SMAPI socket is specified in seconds.
+# 
+# The default value is 240 seconds.
+# 
+# SMAPIs are socket-based systems management application programming interfaces.
+# If the SMAPI socket connection exceeds this timeout, the SMAPI operation will fail.
+# 
+# This param is optional
+#smapi_socket_timeout_seconds=240
+
+
+# 
 # If configure the dasd group, the user can configure `swap_default_with_mdisk`
 # to create swap device with MDISK or VDISK, the default value `True` means create
 # the swap device with MDISK, if `False`, create the swap device with VDISK.

--- a/smtLayer/tests/unit/test_vmUtils.py
+++ b/smtLayer/tests/unit/test_vmUtils.py
@@ -50,4 +50,5 @@ class SMTvmUtilsTestCase(base.SMTTestCase):
             self.assertEqual(res['response'], expected_resp)
             exec_cmd.assert_called_once_with(
                 ['sudo', '/opt/zthin/bin/smcli', 'Image_Query_DM',
-                 '--addRCheader', '-T', 'fakeuid'], close_fds=True)
+                 '--addRCheader', '-T', 'fakeuid',
+                 '--timeout', '240'], close_fds=True)

--- a/zvmsdk/config.py
+++ b/zvmsdk/config.py
@@ -593,6 +593,35 @@ Possible values:
 Sample root disk in user directory:
     MDISK 0100 <disktype> <start> <end> <volumelabel> <readwrite>
 '''),
+    Opt('smapi_socket_timeout_seconds',
+        section='zvm',
+        required=False,
+        default=240,
+        opt_type='int',
+        help='''
+The timeout value for a general SMAPI socket is specified in seconds.
+
+The default value is 240 seconds.
+
+SMAPIs are socket-based systems management application programming interfaces.
+If the SMAPI socket connection exceeds this timeout, the SMAPI operation will fail.
+'''
+        ),
+    Opt('smapi_socket_long_call_timeout_seconds',
+        section='zvm',
+        required=False,
+        default=900,
+        opt_type='int',
+        help='''
+The timeout value for a long-duration SMAPI socket is specified in seconds.
+
+The default value is 900 seconds.
+
+SMAPIs are socket-based systems management application programming interfaces.
+If the SMAPI socket connection of a long-duration operation exceeds this timeout,
+the SMAPI long-duration operation will fail.
+'''
+        ),
     # tests options
     Opt('images',
         section='tests',

--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -117,9 +117,15 @@ class SMTClient(object):
 
                 rc = results.get('rc', 0)
                 if rc in [-110, -102, -103, -108]:
-                    msg += ("This is likely to be caused by temporary z/VM "
-                            "SMAPI down issue, Contact with your z/VM "
-                            "administrators for further help")
+                    if rc == -108:
+                        msg += ("This is likely to be caused by too short timeout "
+                                "specified for z/VM SMAPI. Update SMAPI timeout "
+                                "configuration in zvmsdk.conf. Contact with your z/VM "
+                                "administrators for further help")
+                    else:
+                        msg += ("This is likely to be caused by temporary z/VM "
+                                "SMAPI down issue, Contact with your z/VM "
+                                "administrators for further help")
 
                 raise exception.SDKInternalError(msg=msg,
                                                     modID='smt',


### PR DESCRIPTION
* add `smapi_socket_long_call_timeout_seconds` configuration in `zvmsdk.conf`
* add `smapi_socket_timeout_seconds` configuration in `zvmsdk.conf`
* take `VMRELOCATE` as long-duration operation
* use `smapi_socket_long_call_timeout_seconds` as timeout parameter when executing long-duration SMAPI
* use `smapi_socket_timeout_seconds` as timeout parameter when executing general SMAPI