### PR TITLE
Fix volume configuration script for SLES

### DIFF
--- a/zvmsdk/volumeops/templates/sles_attach_volume.j2
+++ b/zvmsdk/volumeops/templates/sles_attach_volume.j2
@@ -249,6 +249,7 @@ else
     exit $DEVICE_PATH_NOT_FOUND
 fi
 
+# read the WWN from page 0x83 value for a SCSI device
 WWID=`/usr/lib/udev/scsi_id --page 0x83 --whitelisted $diskPath`
 echo "scsi_id command get WWID:$WWID for device $diskPath."
 
@@ -260,9 +261,11 @@ else
     ConfigFile="/etc/udev/rules.d/56-zfcp.rules"
 fi
 
+# add udev rules
 LinkItem="KERNEL==\"dm-*\", ENV{DM_UUID}==\"mpath-$WWID\", SYMLINK+=\"$target_filename\""
 echo -e $LinkItem >> $ConfigFile
 
+# reload udev rules
 echo "Begin to reload udev rules ..."
 udevadm control --reload
 udevadm trigger --sysname-match=dm-*

--- a/zvmsdk/volumeops/templates/sles_attach_volume.j2
+++ b/zvmsdk/volumeops/templates/sles_attach_volume.j2
@@ -56,7 +56,7 @@ if [[ $fcp_count -eq 0 ]]; then
     exit $INVALID_PARAMETERS
 fi
 
-# see if zfcp is enable
+# see if zfcp is enabled
 echo "Begin to enable zfcp mode ..."
 enable_zfcp_mod=`lsmod | grep zfcp`
 if [ -z "$enable_zfcp_mod" ];then
@@ -66,7 +66,7 @@ else
     echo "zfcp mode is already enabled"
 fi
 
-# online fcp devices
+# online FCP devices
 for fcp in ${fcp_list[@]}
 do
     echo "Begin to online FCP $fcp ..."
@@ -92,8 +92,8 @@ do
     fi
 done
 
-# send an iSCSI scan request with given host and optionally the ctl 
-# the ctl means, c: channel,default to -
+# send an iSCSI scan request with given host and optionally the ctl
+# the ctl means: c: channel,default to -
 #                t: target, default to -
 #                l: lun, default to -
 all_hosts=(`ls /sys/class/scsi_host/`)
@@ -104,9 +104,9 @@ do
     echo "Scan on host $host completed"
 done
 
-# the number WWPNs is generated dynamically
+# the WWPNs are generated dynamically
 # so we need to get them from the filesystem
-# and get the intersection between input wwpns and lszfcp output
+# and get the intersection between input WWPNs and lszfcp output
 lszfcp_output=`lszfcp -P | awk '{print $1}' | awk -F'/' '{print $1,$2}'`
 echo -e "lszfcp -P output port info:\n$lszfcp_output"
 
@@ -120,7 +120,7 @@ do
         # Get WWPNs under /sys/bus/ccw/drivers/zfcp/.
         wwpns_shown_in_sys=`ls /sys/bus/ccw/drivers/zfcp/0.0.$fcp/ | grep "0x"`
         echo -e "Target WWPNs shown under /sys/bus/ccw/drivers/zfcp/0.0.$fcp/:\n$wwpns_shown_in_sys"
-        # Try to find match between system WWPNs(from lszfcp output or under /sys) and input WWPNs
+        # Try to match system WWPNs (from lszfcp output or under /sys) with input WWPNs
         found_match=0
         for wwpn in ${input_wwpns[@]}
         do
@@ -138,7 +138,7 @@ do
                 fi
             fi
         done
-        # If no matched wwpn found, need retry
+        # If no matched WWPN found, need retry
         if [[ $found_match -eq 0 ]]; then
             sleep 1
             Timeout=$((Timeout-1))
@@ -163,16 +163,16 @@ if [[ $valid_fcp_count -eq 0 ]]; then
     exit $INVALID_WWPNS
 fi
 
-# flag which indicate whether we found a valid and accessable path for the volume
+# flag which indicates whether we found a valid and accessible path for the volume
 FoundDiskPath=0
 # wait for the device ready
 for fcp in ${!valid_dict[@]}
 do
     ActiveWWPNs=(${valid_dict[$fcp]})
     echo "Discover WWPNs: ${ActiveWWPNs[@]} for FCP device: $fcp"
-    
+
     # If auto-discovery of LUNs is disabled on s390 platforms
-    # luns need to be added to the configuration through
+    # LUNs need to be added to the configuration through
     # the unit_add interface
     AutoScan=`cat /sys/module/zfcp/parameters/allow_lun_scan`
     if [[ "$AutoScan" != "Y" ]]; then
@@ -218,7 +218,7 @@ do
             break
         fi
 
-        # loop all the WWPNs to found the alive device
+        # loop through all the WWPNs to find the alive device
         for j in ${ActiveWWPNs[@]}
         do
             x="/dev/disk/by-path/ccw-0.0.$fcp-zfcp-$j:$lun"
@@ -269,8 +269,7 @@ echo -e $LinkItem >> $ConfigFile
 echo "Begin to reload udev rules ..."
 udevadm control --reload
 udevadm trigger --sysname-match=dm-*
-echo "Undev rules reload done"
+echo "Udev rules reloaded"
 
 echo "Exit SLES attach script"
 exit $OK
-

--- a/zvmsdk/volumeops/templates/sles_attach_volume.j2
+++ b/zvmsdk/volumeops/templates/sles_attach_volume.j2
@@ -249,7 +249,7 @@ else
     exit $DEVICE_PATH_NOT_FOUND
 fi
 
-WWID=`/lib/udev/scsi_id --page 0x83 --whitelisted $diskPath`
+WWID=`/usr/lib/udev/scsi_id --page 0x83 --whitelisted $diskPath`
 echo "scsi_id command get WWID:$WWID for device $diskPath."
 
 ConfigLib="/lib/udev/rules.d/56-zfcp.rules"

--- a/zvmsdk/volumeops/templates/sles_attach_volume.j2
+++ b/zvmsdk/volumeops/templates/sles_attach_volume.j2
@@ -48,7 +48,7 @@ fcp_count=0
 for fcp in ${fcp_list[@]}
 do
     echo "Got FCP $fcp"
-    fcp_count=$((fcp_count+=1))
+    fcp_count=$((fcp_count+1))
 done
 
 if [[ $fcp_count -eq 0 ]]; then
@@ -156,7 +156,7 @@ echo "Got valid wwpns, list of key is: ${!valid_dict[@]}, list of value is: ${va
 valid_fcp_count=0
 for fcp in ${!valid_dict[@]}
 do
-    valid_fcp_count=$((valid_fcp_count+=1))
+    valid_fcp_count=$((valid_fcp_count+1))
 done
 if [[ $valid_fcp_count -eq 0 ]]; then
     echo "Can not find the intersection between input wwpns: ${input_wwpns[@]} and lszfcp output: $lszfcp_output, exit with code $INVALID_WWPNS."
@@ -236,7 +236,7 @@ do
         # if devices still not ready, wait another 5 seconds and retry
         if [ $FoundDiskPath -eq 0 ]; then
             sleep 1
-            Timeout=$((Timeout-=1))
+            Timeout=$((Timeout-1))
             echo "Sleep 1 second to wait the devices ready, timeout left: $Timeout"
         fi
     done


### PR DESCRIPTION
On SLES, the desired device in `/dev` was not created by `AttachVolume()` API call.

Root cause was that path to `scsi_id` utility is `/usr/lib/udev/scsi_id` on SLES, and not `/lib/udev/scsi_id` like in the current configuration script. This PR fixes that path.

This PR also:
 * uses simpler bash syntax for increments and decrements
 * copies some comments from the script for RHEL
 * fixes typos and English
 
 in that configuration script.