### PR TITLE
Automating Feilong Package Building using Github Action

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -1,0 +1,18 @@
+name: Notify Feilong for Packaging
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  notify_buildsdk:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Trigger Feilong Packaging
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          repository: mfcloud/build-zvmsdk
+          event-type: obs-package


### PR DESCRIPTION
This feature allows us to use the `build-zvmsdk` repository to build the feilong packages for `zthin` and `zvmsdk` using OBS.

The theory behind this action is that on each push to the master branch on feilong, the github action will dispatch an event to the `build-zvmsdk` repo which will trigger it's own action to run scripts to generate new tarballs. 

- When `build-zvmsdk` receives the dispatched event from this (feilong) github action, it first runs a few script files to generate new tarballs from the latest version of the feilong master branch. 
- After creating all the source files, it downloads them as artifacts and pushes them to the master branch of `build-zvmsdk`.
- Once `build-zvmsdk` has a push, it triggers the webhook with OBS which causes each package hosted on OBS to download the required `tarballs` and/or `.dsc` files followed by triggering a rebuild for each package.


In order for this feature to work, we will need to have a Personal_Access_Token (PAT) added to the secrets in this (feilong) repository for the action to use. We will also need a PAT on the `build-zvmsdk` repo. This is the [PR](https://github.com/mfcloud/build-zvmsdk/pull/10) with the changes on the `build-zvmsdk` side.

Please create a PAT and add it to the `feilong` repository `secrets`
