### PR TITLE
Reset FCP assignements of deleted VM

### DIFF
--- a/zvmsdk/database.py
+++ b/zvmsdk/database.py
@@ -490,6 +490,15 @@ class FCPDbOperator(object):
             conn.executemany("UPDATE fcp set state=? "
                              "WHERE fcp_id=?", data_to_update)
 
+    def reset_fcps_of_assigner(self, userid):
+        """Reset fcp records for a given assigner."""
+        with get_fcp_conn() as conn:
+            conn.execute("UPDATE fcp SET assigner_id='', reserved=0, "
+                         "connections=0, tmpl_id='' WHERE assigner_id=?",
+                         (userid,))
+            LOG.debug("FCP records for user %s are reset in "
+                      "fcp table" % userid)
+
     def get_all_fcps_of_assigner(self, assigner_id=None):
         """Get dict of all fcp records of specified assigner.
         If assigner is None, will get all fcp records.

--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -84,6 +84,7 @@ class SMTClient(object):
         self._NetDbOperator = database.NetworkDbOperator()
         self._GuestDbOperator = database.GuestDbOperator()
         self._ImageDbOperator = database.ImageDbOperator()
+        self._FCPDbOperator = database.FCPDbOperator()
 
     def _request(self, requestData):
         try:
@@ -2586,8 +2587,10 @@ class SMTClient(object):
         with zvmutils.log_and_reraise_sdkbase_error(action):
             self._NetDbOperator.switch_delete_record_for_userid(userid)
 
-        # TODO: cleanup db record from volume table
-        pass
+        # cleanup db records from FCP table
+        action = "delete FCP records for user %s" % userid
+        with zvmutils.log_and_reraise_sdkbase_error(action):
+            self._FCPDbOperator.reset_fcps_of_assigner(userid)
 
         # cleanup persistent folder for guest
         self._pathutils.remove_guest_path(userid)


### PR DESCRIPTION
With current code when you:

 1. create a VM guest
 2.  attach a disk via `AttachVolume()` to that guest
 3. forget to detach it via `DetachVolume()`
 4. delete the instance
 
then the disk stays counted as attached to the deleted instance.

If you recreate the instance, then `AttachVolume()` will skip the dedication, because it considers that the disk is already dedicated to the instance, while it is not.

This PR resets the FCP records in database for the deleted instance at time of deletion.
