### PR TITLE
Resize CPU with custom cpu share

### DIFF
--- a/zvmconnector/restclient.py
+++ b/zvmconnector/restclient.py
@@ -273,6 +273,8 @@ def req_guest_live_resize_cpus(start_index, *args, **kwargs):
     url = '/guests/%s/action'
     body = {'action': 'live_resize_cpus',
             'cpu_cnt': args[start_index]}
+    if len(args) - start_index == 2:
+        body['cpu_share'] = args[start_index + 1]
     return url, body
 
 
@@ -280,6 +282,8 @@ def req_guest_resize_cpus(start_index, *args, **kwargs):
     url = '/guests/%s/action'
     body = {'action': 'resize_cpus',
             'cpu_cnt': args[start_index]}
+    if len(args) - start_index == 2:
+        body['cpu_share'] = args[start_index + 1]
     return url, body
 
 
@@ -829,11 +833,13 @@ DATABASE = {
     'guest_live_resize_cpus': {
         'method': 'POST',
         'args_required': 2,
+        'args_optional': 1,
         'params_path': 1,
         'request': req_guest_live_resize_cpus},
     'guest_resize_cpus': {
         'method': 'POST',
         'args_required': 2,
+        'args_optional': 1,
         'params_path': 1,
         'request': req_guest_resize_cpus},
     'guest_live_resize_mem': {

--- a/zvmsdk/api.py
+++ b/zvmsdk/api.py
@@ -1005,7 +1005,7 @@ class SDKAPI(object):
                                          rdomain, pcif)
 
     @check_guest_exist()
-    def guest_live_resize_cpus(self, userid, cpu_cnt):
+    def guest_live_resize_cpus(self, userid, cpu_cnt, cpu_share=''):
         """Live resize virtual cpus of guests.
 
         :param userid: (str) the userid of the guest to be live resized
@@ -1018,11 +1018,11 @@ class SDKAPI(object):
                                                                        cpu_cnt)
         LOG.info("Begin to %s" % action)
         with zvmutils.log_and_reraise_sdkbase_error(action):
-            self._vmops.live_resize_cpus(userid, cpu_cnt)
+            self._vmops.live_resize_cpus(userid, cpu_cnt, cpu_share)
         LOG.info("%s successfully." % action)
 
     @check_guest_exist()
-    def guest_resize_cpus(self, userid, cpu_cnt):
+    def guest_resize_cpus(self, userid, cpu_cnt, cpu_share=''):
         """Resize virtual cpus of guests.
 
         :param userid: (str) the userid of the guest to be resized
@@ -1035,7 +1035,7 @@ class SDKAPI(object):
                                                                   cpu_cnt)
         LOG.info("Begin to %s" % action)
         with zvmutils.log_and_reraise_sdkbase_error(action):
-            self._vmops.resize_cpus(userid, cpu_cnt)
+            self._vmops.resize_cpus(userid, cpu_cnt, cpu_share)
         LOG.info("%s successfully." % action)
 
     @check_guest_exist()

--- a/zvmsdk/sdkwsgi/handlers/guest.py
+++ b/zvmsdk/sdkwsgi/handlers/guest.py
@@ -348,17 +348,25 @@ class VMAction(object):
     @validation.schema(guest.resize_cpus)
     def resize_cpus(self, userid, body):
         cpu_cnt = body['cpu_cnt']
-        info = self.client.send_request('guest_resize_cpus',
-                                        userid, cpu_cnt)
-
+        if 'cpu_share' in body:
+            cpu_share = body['cpu_share']
+            info = self.client.send_request('guest_resize_cpus',
+                                            userid, cpu_cnt, cpu_share)
+        else:
+            info = self.client.send_request('guest_resize_cpus',
+                                            userid, cpu_cnt)
         return info
 
     @validation.schema(guest.resize_cpus)
     def live_resize_cpus(self, userid, body):
         cpu_cnt = body['cpu_cnt']
-        info = self.client.send_request('guest_live_resize_cpus',
-                                        userid, cpu_cnt)
-
+        if 'cpu_share' in body:
+            cpu_share = body['cpu_share']
+            info = self.client.send_request('guest_live_resize_cpus',
+                                            userid, cpu_cnt, cpu_share)
+        else:
+            info = self.client.send_request('guest_live_resize_cpus',
+                                            userid, cpu_cnt)
         return info
 
     @validation.schema(guest.resize_mem)

--- a/zvmsdk/sdkwsgi/schemas/guest.py
+++ b/zvmsdk/sdkwsgi/schemas/guest.py
@@ -239,6 +239,7 @@ resize_cpus = {
     'type': 'object',
     'properties': {
         'cpu_cnt': parameter_types.max_cpu,
+        'cpu_share': parameter_types.share,
     },
     'required': ['cpu_cnt'],
     'additionalProperties': False,

--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -3736,7 +3736,7 @@ class SMTClient(object):
             offline_addrs.append(addr)
         return offline_addrs
 
-    def resize_cpus(self, userid, count):
+    def resize_cpus(self, userid, count, cpu_share=''):
         # Check defined cpus in user entry. If greater than requested, then
         # delete cpus. Otherwise, add new cpus.
         # Return value: for revert usage, a tuple of
@@ -3867,7 +3867,11 @@ class SMTClient(object):
                     rd += (" -k COMMAND_DEFINE_CPU=\'CPUADDR=%s TYPE=IFL\'" % addr2)
 
             # Add resize support for share of CPU
-            if CONF.zvm.user_default_share_unit > 0:
+            if cpu_share:
+                need_action = True
+                share, value = cpu_share.split(' ')
+                rd += (" -k SHARE=%s=%s" % (share, value))
+            elif CONF.zvm.user_default_share_unit > 0:
                 need_action = True
                 total = CONF.zvm.user_default_share_unit * count
                 rd += (" -k SHARE=RELATIVE=%s" % total)
@@ -3969,7 +3973,11 @@ class SMTClient(object):
                     rd += (" -k COMMAND_DEFINE_CPU=\'CPUADDR=%s TYPE=IFL\'" % addr2)
 
             # Add resize support for share of CPU
-            if CONF.zvm.user_default_share_unit > 0:
+            if cpu_share:
+                need_action = True
+                share, value = cpu_share.split(' ')
+                rd += (" -k SHARE=%s=%s" % (share, value))
+            elif CONF.zvm.user_default_share_unit > 0:
                 need_action = True
                 total = CONF.zvm.user_default_share_unit * count
                 rd += (" -k SHARE=RELATIVE=%s" % total)
@@ -3990,7 +3998,7 @@ class SMTClient(object):
 
             return (action, to_add_addrs_long + to_delete_addrs_long, max_cpus)
 
-    def live_resize_cpus(self, userid, count):
+    def live_resize_cpus(self, userid, count, cpu_share=''):
         # Get active cpu(online) count and compare with requested count
         active_addrs = self.get_active_cpu_addrs(userid)
         active_count = len(active_addrs)
@@ -4018,7 +4026,7 @@ class SMTClient(object):
         #                                      req=count)
 
         # Static resize CPUs. (add or delete CPUs from user directory)
-        (action, updated_addrs, max_cpus) = self.resize_cpus(userid, count)
+        (action, updated_addrs, max_cpus) = self.resize_cpus(userid, count, cpu_share)
         if active_count == count:
             # active count equals to requested
             LOG.info("Current active cpu count of guest: '%s' equals to the "

--- a/zvmsdk/tests/unit/test_api.py
+++ b/zvmsdk/tests/unit/test_api.py
@@ -522,14 +522,16 @@ class SDKAPITestCase(base.SDKTestCase):
     @mock.patch("zvmsdk.vmops.VMOps.live_resize_cpus")
     def test_guest_live_resize_cpus(self, live_resize_cpus):
         cpu_cnt = 3
-        self.api.guest_live_resize_cpus(self.userid, cpu_cnt)
-        live_resize_cpus.assert_called_once_with(self.userid, cpu_cnt)
+        cpu_share = 'RELATIVE 100'
+        self.api.guest_live_resize_cpus(self.userid, cpu_cnt, cpu_share)
+        live_resize_cpus.assert_called_once_with(self.userid, cpu_cnt, cpu_share)
 
     @mock.patch("zvmsdk.vmops.VMOps.resize_cpus")
     def test_guest_resize_cpus(self, resize_cpus):
         cpu_cnt = 3
-        self.api.guest_resize_cpus(self.userid, cpu_cnt)
-        resize_cpus.assert_called_once_with(self.userid, cpu_cnt)
+        cpu_share = 'RELATIVE 100'
+        self.api.guest_resize_cpus(self.userid, cpu_cnt, cpu_share)
+        resize_cpus.assert_called_once_with(self.userid, cpu_cnt, cpu_share)
 
     @mock.patch("zvmsdk.vmops.VMOps.live_resize_memory")
     def test_guest_live_resize_mem(self, live_resize_memory):

--- a/zvmsdk/tests/unit/test_smtclient.py
+++ b/zvmsdk/tests/unit/test_smtclient.py
@@ -4221,6 +4221,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
                               exec_cmd, request, get_offline, get_defined):
         userid = 'testuid'
         count = 4
+        cpu_share = 'RELATIVE 100'
         get_active.return_value = ['00', '01']
         get_offline.return_value = []
         get_defined.return_value = (32, [], ['00', '01'])
@@ -4236,9 +4237,9 @@ class SDKSMTClientTestCases(base.SDKTestCase):
                      '12', '13', '14', '15', '16', '17', '18', '19',
                      '1A', '1B', '1C', '1D', '1E', '1F']
         get_avail.return_value = avail_lst
-        self._smtclient.live_resize_cpus(userid, count)
+        self._smtclient.live_resize_cpus(userid, count, cpu_share)
         get_active.assert_called_once_with(userid)
-        resize.assert_called_once_with(userid, count)
+        resize.assert_called_once_with(userid, count, cpu_share)
         get_avail.assert_called_once_with(['00', '01'], 32)
         cmd_def_cpu = "vmcp def cpu 02 03"
         cmd_rescan_cpu = "chcpu -r"
@@ -4259,6 +4260,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
                               exec_cmd, request, get_offline, get_defined):
         userid = 'testuid'
         count = 4
+        cpu_share = 'RELATIVE 100'
         get_active.return_value = ['00', '01']
         get_offline.return_value = ['02']
         get_defined.return_value = (32, ['00'], ['00', '01'])
@@ -4275,9 +4277,9 @@ class SDKSMTClientTestCases(base.SDKTestCase):
                      '12', '13', '14', '15', '16', '17', '18', '19',
                      '1A', '1B', '1C', '1D', '1E', '1F']
         get_avail.return_value = avail_lst
-        self._smtclient.live_resize_cpus(userid, count)
+        self._smtclient.live_resize_cpus(userid, count, cpu_share)
         get_active.assert_called_once_with(userid)
-        resize.assert_called_once_with(userid, count)
+        resize.assert_called_once_with(userid, count, cpu_share)
         get_avail.assert_called_once_with(['00', '01'], 32)
         cmd_def_cpu = "vmcp def cpu 03"
         cmd_rescan_cpu = "chcpu -r"
@@ -4298,13 +4300,14 @@ class SDKSMTClientTestCases(base.SDKTestCase):
                                            exec_cmd, request, get_offline, get_defined):
         userid = 'testuid'
         count = 4
+        cpu_share = 'RELATIVE 100'
         get_active.return_value = ['00', '01', '02', '03']
         get_offline.return_value = []
         get_defined.return_value = (32, ['00', '01'], ['00', '01', '02', '03'])
         resize.return_value = (1, ['02', '03'], 32)
-        self._smtclient.live_resize_cpus(userid, count)
+        self._smtclient.live_resize_cpus(userid, count, cpu_share)
         get_active.assert_called_once_with(userid)
-        resize.assert_called_once_with(userid, count)
+        resize.assert_called_once_with(userid, count, cpu_share)
         get_avail.assert_not_called()
         exec_cmd.assert_not_called()
         request.assert_not_called()
@@ -4320,6 +4323,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
                                            exec_cmd, request, get_offline, get_defined):
         userid = 'testuid'
         count = 4
+        cpu_share = 'RELATIVE 100'
         get_active.return_value = ['00', '01', '02', '03', '04']
         get_offline.return_value = []
         get_defined.return_value = (32, ['00', '01'], ['00', '01', '02', '03', '04'])
@@ -4330,9 +4334,9 @@ class SDKSMTClientTestCases(base.SDKTestCase):
                                 [''],
                                 ['']]
 
-        self._smtclient.live_resize_cpus(userid, count)
+        self._smtclient.live_resize_cpus(userid, count, cpu_share)
         get_active.assert_called_once_with(userid)
-        resize.assert_called_once_with(userid, count)
+        resize.assert_called_once_with(userid, count, cpu_share)
         get_avail.assert_not_called()
         cmd_disable_cpu = "chcpu -d 04"
         exec_cmd.assert_has_calls([mock.call(userid, cmd_disable_cpu)])
@@ -4352,6 +4356,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         # Test case: active update failed, definition not updated
         userid = 'testuid'
         count = 4
+        cpu_share = 'RELATIVE 100'
         get_active.return_value = ['00', '01']
         get_offline.return_value = []
         get_defined.return_value = (32, [], ['00', '01'])
@@ -4367,9 +4372,9 @@ class SDKSMTClientTestCases(base.SDKTestCase):
                                  ' 2020 s390x s390x s390x GNU/Linux '],
                                 exception.SDKSMTRequestFailed({}, 'err'), ""]
         self.assertRaises(exception.SDKGuestOperationError,
-                          self._smtclient.live_resize_cpus, userid, count)
+                          self._smtclient.live_resize_cpus, userid, count, cpu_share)
         get_active.assert_called_once_with(userid)
-        resize.assert_called_once_with(userid, count)
+        resize.assert_called_once_with(userid, count, cpu_share)
         get_avail.assert_called_once_with(['00', '01'], 32)
         cmd_rescan_cpu = "chcpu -r"
         cmd_def_cpu = "vmcp def cpu 02 03"
@@ -4390,6 +4395,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
                                                 get_offline, get_defined):
         userid = 'testuid'
         count = 4
+        cpu_share = 'RELATIVE 100'
         base.set_conf('zvm', 'user_default_share_unit', 100)
         get_active.return_value = ['00', '01']
         get_offline.return_value = []
@@ -4403,9 +4409,9 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         get_avail.return_value = avail_lst
         exec_cmd.side_effect = ["", exception.SDKSMTRequestFailed({}, 'err'), ""]
         self.assertRaises(exception.SDKGuestOperationError,
-                          self._smtclient.live_resize_cpus, userid, count)
+                          self._smtclient.live_resize_cpus, userid, count, cpu_share)
         get_active.assert_called_once_with(userid)
-        resize.assert_called_once_with(userid, count)
+        resize.assert_called_once_with(userid, count, cpu_share)
         get_avail.assert_called_once_with(['00', '01'], 32)
         # exec_cmd.assert_called_once_with(userid, "vmcp def cpu 02 03")
         cmd_rescan_cpu = "chcpu -r"
@@ -4428,6 +4434,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
                                                   get_offline, get_defined):
         userid = 'testuid'
         count = 4
+        cpu_share = 'RELATIVE 100'
         get_active.return_value = ['00', '01']
         get_offline.return_value = []
         get_defined.return_value = (32, [], ['00', '01', '04', '0A'])
@@ -4440,9 +4447,9 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         get_avail.return_value = avail_lst
         exec_cmd.side_effect = ["", exception.SDKSMTRequestFailed({}, 'err'), ""]
         self.assertRaises(exception.SDKGuestOperationError,
-                          self._smtclient.live_resize_cpus, userid, count)
+                          self._smtclient.live_resize_cpus, userid, count, cpu_share)
         get_active.assert_called_once_with(userid)
-        resize.assert_called_once_with(userid, count)
+        resize.assert_called_once_with(userid, count, cpu_share)
         get_avail.assert_called_once_with(['00', '01'], 32)
         # exec_cmd.assert_called_once_with(userid, "vmcp def cpu 02 03")
         cmd_rescan_cpu = "chcpu -r"
@@ -4465,6 +4472,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
                                             get_offline, get_defined):
         userid = 'testuid'
         count = 4
+        cpu_share = 'RELATIVE 100'
         get_active.return_value = ['00', '01']
         get_offline.return_value = []
         get_defined.return_value = (32, [], ['00', '01', '04', '0A'])
@@ -4478,9 +4486,9 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         exec_cmd.side_effect = ["", exception.SDKSMTRequestFailed({}, 'err'), ""]
         request.side_effect = [exception.SDKSMTRequestFailed({}, 'err'), ""]
         self.assertRaises(exception.SDKGuestOperationError,
-                          self._smtclient.live_resize_cpus, userid, count)
+                          self._smtclient.live_resize_cpus, userid, count, cpu_share)
         get_active.assert_called_once_with(userid)
-        resize.assert_called_once_with(userid, count)
+        resize.assert_called_once_with(userid, count, cpu_share)
         get_avail.assert_called_once_with(['00', '01'], 32)
         cmd_rescan_cpu = "chcpu -r"
         cmd_def_cpu = "vmcp def cpu 02 03"
@@ -4502,6 +4510,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
                                             get_offline, get_defined):
         userid = 'testuid'
         count = 4
+        cpu_share = 'RELATIVE 100'
         get_active.return_value = ['00', '01']
         get_offline.return_value = []
         get_defined.return_value = (32, [], ['00', '01'])
@@ -4514,9 +4523,9 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         get_avail.return_value = avail_lst
         exec_cmd.side_effect = ["", "", exception.SDKSMTRequestFailed({}, 'err')]
         self.assertRaises(exception.SDKGuestOperationError,
-                          self._smtclient.live_resize_cpus, userid, count)
+                          self._smtclient.live_resize_cpus, userid, count, cpu_share)
         get_active.assert_called_once_with(userid)
-        resize.assert_called_once_with(userid, count)
+        resize.assert_called_once_with(userid, count, cpu_share)
         get_avail.assert_called_once_with(['00', '01'], 32)
         cmd_def_cpu = "vmcp def cpu 02 03"
         cmd_rescan_cpu = "chcpu -r"
@@ -4537,6 +4546,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
                               exec_cmd, request, get_offline, get_defined):
         userid = 'testuid'
         count = 4
+        cpu_share = 'RELATIVE 100'
         get_active.return_value = ['00', '01']
         get_offline.return_value = []
         get_defined.return_value = (32, [], ['00', '01'])
@@ -4552,9 +4562,9 @@ class SDKSMTClientTestCases(base.SDKTestCase):
                                  ' 2020 s390x s390x s390x GNU/Linux '],
                                 [''],
                                 ['']]
-        self._smtclient.live_resize_cpus(userid, count)
+        self._smtclient.live_resize_cpus(userid, count, cpu_share)
         get_active.assert_called_once_with(userid)
-        resize.assert_called_once_with(userid, count)
+        resize.assert_called_once_with(userid, count, cpu_share)
         get_avail.assert_called_once_with(['00', '01'], 32)
         cmd_enable_cpu = "chcpu -e 02,03"
         cmd_def_cpu = "vmcp def cpu 02 03"
@@ -4575,6 +4585,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
                               exec_cmd, request, get_offline, get_defined):
         userid = 'testuid'
         count = 4
+        cpu_share = 'RELATIVE 100'
         get_active.return_value = ['00', '01']
         get_offline.return_value = []
         get_defined.return_value = (32, [], ['00', '01'])
@@ -4591,9 +4602,9 @@ class SDKSMTClientTestCases(base.SDKTestCase):
                                   [''],
                                   [''],
                                   ['']]
-        self._smtclient.live_resize_cpus(userid, count)
+        self._smtclient.live_resize_cpus(userid, count, cpu_share)
         get_active.assert_called_once_with(userid)
-        resize.assert_called_once_with(userid, count)
+        resize.assert_called_once_with(userid, count, cpu_share)
         get_avail.assert_called_once_with(['00', '01'], 32)
 
         cmd_def_cpu = "vmcp def cpu 02 03"

--- a/zvmsdk/tests/unit/test_vmops.py
+++ b/zvmsdk/tests/unit/test_vmops.py
@@ -383,19 +383,21 @@ class SDKVMOpsTestCase(base.SDKTestCase):
     def test_live_resize_cpus(self, power_state, do_resize):
         userid = 'testuid'
         cpu_cnt = 3
+        cpu_share = 'RELATIVE 100'
         power_state.return_value = 'on'
-        self.vmops.live_resize_cpus(userid, cpu_cnt)
+        self.vmops.live_resize_cpus(userid, cpu_cnt, cpu_share)
         power_state.assert_called_once_with(userid)
-        do_resize.assert_called_once_with(userid, cpu_cnt)
+        do_resize.assert_called_once_with(userid, cpu_cnt, cpu_share)
 
     @mock.patch("zvmsdk.smtclient.SMTClient.live_resize_cpus")
     @mock.patch('zvmsdk.vmops.VMOps.get_power_state')
     def test_live_resize_cpus_guest_inactive(self, power_state, do_resize):
         userid = 'testuid'
         cpu_cnt = 3
+        cpu_share = 'RELATIVE 100'
         power_state.return_value = 'off'
         self.assertRaises(exception.SDKConflictError,
-                          self.vmops.live_resize_cpus, userid, cpu_cnt)
+                          self.vmops.live_resize_cpus, userid, cpu_cnt, cpu_share)
         power_state.assert_called_once_with(userid)
         do_resize.assert_not_called()
 
@@ -403,8 +405,9 @@ class SDKVMOpsTestCase(base.SDKTestCase):
     def test_resize_cpus(self, do_resize):
         userid = 'testuid'
         cpu_cnt = 3
-        self.vmops.resize_cpus(userid, cpu_cnt)
-        do_resize.assert_called_once_with(userid, cpu_cnt)
+        cpu_share = 'RELATIVE 100'
+        self.vmops.resize_cpus(userid, cpu_cnt, cpu_share)
+        do_resize.assert_called_once_with(userid, cpu_cnt, cpu_share)
 
     @mock.patch("zvmsdk.smtclient.SMTClient.live_resize_memory")
     @mock.patch('zvmsdk.vmops.VMOps.get_power_state')

--- a/zvmsdk/vmops.py
+++ b/zvmsdk/vmops.py
@@ -504,7 +504,7 @@ class VMOps(object):
                                         uid, comments=comment)
             return flag
 
-    def live_resize_cpus(self, userid, count):
+    def live_resize_cpus(self, userid, count, cpu_share):
         # Check power state is 'on'
         state = self.get_power_state(userid)
         if state != 'on':
@@ -514,14 +514,14 @@ class VMOps(object):
             raise exception.SDKConflictError(modID='guest', rs=1,
                                              userid=userid)
         # Do live resize
-        self._smtclient.live_resize_cpus(userid, count)
+        self._smtclient.live_resize_cpus(userid, count, cpu_share)
 
         LOG.info("Complete live resize cpu on vm %s", userid)
 
-    def resize_cpus(self, userid, count):
+    def resize_cpus(self, userid, count, cpu_share):
         LOG.info("Begin to resize cpu on vm %s", userid)
         # Do resize
-        self._smtclient.resize_cpus(userid, count)
+        self._smtclient.resize_cpus(userid, count, cpu_share)
         LOG.info("Complete resize cpu on vm %s", userid)
 
     def live_resize_memory(self, userid, memory):


### PR DESCRIPTION
What this PR does / why we need it:

The code will help successful CPU resize Operation by preserving the custom CPU share deployed by the customer.

Which issue(s) this PR fixes(unless minor typo change ,better to have an issue opened):

https://github.ibm.com/zvc/planning/issues/18693

Special notes for your reviewer:

**There is a dependent PR for this in icic-dev repo, " https://github.ibm.com/zvc/icic-dev/pull/6088 "  both of the PR's should be merged together**

Results are attached here :

https://github.ibm.com/zvc/planning/issues/18693#issuecomment-88412796
https://github.ibm.com/zvc/planning/issues/18693#issuecomment-88412883 
https://github.ibm.com/zvc/planning/issues/18693#issuecomment-88499911 << resize with VM shutdown

[optional] which components (compute, zvm/kvm etc)

zvm

[optional] backward incompatible change

[optional] security impact

[optional] open source package impact

--signed-off : santhoshs.1988@gmail.com ( ssanthosh@in.ibm.com )