### PR TITLE
WIP: Publish updated documentation

### DIFF
--- a/doc/source/errorcodemsg.rst
+++ b/doc/source/errorcodemsg.rst
@@ -9,7 +9,7 @@ This is a reference to Feilong API error codes
 and messages.
 
 .. csv-table::
-   :header: "overallRC", "modID", "rc", "rs", "errmsg"
+   :header: "overallRC";"modID";"rc";"rs";"errmsg"
    :delim: ;
-   :widths: 20,5,5,5,65
+   :widths: 20,10,5,5,65
    :file: errcode.csv


### PR DESCRIPTION
This changes the link to the documentation location in the [README.md](https://github.com/openmainframeproject/feilong/blob/master/README.md) because we do have the authority to update older documentation located at https://cloudlib4zvm.readthedocs.io/en/latest/index.html