### PR TITLE
Allow 'None' as a valid value in deploy schema

### DIFF
--- a/zvmsdk/sdkwsgi/schemas/guest.py
+++ b/zvmsdk/sdkwsgi/schemas/guest.py
@@ -212,7 +212,7 @@ deploy = {
     'type': 'object',
     'properties': {
         'image': parameter_types.name,
-        'transportfiles': {'type': ['string']},
+        'transportfiles': {'type': ['string', 'null']},
         'remotehost': parameter_types.remotehost,
         'vdev': parameter_types.vdev_or_None,
         'hostname': parameter_types.hostname,


### PR DESCRIPTION
This PR updates the deploy schema to allow `None` (`null`) as a valid value for the `transportfiles` parameter, along with the existing string type. This fix resolves validation issues where optional string parameters were incorrectly rejecting `None` values, leading to deployment failures.

Fixes #883 

CC @Bischoff 