### PR TITLE
Changes to Support Dasd deployment without ssh keys

### DIFF
--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -1071,7 +1071,12 @@ class SMTClient(object):
                 tmp_trans_dir = tempfile.mkdtemp()
                 local_trans = '/'.join([tmp_trans_dir,
                                         os.path.basename(transportfiles)])
-                if remotehost:
+                if os.path.isfile(local_trans):
+                    LOG.info(f"Transport file {local_trans} already present, skipping scp/cp.")
+                elif os.path.isfile(transportfiles):
+                    LOG.info(f"Transport file is local, copying {transportfiles} to {local_trans}")
+                    shutil.copyfile(transportfiles, local_trans)
+                elif remotehost:
                     cmd = ["/usr/bin/scp", "-B",
                            "-P", CONF.zvm.remotehost_sshd_port,
                            "-o StrictHostKeyChecking=no",


### PR DESCRIPTION
**Short Description:**

Support DASD deployment without SSH keys when operating on the same compute node.

**PR Summary:**
This change enhances the guest deployment workflow by enabling DASD disk deployment without requiring SSH key-based transfer when the deployment is happening locally on the same compute node. This helps streamline deployments, reduces dependency on SSH configuration, and improves compatibility in secure or restricted environments.