### PR TITLE
Update Pull Request Check Test python version

### DIFF
--- a/.github/workflows/pr_ut_py311.yaml
+++ b/.github/workflows/pr_ut_py311.yaml
@@ -4,17 +4,17 @@ on:
     branches: [ master ]
 jobs:
   python:
-    name: python checks ${{ matrix.python }} ${{ matrix.os }}
+    name: python checks ${{ matrix.python-version }} ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7]
+        python-version: ['3.11']
 
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -24,4 +24,4 @@ jobs:
     - name: PEP8
       run: tox -e pep8
     - name: unit test
-      run: tox -e py37
+      run: tox -e py311

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ commands = flake8
 
 [flake8]
 max-line-length = 120
-ignore = E121,E122,E123,E124,E125,E126,E127,E128,E129,E131,E251,H405,W504,W605
+ignore = E121,E122,E123,E124,E125,E126,E127,E128,E129,E131,E251,E721,H405,W504,W605
 exclude =  .venv,.git,.tox,dist,doc,*openstack/common*,sample,*lib/python*,*egg,build,tools,*.py.*.py
 
 [testenv:docs]


### PR DESCRIPTION
This will allow the Pull Request Check Test github action to complete properly for all PRs.

The flake8 test for [restclient.py](https://github.com/mfriesenegger/feilong/blob/b77a8ff51dacb2928a55915bcfe40f9b83787224/zvmconnector/restclient.py#L1143) fails with [E721](https://www.flake8rules.com/rules/E721.html).  I have added E721 to the [ignore](https://github.com/openmainframeproject/feilong/compare/master...mfriesenegger:feilong:update-unit-test-python-version?expand=1#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449R24) option in tox.ini.