### PR TITLE
Add multiple disk pool support for the zvmsdk

### DIFF
--- a/scale_test/create.py
+++ b/scale_test/create.py
@@ -215,19 +215,6 @@ def _run_guest(userid, image_path, os_version, profile,
 
 def run_guest():
     """ A sample for quick deploy and start a virtual guest."""
-    global GUEST_USERID
-    global GUEST_PROFILE
-    global GUEST_VCPUS
-    global GUEST_MEMORY
-    global GUEST_ROOT_DISK_SIZE
-    global DISK_POOL
-    global IMAGE_PATH
-    global IMAGE_OS_VERSION
-    global GUEST_IP_ADDR
-    global GATEWAY
-    global CIDR
-    global VSWITCH_NAME
-
     network_info = {'ip_addr': GUEST_IP_ADDR,
          'gateway_addr': GATEWAY,
          'cidr': CIDR,

--- a/smtLayer/smtTest.py
+++ b/smtLayer/smtTest.py
@@ -1370,8 +1370,6 @@ def runTest(smt, test):
     Output:
        Final test score - 0: failed, 1: passed,
     """
-    global args
-
     if test['request'][0:10] != 'SHELL_TEST':
         reqHandle = ReqHandle(cmdName=sys.argv[0], captureLogs=True)
         results = reqHandle.parseCmdline(test['request'])
@@ -1541,9 +1539,6 @@ def driveTestSet(smt, setId, setToTest):
     Output:
        Global values changed
     """
-    global args
-    global cnts
-
     print(" ")
     print("******************************************************************")
     print("******************************************************************")

--- a/smtLayer/vmStatus.py
+++ b/smtLayer/vmStatus.py
@@ -79,7 +79,6 @@ _SMAPIStatus = None
 
 
 def GetSMAPIStatus():
-    global _SMAPIStatus
     if _SMAPIStatus is None:
         _GetSMAPIStatus = SMAPIStatus()
     return _GetSMAPIStatus

--- a/zvmsdk/config.py
+++ b/zvmsdk/config.py
@@ -777,10 +777,14 @@ class ConfigOpts(object):
                     self._check_user_default_max_cpu(v2['default'])
 
     def _check_zvm_disk_pool(self, value):
-        disks = value.split(':')
-        if (len(disks) != 2) or (disks[0].upper() not in ['FBA', 'ECKD']) or (
-            disks[1] == ''):
-            raise OptFormatError("zvm", "disk_pool", value)
+        disk_pools = value.split(',')
+        if (len(disk_pools) > 10):
+            raise LenFormatError("zvm", "disk_pool", disk_pools)
+        for disk_pool in disk_pools:
+            disks = disk_pool.split(':')
+            if (len(disks) != 2) or (disks[0].upper() not in ['FBA', 'ECKD']) or (
+                disks[1] == ''):
+                raise OptFormatError("zvm", "disk_pool", value)
 
     def _check_user_default_max_memory(self, value):
         suffix = value[-1].upper()
@@ -915,6 +919,16 @@ class OptFormatError(Exception):
         return "value %s for option  %s - %s is invalid" % (self.value,
                                                             self.grp_name,
                                                             self.opt_name)
+
+
+class LenFormatError(Exception):
+    def __init__(self, grp_name, opt_name, value):
+        self.grp_name = grp_name
+        self.opt_name = opt_name
+        self.value = value
+
+    def __str__(self):
+        return "value %s, not more than 10 disk pools can be added" % (self.value)
 
 
 CONFOPTS = ConfigOpts()

--- a/zvmsdk/database.py
+++ b/zvmsdk/database.py
@@ -51,7 +51,7 @@ _DBLOCK_FCP = threading.RLock()
 
 @contextlib.contextmanager
 def get_network_conn():
-    global _NETWORK_CONN, _DBLOCK_NETWORK
+    global _NETWORK_CONN
     if not _NETWORK_CONN:
         _NETWORK_CONN = _init_db_conn(const.DATABASE_NETWORK)
 
@@ -68,7 +68,7 @@ def get_network_conn():
 
 @contextlib.contextmanager
 def get_image_conn():
-    global _IMAGE_CONN, _DBLOCK_IMAGE
+    global _IMAGE_CONN
     if not _IMAGE_CONN:
         _IMAGE_CONN = _init_db_conn(const.DATABASE_IMAGE)
 
@@ -84,7 +84,7 @@ def get_image_conn():
 
 @contextlib.contextmanager
 def get_guest_conn():
-    global _GUEST_CONN, _DBLOCK_GUEST
+    global _GUEST_CONN
     if not _GUEST_CONN:
         _GUEST_CONN = _init_db_conn(const.DATABASE_GUEST)
 
@@ -101,7 +101,7 @@ def get_guest_conn():
 
 @contextlib.contextmanager
 def get_fcp_conn():
-    global _FCP_CONN, _DBLOCK_FCP
+    global _FCP_CONN
     if not _FCP_CONN:
         _FCP_CONN = _init_db_conn(const.DATABASE_FCP)
         # enable access columns by name

--- a/zvmsdk/hostops.py
+++ b/zvmsdk/hostops.py
@@ -82,14 +82,25 @@ class HOSTOps(object):
                 host_info['zvm_host'] = inv_info['zvm_host']
                 host_info['hypervisor_hostname'] = inv_info['hypervisor_name']
 
-        disk_pool = CONF.zvm.disk_pool
-        if disk_pool is None:
-            dp_info = {'disk_total': 0, 'disk_used': 0, 'disk_available': 0}
-        else:
-            diskpool_name = disk_pool.split(':')[1]
-            dp_info = self.diskpool_get_info(diskpool_name)
-        host_info.update(dp_info)
-
+        disk_pool_list = CONF.zvm.disk_pool
+        disk_pools_total = 0
+        disk_pools_used = 0
+        disk_pools_available = 0
+        if disk_pool_list is not None:
+            disk_pools = disk_pool_list.split(',')
+            for disk_pool in disk_pools:
+                if disk_pool is not None:
+                    disk_pool_name = disk_pool.split(':')[1]
+                    dp_info = self.diskpool_get_info(disk_pool_name)
+                    disk_pools_total = disk_pools_total + dp_info.get("disk_total", 0)
+                    disk_pools_used = disk_pools_used + dp_info.get("disk_used", 0)
+                    disk_pools_available = disk_pools_available + dp_info.get("disk_available", 0)
+        disk_pool_info = {
+            'disk_total': disk_pools_total,
+            'disk_used': disk_pools_used,
+            'disk_available': disk_pools_available
+        }
+        host_info.update(disk_pool_info)
         return host_info
 
     def guest_list(self):

--- a/zvmsdk/log.py
+++ b/zvmsdk/log.py
@@ -77,7 +77,6 @@ class Logger():
 
 
 def setup_log():
-    global LOGGER
     LOGGER.setup(log_dir=config.CONF.logging.log_dir,
                  log_level=config.CONF.logging.log_level)
 

--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -211,7 +211,18 @@ class SMTClient(object):
         # and not configured(the default vaule is None), report error
         # report error
         for idx, disk in enumerate(disk_list):
-            disk_pool = disk.get('disk_pool') or CONF.zvm.disk_pool
+            disk_pool = disk.get('disk_pool')
+            if disk_pool is None:
+                disk_pool = CONF.zvm.disk_pool
+                if disk_pool is not None:
+                    disk_pools = disk_pool.split(",")
+                    if len(disk_pools) == 1:
+                        disk_pool = disk_pools[0]
+                    else:
+                        errmsg = ("disk_pool input is required if multiple disk_pool"
+                                  " is configured for sdkserver.")
+                        LOG.error(errmsg)
+                        raise exception.SDKGuestOperationError(rs=2, msg=errmsg)
             disk['disk_pool'] = disk_pool
             if disk_pool is None:
                 msg = ('disk_pool not configured for sdkserver.')
@@ -856,7 +867,18 @@ class SMTClient(object):
         """
         size = disk['size']
         fmt = disk.get('format', 'ext4')
-        disk_pool = disk.get('disk_pool') or CONF.zvm.disk_pool
+        disk_pool = disk.get('disk_pool')
+        if disk_pool is None:
+            disk_pool = CONF.zvm.disk_pool
+            if disk_pool is not None:
+                disk_pools = disk_pool.split(",")
+                if len(disk_pools) == 1:
+                    disk_pool = disk_pools[0]
+                else:
+                    errmsg = ("disk_pool input is required if multiple disk_pool"
+                              " is configured for sdkserver.")
+                    LOG.error(errmsg)
+                    raise exception.SDKGuestOperationError(rs=2, msg=errmsg)
         # Check disk_pool, if it's None, report error
         if disk_pool is None:
             msg = ('disk_pool not configured for sdkserver.')

--- a/zvmsdk/tests/fvt/test_guest.py
+++ b/zvmsdk/tests/fvt/test_guest.py
@@ -38,7 +38,6 @@ TEST_USERID_LIST = []
 
 
 def generate_test_userid_list():
-    global TEST_USERID_LIST
     utils = test_utils.ZVMConnectorTestUtils()
     for i in range(0, len(TEST_IMAGE_LIST)):
         userid = utils.generate_test_userid()

--- a/zvmsdk/tests/fvt/test_utils.py
+++ b/zvmsdk/tests/fvt/test_utils.py
@@ -39,7 +39,6 @@ TEST_IMAGE_LIST = []
 
 
 def get_test_image_list():
-    global TEST_IMAGES_LIST
     for image in CONF.tests.images.split(','):
         info = image.strip(' ').split(':')
         # use image_file_name-distro as the image name

--- a/zvmsdk/tests/fvt/test_volume.py
+++ b/zvmsdk/tests/fvt/test_volume.py
@@ -31,7 +31,6 @@ TEST_USERID_LIST = []
 
 
 def generate_test_userid_list():
-    global TEST_USERID_LIST
     utils = test_utils.ZVMConnectorTestUtils()
     for i in range(0, len(TEST_IMAGE_LIST)):
         userid = utils.generate_test_userid()

--- a/zvmsdk/tests/unit/test_config.py
+++ b/zvmsdk/tests/unit/test_config.py
@@ -39,6 +39,13 @@ class ZVMConfigTestCases(base.SDKTestCase):
         self.assertRaises(config.OptFormatError,
                           CONFOPTS._check_zvm_disk_pool, 'ECKD:')
 
+    def test_check_zvm_disk_pool_err3(self):
+        disk_pool = ("ECKD:fakepool,ECKD:fakepool1,ECKD:fakepool2,ECKD:fakepool3,ECKD:fakepool4,"
+                  "ECKD:fakepool5,ECKD:fakepool6,ECKD:fakepool7,ECKD:fakepool8,ECKD:fakepool9,"
+                  "ECKD:fakepool10")
+        self.assertRaises(config.LenFormatError,
+                          CONFOPTS._check_zvm_disk_pool, disk_pool)
+
     def test_check_user_default_max_memory(self):
         CONFOPTS._check_user_default_max_memory('30G')
         CONFOPTS._check_user_default_max_memory('1234M')

--- a/zvmsdk/tests/unit/test_hostops.py
+++ b/zvmsdk/tests/unit/test_hostops.py
@@ -85,6 +85,13 @@ class SDKHostOpsTestCase(base.SDKTestCase):
         self.assertEqual(host_info['hypervisor_version'], 610)
         self.assertEqual(host_info['disk_total'], 406105)
 
+        # Test multiple disk_pool
+        base.set_conf('zvm', 'disk_pool', 'eckd:fakepool,eckd:fakepool1,fba:fakepool2')
+        host_info = self._hostops.get_info()
+        diskpool_get_info.assert_has_calls([mock.call('fakepool'),
+                                            mock.call('fakepool1'),
+                                            mock.call('fakepool2')])
+
         # Test disk_pool is None
         base.set_conf('zvm', 'disk_pool', None)
         host_info = self._hostops.get_info()

--- a/zvmsdk/tests/unit/test_smtclient.py
+++ b/zvmsdk/tests/unit/test_smtclient.py
@@ -1072,6 +1072,27 @@ class SDKSMTClientTestCases(base.SDKTestCase):
                           self._smtclient._add_mdisk, 'fakeuser', disk, vdev)
 
     @mock.patch.object(smtclient.SMTClient, '_request')
+    def test_add_mdisk_single_disk_pool(self, request):
+        userid = 'fakeuser'
+        vdev = '0101'
+        disk = {'size': '1g',
+                'format': 'ext3'}
+        base.set_conf('zvm', 'disk_pool', 'ECKD:eckdpool1')
+        rd = ('changevm fakeuser add3390 eckdpool1 0101 1g --mode MR '
+              '--filesystem ext3')
+        self._smtclient._add_mdisk(userid, disk, vdev),
+        request.assert_called_once_with(rd)
+
+    def test_add_mdisk_multiple_disk_pool(self):
+        userid = 'fakeuser'
+        vdev = '0101'
+        disk = {'size': '1g',
+                'format': 'ext3'}
+        base.set_conf('zvm', 'disk_pool', 'ECKD:eckdpool1,ECKD:eckdpool2')
+        self.assertRaises(exception.SDKGuestOperationError,
+                          self._smtclient._add_mdisk, userid, disk, vdev)
+
+    @mock.patch.object(smtclient.SMTClient, '_request')
     def test_add_mdisk_format_none(self, request):
         userid = 'fakeuser'
         disk = {'size': '1g',
@@ -2966,8 +2987,26 @@ class SDKSMTClientTestCases(base.SDKTestCase):
                       'disk_pool': 'ECKD:eckdpool1'},
                      {'size': '200000',
                       'format': 'ext3'}]
+        base.set_conf('zvm', 'disk_pool', None)
         self.assertRaises(exception.SDKGuestOperationError,
                           self._smtclient.add_mdisks, 'fakeuser', disk_list)
+
+    @mock.patch.object(smtclient.SMTClient, '_add_mdisk')
+    def test_add_mdisks_single_disk_pool(self, add_mdisk):
+        userid = 'fakeuser'
+        disk_list = [{'size': '1g',
+                      'is_boot_disk': True}]
+        base.set_conf('zvm', 'disk_pool', "ECKD:fakepool")
+        self._smtclient.add_mdisks(userid, disk_list)
+        add_mdisk.assert_any_call(userid, disk_list[0], '0100')
+
+    def test_add_mdisks_multiple_disk_pool(self):
+        userid = 'fakeuser'
+        disk_list = [{'size': '1g',
+                      'is_boot_disk': True}]
+        base.set_conf('zvm', 'disk_pool', "ECKD:fakepool,ECKD:fakepool1")
+        self.assertRaises(exception.SDKGuestOperationError,
+                          self._smtclient.add_mdisks, userid, disk_list)
 
     @mock.patch.object(smtclient.SMTClient, '_add_mdisk')
     def test_add_mdisks_with_1dev(self, add_mdisk):


### PR DESCRIPTION
Multiple disk pool support is added for the zvmsdk.
1. ZVMSDK allows user to add 10 disk pool
2. While creating VM, user has to pass disk_pool name if user configures multiple disk pool
3. No need to pass disk_pool name if user configures one disk pool