### PR TITLE
Replaced code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,1 +1,3 @@
-All participants agree to abide by the Code of Conduct available at https://github.com/openmainframeproject/tsc/blob/master/CODE_OF_CONDUCT.md.
+All participants agree to abide by the Code of Conduct of the Linux Foundation:
+https://lfprojects.org/policies/code-of-conduct/
+

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ commands = flake8
 
 [flake8]
 max-line-length = 120
-ignore = E121,E122,E123,E124,E125,E126,E127,E128,E129,E131,E251,E721,H405,W504,W605
+ignore = E121,E122,E123,E124,E125,E126,E127,E128,E129,E131,E251,E721,F824,H405,W504,W605
 exclude =  .venv,.git,.tox,dist,doc,*openstack/common*,sample,*lib/python*,*egg,build,tools,*.py.*.py
 
 [testenv:docs]


### PR DESCRIPTION
Replaced the code of conduct: the existing link was deprecated.

Piggyback: ignore a flake8 error about unused global variables.